### PR TITLE
Change callback defaults for transfers.

### DIFF
--- a/apitools/gen/command_registry.py
+++ b/apitools/gen/command_registry.py
@@ -541,14 +541,22 @@ class CommandRegistry(object):
             printer('if FLAGS.upload_filename:')
             with printer.Indent():
               printer('upload = apitools_base.Upload.FromFile(')
-              printer('    FLAGS.upload_filename, FLAGS.upload_mime_type)')
+              printer('    FLAGS.upload_filename, FLAGS.upload_mime_type,')
+              printer('    progress_callback='
+                      'apitools_base.UploadProgressPrinter,')
+              printer('    finish_callback='
+                      'apitools_base.UploadCompletePrinter)')
           if command_info.has_download:
             call_args.append('download=download')
             printer('download = None')
             printer('if FLAGS.download_filename:')
             with printer.Indent():
               printer('download = apitools_base.Download.FromFile('
-                      'FLAGS.download_filename, overwrite=FLAGS.overwrite)')
+                      'FLAGS.download_filename, overwrite=FLAGS.overwrite,')
+              printer('    progress_callback='
+                      'apitools_base.DownloadProgressPrinter,')
+              printer('    finish_callback='
+                      'apitools_base.DownloadCompletePrinter)')
           printer('result = client.%s(', command_info.client_method_path)
           with printer.Indent(indent='    '):
             printer('%s)', ', '.join(call_args))


### PR DESCRIPTION
This makes several changes to the way we use callbacks in media transfers:
 * allow callbacks to be attached to a transfer, not just be provided as an
 argument to streaming functions,
 * switch the defaults to "don't print",
 * expose the "print progress" defaults as public functions instead of
 protected static methods, and
 * teach the generated CLIs to print by default.

PTAL @thobrla and @dhermes 

@thobrla -- if this looks good, I can go in and remove all the "null callback" business in gsutil after the next apitools release.