### PR TITLE
Restore chunked download support.

### DIFF
--- a/apitools/base/py/transfer_test.py
+++ b/apitools/base/py/transfer_test.py
@@ -1,5 +1,9 @@
 """Tests for transfer.py."""
+import string
+
+import mock
 import six
+from six.moves import http_client
 import unittest2
 
 from apitools.base.py import base_api
@@ -8,6 +12,147 @@ from apitools.base.py import transfer
 
 
 class TransferTest(unittest2.TestCase):
+
+    def assertRangeAndContentRangeCompatible(self, request, response):
+        request_prefix = 'bytes='
+        self.assertIn('range', request.headers)
+        self.assertTrue(request.headers['range'].startswith(request_prefix))
+        request_range = request.headers['range'][len(request_prefix):]
+
+        response_prefix = 'bytes '
+        self.assertIn('content-range', response.info)
+        response_header = response.info['content-range']
+        self.assertTrue(response_header.startswith(response_prefix))
+        response_range = (
+            response_header[len(response_prefix):].partition('/')[0])
+
+        msg = ('Request range ({0}) not a prefix of '
+               'response_range ({1})').format(
+                   request_range, response_range)
+        self.assertTrue(response_range.startswith(request_range), msg=msg)
+
+    def testComputeEndByte(self):
+        total_size = 100
+        chunksize = 10
+        download = transfer.Download.FromStream(
+            six.StringIO(), chunksize=chunksize, total_size=total_size)
+        self.assertEqual(chunksize - 1,
+                         download._Download__ComputeEndByte(0, end=50))
+
+    def testComputeEndByteReturnNone(self):
+        download = transfer.Download.FromStream(six.StringIO())
+        self.assertIsNone(
+            download._Download__ComputeEndByte(0, use_chunks=False))
+
+    def testComputeEndByteNoChunks(self):
+        total_size = 100
+        download = transfer.Download.FromStream(
+            six.StringIO(), chunksize=10, total_size=total_size)
+        for end in (None, 1000):
+            self.assertEqual(
+                total_size - 1,
+                download._Download__ComputeEndByte(0, end=end,
+                                                   use_chunks=False),
+                msg='Failed on end={0}'.format(end))
+
+    def testComputeEndByteNoTotal(self):
+        download = transfer.Download.FromStream(six.StringIO())
+        default_chunksize = download.chunksize
+        for chunksize in (100, default_chunksize):
+            download.chunksize = chunksize
+            for start in (0, 10):
+                self.assertEqual(
+                    download.chunksize + start - 1,
+                    download._Download__ComputeEndByte(start),
+                    msg='Failed on start={0}, chunksize={1}'.format(
+                        start, chunksize))
+
+    def testComputeEndByteSmallTotal(self):
+        total_size = 100
+        download = transfer.Download.FromStream(six.StringIO(),
+                                                total_size=total_size)
+        for start in (0, 10):
+            self.assertEqual(total_size - 1,
+                             download._Download__ComputeEndByte(start),
+                             msg='Failed on start={0}'.format(start))
+
+    def testNonChunkedDownload(self):
+        bytes_http = object()
+        http = object()
+        download_stream = six.StringIO()
+        download = transfer.Download.FromStream(download_stream, total_size=52)
+        download.bytes_http = bytes_http
+        base_url = 'https://part.one/'
+
+        with mock.patch.object(http_wrapper, 'MakeRequest',
+                               autospec=True) as make_request:
+            make_request.return_value = http_wrapper.Response(
+                info={
+                    'content-range': 'bytes 0-51/52',
+                    'status': http_client.OK,
+                },
+                content=string.ascii_lowercase * 2,
+                request_url=base_url,
+            )
+            request = http_wrapper.Request(url='https://part.one/')
+            download.InitializeDownload(request, http=http)
+            self.assertEqual(1, make_request.call_count)
+            received_request = make_request.call_args[0][1]
+            self.assertEqual(base_url, received_request.url)
+            self.assertRangeAndContentRangeCompatible(
+                received_request, make_request.return_value)
+            download_stream.seek(0)
+            self.assertEqual(string.ascii_lowercase * 2,
+                             download_stream.getvalue())
+
+    def testChunkedDownload(self):
+        bytes_http = object()
+        http = object()
+        download_stream = six.StringIO()
+        download = transfer.Download.FromStream(
+            download_stream, chunksize=26, total_size=52)
+        download.bytes_http = bytes_http
+
+        # Setting autospec on a mock with an iterable side_effect is
+        # currently broken (http://bugs.python.org/issue17826), so
+        # instead we write a little function.
+        def _ReturnBytes(unused_http, http_request,
+                         *unused_args, **unused_kwds):
+            url = http_request.url
+            if url == 'https://part.one/':
+                return http_wrapper.Response(
+                    info={
+                        'content-location': 'https://part.two/',
+                        'content-range': 'bytes 0-25/52',
+                        'status': http_client.PARTIAL_CONTENT,
+                    },
+                    content=string.ascii_lowercase,
+                    request_url='https://part.one/',
+                )
+            elif url == 'https://part.two/':
+                return http_wrapper.Response(
+                    info={
+                        'content-range': 'bytes 26-51/52',
+                        'status': http_client.OK,
+                    },
+                    content=string.ascii_uppercase,
+                    request_url='https://part.two/',
+                )
+            else:
+                self.fail('Unknown URL requested: %s' % url)
+
+        with mock.patch.object(http_wrapper, 'MakeRequest',
+                               autospec=True) as make_request:
+            make_request.side_effect = _ReturnBytes
+            request = http_wrapper.Request(url='https://part.one/')
+            download.InitializeDownload(request, http=http)
+            self.assertEqual(2, make_request.call_count)
+            for call in make_request.call_args_list:
+                self.assertRangeAndContentRangeCompatible(
+                    call[0][1], _ReturnBytes(*call[0]))
+            download_stream.seek(0)
+            self.assertEqual(string.ascii_lowercase + string.ascii_uppercase,
+                             download_stream.getvalue())
 
     def testFromEncoding(self):
         # Test a specific corner case in multipart encoding.

--- a/samples/storage_sample/downloads_test.py
+++ b/samples/storage_sample/downloads_test.py
@@ -4,10 +4,11 @@ These tests exercise most of the corner cases for upload/download of
 files in apitools, via GCS. There are no performance tests here yet.
 """
 
-import io
 import json
 import os
 import unittest
+
+import six
 
 import apitools.base.py as apitools_base
 import storage
@@ -31,7 +32,7 @@ class DownloadsTest(unittest.TestCase):
         self.__ResetDownload()
 
     def __ResetDownload(self, auto_transfer=False):
-        self.__buffer = io.StringIO()
+        self.__buffer = six.StringIO()
         self.__download = storage.Download.FromStream(
             self.__buffer, auto_transfer=auto_transfer)
 
@@ -62,6 +63,7 @@ class DownloadsTest(unittest.TestCase):
         self.assertEqual(0, self.__buffer.tell())
 
     def testObjectDoesNotExist(self):
+        self.__ResetDownload(auto_transfer=True)
         with self.assertRaises(apitools_base.HttpError):
             self.__GetFile(self.__GetRequest('nonexistent_file'))
 
@@ -159,7 +161,7 @@ class DownloadsTest(unittest.TestCase):
         request = storage.StorageObjectsGetRequest(
             bucket=self._DEFAULT_BUCKET, object=object_name)
         response = self.__client.objects.Get(request)
-        self.__buffer = io.StringIO()
+        self.__buffer = six.StringIO()
         download_data = json.dumps({
             'auto_transfer': False,
             'progress': 0,

--- a/samples/storage_sample/uploads_test.py
+++ b/samples/storage_sample/uploads_test.py
@@ -4,12 +4,13 @@ These tests exercise most of the corner cases for upload/download of
 files in apitools, via GCS. There are no performance tests here yet.
 """
 
-import io
 import json
 import os
 import random
 import string
 import unittest
+
+import six
 
 import apitools.base.py as apitools_base
 import storage
@@ -41,7 +42,7 @@ class UploadsTest(unittest.TestCase):
     def __ResetUpload(self, size, auto_transfer=True):
         self.__content = ''.join(
             random.choice(string.ascii_letters) for _ in range(size))
-        self.__buffer = io.StringIO(self.__content)
+        self.__buffer = six.StringIO(self.__content)
         self.__upload = storage.Upload.FromStream(
             self.__buffer, 'text/plain', auto_transfer=auto_transfer)
 


### PR DESCRIPTION
We lost support for chunked downloads in a merge; this PR restores chunked
download support, and adds tests.

In particular, since gsutil does its own chunking, we do one-shot downloads in
the case that `download.chunksize == 0`.

PTAL @thobrla -- i'm sure there are some corner cases I'm not yet thinking of.

@charlesccychen I think this should get you fixed up.