### PR TITLE
Allow clients to set max_retry_wait. Use float for jitter

### DIFF
--- a/apitools/base/py/http_wrapper.py
+++ b/apitools/base/py/http_wrapper.py
@@ -47,7 +47,8 @@ _REDIRECT_STATUS_CODES = (
 # exc: Exception being raised.
 # num_retries: Number of retries consumed; used for exponential backoff.
 ExceptionRetryArgs = collections.namedtuple(
-    'ExceptionRetryArgs', ['http', 'http_request', 'exc', 'num_retries'])
+    'ExceptionRetryArgs', ['http', 'http_request', 'exc', 'num_retries',
+                           'max_retry_wait'])
 
 
 @contextlib.contextmanager
@@ -276,10 +277,12 @@ def HandleExceptionsAndRebuildHttpConnections(retry_args):
     logging.debug('Retrying request to url %s after exception %s',
                   retry_args.http_request.url, retry_args.exc)
     time.sleep(
-        retry_after or util.CalculateWaitForRetry(retry_args.num_retries))
+        retry_after or util.CalculateWaitForRetry(
+            retry_args.num_retries, max_wait=retry_args.max_retry_wait))
 
 
-def MakeRequest(http, http_request, retries=7, redirections=5,
+def MakeRequest(http, http_request, retries=7, max_retry_wait=60,
+                redirections=5,
                 retry_func=HandleExceptionsAndRebuildHttpConnections,
                 check_response_func=CheckResponse):
     """Send http_request via the given http, performing error/retry handling.
@@ -288,7 +291,10 @@ def MakeRequest(http, http_request, retries=7, redirections=5,
       http: An httplib2.Http instance, or a http multiplexer that delegates to
           an underlying http, for example, HTTPMultiplexer.
       http_request: A Request to send.
-      retries: (int, default 5) Number of retries to attempt on 5XX replies.
+      retries: (int, default 7) Number of retries to attempt on retryable
+          replies (such as 429 or 5XX).
+      max_retry_wait: (int, default 60) Maximum number of seconds to wait
+          when retrying.
       redirections: (int, default 5) Number of redirects to follow.
       retry_func: Function to handle retries on exceptions. Arguments are
           (Httplib2.Http, Request, Exception, int num_retries).
@@ -315,7 +321,8 @@ def MakeRequest(http, http_request, retries=7, redirections=5,
             if retry >= retries:
                 raise
             else:
-                retry_func(ExceptionRetryArgs(http, http_request, e, retry))
+                retry_func(ExceptionRetryArgs(
+                    http, http_request, e, retry, max_retry_wait))
 
 
 def _MakeRequestNoRetry(http, http_request, redirections=5,

--- a/apitools/base/py/util.py
+++ b/apitools/base/py/util.py
@@ -126,20 +126,17 @@ def CalculateWaitForRetry(retry_attempt, max_wait=60):
 
     Args:
       retry_attempt: Retry attempt counter.
-      max_wait: Upper bound for wait time.
+      max_wait: Upper bound for wait time [seconds].
 
     Returns:
-      Amount of time to wait before retrying request.
+      Number of seconds to wait before retrying request.
 
     """
 
     wait_time = 2 ** retry_attempt
-    # randrange requires a nonzero interval, so we want to drop it if
-    # the range is too small for jitter.
-    if retry_attempt:
-        max_jitter = (2 ** retry_attempt) / 2
-        wait_time += random.randrange(-max_jitter, max_jitter)
-    return min(wait_time, max_wait)
+    max_jitter = wait_time / 4.0
+    wait_time += random.uniform(-max_jitter, max_jitter)
+    return max(1, min(wait_time, max_wait))
 
 
 def AcceptableMimeType(accept_patterns, mime_type):

--- a/apitools/base/py/util_test.py
+++ b/apitools/base/py/util_test.py
@@ -56,14 +56,23 @@ class UtilTest(unittest2.TestCase):
             method_config_no_reserved, {'x': 'foo/:bar:'}))
 
     def testCalculateWaitForRetry(self):
-        self.assertTrue(util.CalculateWaitForRetry(1) in range(1, 4))
-        self.assertTrue(util.CalculateWaitForRetry(2) in range(2, 7))
-        self.assertTrue(util.CalculateWaitForRetry(3) in range(4, 13))
-        self.assertTrue(util.CalculateWaitForRetry(4) in range(8, 25))
+        try0 = util.CalculateWaitForRetry(0)
+        self.assertTrue(try0 >= 1.0)
+        self.assertTrue(try0 <= 1.5)
+        try1 = util.CalculateWaitForRetry(1)
+        self.assertTrue(try1 >= 1.0)
+        self.assertTrue(try1 <= 3.0)
+        try2 = util.CalculateWaitForRetry(2)
+        self.assertTrue(try2 >= 2.0)
+        self.assertTrue(try2 <= 6.0)
+        try3 = util.CalculateWaitForRetry(3)
+        self.assertTrue(try3 >= 4.0)
+        self.assertTrue(try3 <= 12.0)
+        try4 = util.CalculateWaitForRetry(4)
+        self.assertTrue(try4 >= 8.0)
+        self.assertTrue(try4 <= 24.0)
 
-        self.assertEquals(10, util.CalculateWaitForRetry(5, max_wait=10))
-
-        self.assertGreater(util.CalculateWaitForRetry(0), 0)
+        self.assertAlmostEqual(10, util.CalculateWaitForRetry(5, max_wait=10))
 
     def testTypecheck(self):
 


### PR DESCRIPTION
This change allows clients to specify a max_retry_wait to provide
a custom upper bound for automatic client retries.

It also changes the granularity of retry jitter to a floating-point
value, further decreasing the likelihood of clustering retry
requests.