### PR TITLE
Fix credentials_lib tests to not rely on sys.argv.

### DIFF
--- a/apitools/base/py/credentials_lib.py
+++ b/apitools/base/py/credentials_lib.py
@@ -403,10 +403,10 @@ class GaeAssertionCredentials(oauth2client.client.AssertionCredentials):
         self.access_token = token
 
 
-def _GetRunFlowFlags():
+def _GetRunFlowFlags(args=None):
     parser = argparse.ArgumentParser(parents=[tools.argparser])
     # Get command line argparse flags.
-    flags = parser.parse_args()
+    flags = parser.parse_args(args=args)
 
     # Allow `gflags` and `argparse` to be used side-by-side.
     if hasattr(FLAGS, 'auth_host_name'):

--- a/apitools/base/py/credentials_lib_test.py
+++ b/apitools/base/py/credentials_lib_test.py
@@ -74,8 +74,8 @@ class TestGetRunFlowFlags(unittest2.TestCase):
         credentials_lib.FLAGS = self._flags_actual
 
     def test_with_gflags(self):
-        HOST = object()
-        PORT = object()
+        HOST = 'myhostname'
+        PORT = '144169'
 
         class MockFlags(object):
             auth_host_name = HOST
@@ -83,7 +83,11 @@ class TestGetRunFlowFlags(unittest2.TestCase):
             auth_local_webserver = False
 
         credentials_lib.FLAGS = MockFlags
-        flags = credentials_lib._GetRunFlowFlags()
+        flags = credentials_lib._GetRunFlowFlags([
+            '--auth_host_name=%s' % HOST,
+            '--auth_host_port=%s' % PORT,
+            '--noauth_local_webserver',
+        ])
         self.assertEqual(flags.auth_host_name, HOST)
         self.assertEqual(flags.auth_host_port, PORT)
         self.assertEqual(flags.logging_level, 'ERROR')
@@ -91,7 +95,7 @@ class TestGetRunFlowFlags(unittest2.TestCase):
 
     def test_without_gflags(self):
         credentials_lib.FLAGS = None
-        flags = credentials_lib._GetRunFlowFlags()
+        flags = credentials_lib._GetRunFlowFlags([])
         self.assertEqual(flags.auth_host_name, 'localhost')
         self.assertEqual(flags.auth_host_port, [8080, 8090])
         self.assertEqual(flags.logging_level, 'ERROR')


### PR DESCRIPTION
Previously, some tests in credentials_lib were implicitly reading argv (via
`argparse`); this cleans them up to have an explicit argv passed in.

PTAL @dhermes 