### PR TITLE
Fix an issue with setup scripts in tox.ini.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py26,py27,pypy,py33,py34
 [testenv]
 deps = nose
 commands =
-    pip install google-apitools[testing]
+    pip install -e .[testing] -q --log={envlogdir}/pip-extra-install.log
     nosetests
 
 [testenv:py33]


### PR DESCRIPTION
This tweaks `tox.ini` to install additional packages in such a way that we
don't run afoul of the issues in #4.

@tseaver do you have any sense for *why* this would fix the failures we're seeing in #4? this is far beyond my python-packaging-fu. in particular, danny found [this link](https://bitbucket.org/hpk42/tox/issue/77/cant-install-new-extras-for-target-package) with the fix, but I'm still confused as to why this particular fix works, whereas other attempts (including *not* calling `pip` from inside `tox.ini`) didn't.