### PR TITLE
Validate user-provided MIME types on uploads.

### DIFF
--- a/apitools/base/py/util.py
+++ b/apitools/base/py/util.py
@@ -157,6 +157,9 @@ def AcceptableMimeType(accept_patterns, mime_type):
     Returns:
       Whether or not mime_type matches (at least) one of these patterns.
     """
+    if '/' not in mime_type:
+        raise exceptions.InvalidUserInputError(
+            'Invalid MIME type: "%s"' % mime_type)
     unsupported_patterns = [p for p in accept_patterns if ';' in p]
     if unsupported_patterns:
         raise exceptions.GeneratedClientError(

--- a/apitools/base/py/util_test.py
+++ b/apitools/base/py/util_test.py
@@ -142,6 +142,11 @@ class UtilTest(unittest2.TestCase):
         self.assertFalse(util.AcceptableMimeType(['application/json', 'img/*'],
                                                  'text/plain'))
 
+    def testMalformedMimeType(self):
+        self.assertRaises(
+            exceptions.InvalidUserInputError,
+            util.AcceptableMimeType, ['*/*'], 'abcd')
+
     def testUnsupportedMimeType(self):
         self.assertRaises(
             exceptions.GeneratedClientError,


### PR DESCRIPTION
Currently, we'll allow any string as the MIME type -- but valid MIME types
must contain a `/`. The code implicitly assumes this, so we might as well
check it and raise a comprehensible error.

PTAL @thobrla 