### PR TITLE
Adding tox test coverage rule.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[report]
+omit =
+    */demo/*
+exclude_lines =
+    # Re-enable the standard pragma
+    pragma: NO COVER
+    # Ignore debug-only repr
+    def __repr__

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,9 @@
 build/
 dist/
 distribute-*
+
 # Test files
 .tox/
+.coverage
+coverage.xml
+nosetests.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,5 @@ install:
   - pip install tox
   - pip install . --allow-external argparse
 script: tox -e $TOX_ENV
+after_success:
+  - tox -e coveralls

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 google-apitools
 ===============
 
-|pypi| |build|
+|pypi| |build| |coverage|
 
 ``google-apitools`` is a collection of utilities to make it easier to build
 client-side tools, especially those that talk to Google APIs.
@@ -43,3 +43,5 @@ Then run the tests::
    :target: https://travis-ci.org/google/apitools
 .. |pypi| image:: https://img.shields.io/pypi/v/google-apitools.svg
    :target: https://pypi.python.org/pypi/google-apitools
+.. |coverage| image:: https://coveralls.io/repos/google/apitools/badge.png?branch=master
+   :target: https://coveralls.io/r/google/apitools?branch=master

--- a/tox.ini
+++ b/tox.ini
@@ -22,3 +22,25 @@ deps =
     nose
     unittest2
 commands = nosetests
+
+[testenv:cover]
+basepython =
+    python2.7
+commands =
+    nosetests --with-xunit --with-xcoverage --cover-package=apitools --nocapture --cover-erase --cover-tests --cover-branches
+deps =
+    google-apputils
+    mock
+    nose
+    unittest2
+    coverage
+    nosexcover
+
+[testenv:coveralls]
+basepython = {[testenv:cover]basepython}
+commands =
+    {[testenv:cover]commands}
+    coveralls
+deps =
+    {[testenv:cover]deps}
+    coveralls


### PR DESCRIPTION
- Adding badge in README
- Adding after_success rule to run test coverage in Travis

NOTE: The Coveralls badge needs to be activated by a project owner.
NOTE: The README changes compete (somewhat) with #2