### PR TITLE
Adding Python 3.4 to Travis and tox config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 env:
   - TOX_ENV=py27
   - TOX_ENV=pypy
+  - TOX_ENV=py34
 install:
   - pip install tox
   - pip install . --allow-external argparse

--- a/apitools/base/py/base_api_test.py
+++ b/apitools/base/py/base_api_test.py
@@ -3,7 +3,6 @@
 
 import datetime
 import sys
-import urllib
 
 from six.moves import urllib_parse
 
@@ -124,7 +123,7 @@ class BaseApiTest(unittest2.TestCase):
         timestamp=datetime.datetime(2014, 10, 0o7, 12, 53, 13))
     http_request = service.PrepareHttpRequest(method_config, request)
 
-    url_timestamp = urllib.quote(request.timestamp.isoformat())
+    url_timestamp = urllib_parse.quote(request.timestamp.isoformat())
     self.assertTrue(http_request.url.endswith(url_timestamp))
 
   def testPrettyPrintEncoding(self):

--- a/apitools/base/py/base_api_test.py
+++ b/apitools/base/py/base_api_test.py
@@ -4,7 +4,8 @@
 import datetime
 import sys
 import urllib
-import urlparse
+
+from six.moves import urllib_parse
 
 from protorpc import message_types
 from protorpc import messages
@@ -150,8 +151,8 @@ class BaseApiTest(unittest2.TestCase):
     request = MessageWithRemappings(
         str_field='foo', enum_field=MessageWithRemappings.AnEnum.value_one)
     http_request = FakeService().PrepareHttpRequest(method_config, request)
-    result_params = urlparse.parse_qs(
-        urlparse.urlparse(http_request.url).query)
+    result_params = urllib_parse.parse_qs(
+        urllib_parse.urlparse(http_request.url).query)
     expected_params = {'enum_field': 'ONE%2FTWO', 'remapped_field': 'foo'}
     self.assertTrue(expected_params, result_params)
 

--- a/apitools/base/py/batch.py
+++ b/apitools/base/py/batch.py
@@ -9,7 +9,6 @@ import email.parser as email_parser
 import itertools
 import io
 import time
-import urllib
 import uuid
 
 from six.moves import http_client
@@ -235,7 +234,7 @@ class BatchHttpRequest(object):
       the value because Content-ID headers are supposed to be universally
       unique.
     """
-    return '<%s+%s>' % (self.__base_id, urllib.quote(request_id))
+    return '<%s+%s>' % (self.__base_id, urllib_parse.quote(request_id))
 
   @staticmethod
   def _ConvertHeaderToId(header):
@@ -259,7 +258,7 @@ class BatchHttpRequest(object):
       raise exceptions.BatchError('Invalid value for Content-ID: %s' % header)
     _, request_id = header[1:-1].rsplit('+', 1)
 
-    return urllib.unquote(request_id)
+    return urllib_parse.unquote(request_id)
 
   def _SerializeRequest(self, request):
     """Convert a http_wrapper.Request object into a string.

--- a/apitools/base/py/batch.py
+++ b/apitools/base/py/batch.py
@@ -7,13 +7,13 @@ import email.mime.multipart as mime_multipart
 import email.mime.nonmultipart as mime_nonmultipart
 import email.parser as email_parser
 import itertools
-import StringIO
+import io
 import time
 import urllib
-import urlparse
 import uuid
 
 from six.moves import http_client
+from six.moves import urllib_parse
 
 from apitools.base.py import exceptions
 from apitools.base.py import http_wrapper
@@ -271,8 +271,8 @@ class BatchHttpRequest(object):
       The request as a string in application/http format.
     """
     # Construct status line
-    parsed = urlparse.urlsplit(request.url)
-    request_line = urlparse.urlunsplit(
+    parsed = urllib_parse.urlsplit(request.url)
+    request_line = urllib_parse.urlunsplit(
         (None, None, parsed.path, parsed.query, None))
     status_line = request.http_method + ' ' + request_line + ' HTTP/1.1\n'
     major, minor = request.headers.get(
@@ -293,7 +293,7 @@ class BatchHttpRequest(object):
       msg.set_payload(request.body)
 
     # Serialize the mime message.
-    str_io = StringIO.StringIO()
+    str_io = io.StringIO()
     # maxheaderlen=0 means don't line wrap headers.
     gen = generator.Generator(str_io, maxheaderlen=0)
     gen.flatten(msg, unixfrom=False)

--- a/apitools/base/py/buffered_stream_test.py
+++ b/apitools/base/py/buffered_stream_test.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 """Tests for stream_slice."""
 
+import io
 import string
-import StringIO
 
 import unittest2
 
@@ -13,7 +13,7 @@ from apitools.base.py import exceptions
 class BufferedStreamTest(unittest2.TestCase):
 
   def setUp(self):
-    self.stream = StringIO.StringIO(string.letters)
+    self.stream = io.BytesIO(string.ascii_letters)
     self.value = self.stream.getvalue()
     self.stream.seek(0)
 

--- a/apitools/base/py/buffered_stream_test.py
+++ b/apitools/base/py/buffered_stream_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """Tests for stream_slice."""
 
-import io
+import six
 import string
 
 import unittest2
@@ -13,7 +13,7 @@ from apitools.base.py import exceptions
 class BufferedStreamTest(unittest2.TestCase):
 
   def setUp(self):
-    self.stream = io.BytesIO(string.ascii_letters)
+    self.stream = six.StringIO(string.ascii_letters)
     self.value = self.stream.getvalue()
     self.stream.seek(0)
 

--- a/apitools/base/py/credentials_lib_test.py
+++ b/apitools/base/py/credentials_lib_test.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
 
-import io
 import re
+import six
 
 import mock
 from six.moves import http_client
@@ -38,12 +38,12 @@ class CredentialsLibTest(unittest2.TestCase):
     def MockMetadataCalls(request):
       request_url = request.get_full_url()
       if request_url.endswith('scopes'):
-        return io.BytesIO(''.join(scopes))
+        return six.StringIO(''.join(scopes))
       elif request_url.endswith('service-accounts'):
-        return io.BytesIO(service_account_name)
+        return six.StringIO(service_account_name)
       elif request_url.endswith(
           '/service-accounts/%s/token' % service_account_name):
-        return io.BytesIO('{"access_token": "token"}')
+        return six.StringIO('{"access_token": "token"}')
       self.fail('Unexpected HTTP request to %s' % request_url)
 
     with mock.patch.object(credentials_lib, '_OpenNoProxy',

--- a/apitools/base/py/credentials_lib_test.py
+++ b/apitools/base/py/credentials_lib_test.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
 
+import io
 import re
-import StringIO
 
 import mock
 from six.moves import http_client
@@ -38,12 +38,12 @@ class CredentialsLibTest(unittest2.TestCase):
     def MockMetadataCalls(request):
       request_url = request.get_full_url()
       if request_url.endswith('scopes'):
-        return StringIO.StringIO(''.join(scopes))
+        return io.BytesIO(''.join(scopes))
       elif request_url.endswith('service-accounts'):
-        return StringIO.StringIO(service_account_name)
+        return io.BytesIO(service_account_name)
       elif request_url.endswith(
           '/service-accounts/%s/token' % service_account_name):
-        return StringIO.StringIO('{"access_token": "token"}')
+        return io.BytesIO('{"access_token": "token"}')
       self.fail('Unexpected HTTP request to %s' % request_url)
 
     with mock.patch.object(credentials_lib, '_OpenNoProxy',

--- a/apitools/base/py/encoding.py
+++ b/apitools/base/py/encoding.py
@@ -517,8 +517,8 @@ def AddCustomJsonEnumMapping(enum_type, python_name, json_name):
 
   Args:
     enum_type: (messages.Enum) An enum type
-    python_name: (basestring) Python name for this value.
-    json_name: (basestring) JSON name to be used on the wire.
+    python_name: (string) Python name for this value.
+    json_name: (string) JSON name to be used on the wire.
   """
   if not issubclass(enum_type, messages.Enum):
     raise exceptions.TypecheckError(
@@ -540,8 +540,8 @@ def AddCustomJsonFieldMapping(message_type, python_name, json_name):
 
   Args:
     message_type: (messages.Message) A message type
-    python_name: (basestring) Python name for this value.
-    json_name: (basestring) JSON name to be used on the wire.
+    python_name: (string) Python name for this value.
+    json_name: (string) JSON name to be used on the wire.
   """
   if not issubclass(message_type, messages.Message):
     raise exceptions.TypecheckError(

--- a/apitools/base/py/http_wrapper.py
+++ b/apitools/base/py/http_wrapper.py
@@ -131,7 +131,7 @@ class Request(object):
     else:
       self.headers.pop('content-length', None)
     # This line ensures we don't try to print large requests.
-    if not isinstance(value, basestring):
+    if not isinstance(value, six.string_types):
       self.loggable_body = '<media body>'
 
 

--- a/apitools/base/py/stream_slice_test.py
+++ b/apitools/base/py/stream_slice_test.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 """Tests for stream_slice."""
 
+import io
 import string
-import StringIO
 
 import unittest2
 
@@ -13,7 +13,7 @@ from apitools.base.py import stream_slice
 class StreamSliceTest(unittest2.TestCase):
 
   def setUp(self):
-    self.stream = StringIO.StringIO(string.letters)
+    self.stream = io.BytesIO(string.ascii_letters)
     self.value = self.stream.getvalue()
     self.stream.seek(0)
 

--- a/apitools/base/py/stream_slice_test.py
+++ b/apitools/base/py/stream_slice_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """Tests for stream_slice."""
 
-import io
+import six
 import string
 
 import unittest2
@@ -13,7 +13,7 @@ from apitools.base.py import stream_slice
 class StreamSliceTest(unittest2.TestCase):
 
   def setUp(self):
-    self.stream = io.BytesIO(string.ascii_letters)
+    self.stream = six.StringIO(string.ascii_letters)
     self.value = self.stream.getvalue()
     self.stream.seek(0)
 

--- a/apitools/base/py/transfer.py
+++ b/apitools/base/py/transfer.py
@@ -9,7 +9,6 @@ import io
 import json
 import mimetypes
 import os
-import StringIO
 import threading
 
 import six
@@ -632,7 +631,7 @@ class Upload(_Transfer):
 
     # encode the body: note that we can't use `as_string`, because
     # it plays games with `From ` lines.
-    fp = StringIO.StringIO()
+    fp = io.BytesIO()
     g = email_generator.Generator(fp, mangle_from_=False)
     g.flatten(msg_root, unixfrom=False)
     http_request.body = fp.getvalue()

--- a/apitools/base/py/transfer.py
+++ b/apitools/base/py/transfer.py
@@ -631,7 +631,7 @@ class Upload(_Transfer):
 
     # encode the body: note that we can't use `as_string`, because
     # it plays games with `From ` lines.
-    fp = io.BytesIO()
+    fp = six.StringIO()  # email: cStringIO in Py2 / io.StringIO in Py3.
     g = email_generator.Generator(fp, mangle_from_=False)
     g.flatten(msg_root, unixfrom=False)
     http_request.body = fp.getvalue()

--- a/apitools/base/py/transfer.py
+++ b/apitools/base/py/transfer.py
@@ -629,9 +629,11 @@ class Upload(_Transfer):
     msg.set_payload(self.stream.read())
     msg_root.attach(msg)
 
-    # encode the body: note that we can't use `as_string`, because
-    # it plays games with `From ` lines.
-    fp = six.StringIO()  # email: cStringIO in Py2 / io.StringIO in Py3.
+    # NOTE: We encode the body, but can't use `email.message.Message.as_string`
+    #       because it prepends `> ` to `From ` lines.
+    # NOTE: We must use six.StringIO() instead of io.StringIO() since the
+    #       `email` library uses cStringIO in Py2 and io.StringIO in Py3.
+    fp = six.StringIO()
     g = email_generator.Generator(fp, mangle_from_=False)
     g.flatten(msg_root, unixfrom=False)
     http_request.body = fp.getvalue()

--- a/apitools/base/py/transfer_test.py
+++ b/apitools/base/py/transfer_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 
-import io
+import six
 
 import unittest2
 
@@ -36,7 +36,7 @@ class TransferTest(unittest2.TestCase):
     # Test multipart: having a body argument in http_request forces
     # multipart here.
     upload = transfer.Upload.FromStream(
-        io.BytesIO(upload_contents),
+        six.StringIO(upload_contents),
         'text/plain',
         total_size=len(upload_contents))
     http_request = http_wrapper.Request(
@@ -52,7 +52,7 @@ class TransferTest(unittest2.TestCase):
     # Test non-multipart (aka media): no body argument means this is
     # sent as media.
     upload = transfer.Upload.FromStream(
-        io.BytesIO(upload_contents),
+        six.StringIO(upload_contents),
         'text/plain',
         total_size=len(upload_contents))
     http_request = http_wrapper.Request(

--- a/apitools/base/py/transfer_test.py
+++ b/apitools/base/py/transfer_test.py
@@ -13,14 +13,13 @@ from apitools.base.py import transfer
 class TransferTest(unittest2.TestCase):
 
   def testFromEncoding(self):
-    """Test a specific corner case in multipart encoding.
+    # Test a specific corner case in multipart encoding.
 
-    Python's mime module by default encodes lines that start with
-    "From " as ">From ", which we need to make sure we don't run afoul
-    of when sending content that isn't intended to be so encoded. This
-    test calls out that we get this right. We test for both the
-    multipart and non-multipart case.
-    """
+    # Python's mime module by default encodes lines that start with
+    # "From " as ">From ", which we need to make sure we don't run afoul
+    # of when sending content that isn't intended to be so encoded. This
+    # test calls out that we get this right. We test for both the
+    # multipart and non-multipart case.
     multipart_body = '{"body_field_one": 7}'
     upload_contents = 'line one\nFrom \nline two'
     upload_config = base_api.ApiUploadInfo(

--- a/apitools/base/py/transfer_test.py
+++ b/apitools/base/py/transfer_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 
-import StringIO
+import io
 
 import unittest2
 
@@ -36,7 +36,7 @@ class TransferTest(unittest2.TestCase):
     # Test multipart: having a body argument in http_request forces
     # multipart here.
     upload = transfer.Upload.FromStream(
-        StringIO.StringIO(upload_contents),
+        io.BytesIO(upload_contents),
         'text/plain',
         total_size=len(upload_contents))
     http_request = http_wrapper.Request(
@@ -52,7 +52,7 @@ class TransferTest(unittest2.TestCase):
     # Test non-multipart (aka media): no body argument means this is
     # sent as media.
     upload = transfer.Upload.FromStream(
-        StringIO.StringIO(upload_contents),
+        io.BytesIO(upload_contents),
         'text/plain',
         total_size=len(upload_contents))
     http_request = http_wrapper.Request(

--- a/apitools/gen/client_generation_test.py
+++ b/apitools/gen/client_generation_test.py
@@ -38,13 +38,14 @@ class ClientGenerationTest(unittest2.TestCase):
     super(ClientGenerationTest, self).setUp()
     self.gen_client_binary = 'gen_client'
 
+  # TODO(craigcitro): Make apitools codegen support python 2.6.
+  # Maybe.
+  #
+  # unittest in 2.6 doesn't have skipIf.
+  @unittest2.skipUnless(sys.version_info[0] == 2 and
+                        sys.version_info[1] == 7,
+                        'Only runs in Python 2.7')
   def testGeneration(self):
-    if sys.version_info < (2, 7):
-      # TODO(craigcitro): Make apitools codegen support python 2.6.
-      # Maybe.
-      #
-      # unittest in 2.6 doesn't have skipIf.
-      return
     for api in _API_LIST:
       with TempDir():
         args = [

--- a/apitools/gen/gen_client_lib.py
+++ b/apitools/gen/gen_client_lib.py
@@ -6,7 +6,7 @@ Relevant links:
 """
 
 import json
-import urlparse
+from six.moves import urllib_parse
 
 from apitools.base.py import base_cli
 from apitools.gen import command_registry
@@ -33,7 +33,7 @@ def _StandardQueryParametersSchema(discovery_doc):
 
 
 def _ComputePaths(package, version, discovery_doc):
-  full_path = urlparse.urljoin(
+  full_path = urllib_parse.urljoin(
       discovery_doc['rootUrl'], discovery_doc['servicePath'])
   api_path_component = '/'.join((package, version, ''))
   if api_path_component not in full_path:

--- a/apitools/gen/util.py
+++ b/apitools/gen/util.py
@@ -10,7 +10,6 @@ import logging
 import os
 import re
 import urllib2
-import urlparse
 
 import six
 

--- a/samples/storage_sample/downloads_test.py
+++ b/samples/storage_sample/downloads_test.py
@@ -4,10 +4,10 @@ These tests exercise most of the corner cases for upload/download of
 files in apitools, via GCS. There are no performance tests here yet.
 """
 
+import io
 import json
 import os
 import pkgutil
-import StringIO
 import unittest
 
 import apitools.base.py as apitools_base
@@ -29,7 +29,7 @@ class DownloadsTest(unittest.TestCase):
     self.__ResetDownload()
 
   def __ResetDownload(self, auto_transfer=False):
-    self.__buffer = StringIO.StringIO()
+    self.__buffer = io.StringIO()
     self.__download = storage.Download.FromStream(
         self.__buffer, auto_transfer=auto_transfer)
 
@@ -157,7 +157,7 @@ class DownloadsTest(unittest.TestCase):
     request = storage.StorageObjectsGetRequest(
         bucket=self._DEFAULT_BUCKET, object=object_name)
     response = self.__client.objects.Get(request)
-    self.__buffer = StringIO.StringIO()
+    self.__buffer = io.StringIO()
     download_data = json.dumps({
         'auto_transfer': False,
         'progress': 0,

--- a/samples/storage_sample/uploads_test.py
+++ b/samples/storage_sample/uploads_test.py
@@ -4,11 +4,11 @@ These tests exercise most of the corner cases for upload/download of
 files in apitools, via GCS. There are no performance tests here yet.
 """
 
+import io
 import json
 import os
 import random
 import string
-import StringIO
 import unittest
 
 import apitools.base.py as apitools_base
@@ -37,8 +37,8 @@ class UploadsTest(unittest.TestCase):
 
   def __ResetUpload(self, size, auto_transfer=True):
     self.__content = ''.join(
-        random.choice(string.letters) for _ in xrange(size))
-    self.__buffer = StringIO.StringIO(self.__content)
+        random.choice(string.ascii_letters) for _ in xrange(size))
+    self.__buffer = io.StringIO(self.__content)
     self.__upload = storage.Upload.FromStream(
         self.__buffer, 'text/plain', auto_transfer=auto_transfer)
 
@@ -100,7 +100,8 @@ class UploadsTest(unittest.TestCase):
     self.assertEqual(size, response.size)
 
   def testBreakAndResumeUpload(self):
-    filename = 'ten_meg_file_' + ''.join(random.sample(string.letters, 5))
+    filename = ('ten_meg_file_' +
+                ''.join(random.sample(string.ascii_letters, 5)))
     size = 10 << 20
     self.__ResetUpload(size, auto_transfer=False)
     self.__upload.strategy = 'resumable'

--- a/samples/storage_sample/uploads_test.py
+++ b/samples/storage_sample/uploads_test.py
@@ -37,7 +37,7 @@ class UploadsTest(unittest.TestCase):
 
   def __ResetUpload(self, size, auto_transfer=True):
     self.__content = ''.join(
-        random.choice(string.ascii_letters) for _ in xrange(size))
+        random.choice(string.ascii_letters) for _ in range(size))
     self.__buffer = io.StringIO(self.__content)
     self.__upload = storage.Upload.FromStream(
         self.__buffer, 'text/plain', auto_transfer=auto_transfer)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,pypy
+envlist = py26,py27,pypy,py33,py34
 
 [testenv]
 deps = nose

--- a/tox.ini
+++ b/tox.ini
@@ -6,3 +6,19 @@ deps = nose
 commands =
     pip install google-apitools[testing]
     nosetests
+
+[testenv:py33]
+basepython = python3.3
+deps =
+    mock
+    nose
+    unittest2
+commands = nosetests
+
+[testenv:py34]
+basepython = python3.4
+deps =
+    mock
+    nose
+    unittest2
+commands = nosetests


### PR DESCRIPTION
Had to remove `google-apitools[testing]` for Python 3 tests.

---------

**ORIGINALLY SAID**:

Though this adds Python 3.4 to Travis, it doesn't currently pass due to a syntax error:

```python
  File ".../apitools/apitools/base/py/__init__.py", line 5, in <module>
    from apitools.base.py.base_api import *
  File ".../apitools/apitools/base/py/base_api.py", line 17, in <module>
    from apitools.base.py import credentials_lib
  File ".../apitools/apitools/base/py/credentials_lib.py", line 15, in <module>
    import oauth2client.tools  # for flag declarations
  File ".../apitools/.tox/py34/lib/python3.4/site-packages/oauth2client/tools.py", line 242, in <module>
    from oauth2client.old_run import run
  File ".../apitools/.tox/py34/lib/python3.4/site-packages/oauth2client/old_run.py", line 25, in <module>
    import gflags
  File ".../apitools/.tox/py34/lib/python3.4/site-packages/gflags.py", line 1091
    except gflags_validators.Error, e:
                                  ^
SyntaxError: invalid syntax
```

It may just be that you don't want those `gflags` tests to run under Python 3?