### PR TITLE
Testing neaten

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 env:
   - TOX_ENV=py27
   - TOX_ENV=pypy

--- a/tox.ini
+++ b/tox.ini
@@ -1,46 +1,48 @@
 [tox]
 envlist = py26,py27,pypy,py33,py34
 
+[minimal]
+deps =
+    nose
+    mock
+    unittest2
+
 [testenv]
-deps = nose
+deps =
+    {[minimal]deps}
+    google-apputils
 commands =
-    pip install google-apitools[testing]
     nosetests
 
 [testenv:py33]
 basepython = python3.3
 deps =
-    mock
-    nose
-    unittest2
-commands = nosetests
+    {[minimal]deps}
+commands =
+    nosetests
 
 [testenv:py34]
 basepython = python3.4
 deps =
-    mock
-    nose
-    unittest2
-commands = nosetests
+    {[minimal]deps}
+commands =
+    nosetests
 
 [testenv:cover]
 basepython =
     python2.7
-commands =
-    nosetests --with-xunit --with-xcoverage --cover-package=apitools --nocapture --cover-erase --cover-tests --cover-branches
 deps =
-    google-apputils
-    mock
-    nose
-    unittest2
+    {[testenv]deps}
     coverage
     nosexcover
+commands =
+    nosetests --with-xunit --with-xcoverage --cover-package=apitools --nocapture --cover-erase --cover-tests --cover-branches
 
 [testenv:coveralls]
 basepython = {[testenv:cover]basepython}
-commands =
-    {[testenv:cover]commands}
-    coveralls
 deps =
     {[testenv:cover]deps}
+    coveralls
+commands =
+    {[testenv:cover]commands}
     coveralls


### PR DESCRIPTION
DRY tox dependencies (don't depend on setuptools 'testing' extra for it).

 Speed up Travis builds via `sudo: false` (see: http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/ )