### PR TITLE
Fixed off by one error in GetRange.

### DIFF
--- a/apitools/base/py/transfer_test.py
+++ b/apitools/base/py/transfer_test.py
@@ -76,6 +76,36 @@ class TransferTest(unittest2.TestCase):
                              download._Download__ComputeEndByte(start),
                              msg='Failed on start={0}'.format(start))
 
+    def testGetRange(self):
+        for (start_byte, end_byte) in [(0, 25), (5, 15), (0, 0), (25, 25)]:
+            bytes_http = object()
+            http = object()
+            download_stream = six.StringIO()
+            download = transfer.Download.FromStream(download_stream,
+                                                    total_size=26,
+                                                    auto_transfer=False)
+            download.bytes_http = bytes_http
+            base_url = 'https://part.one/'
+            with mock.patch.object(http_wrapper, 'MakeRequest',
+                                   autospec=True) as make_request:
+                make_request.return_value = http_wrapper.Response(
+                    info={
+                        'content-range': 'bytes %d-%d/26' %
+                                         (start_byte, end_byte),
+                        'status': http_client.OK,
+                    },
+                    content=string.ascii_lowercase[start_byte:end_byte+1],
+                    request_url=base_url,
+                )
+                request = http_wrapper.Request(url='https://part.one/')
+                download.InitializeDownload(request, http=http)
+                download.GetRange(start_byte, end_byte)
+                self.assertEqual(1, make_request.call_count)
+                received_request = make_request.call_args[0][1]
+                self.assertEqual(base_url, received_request.url)
+                self.assertRangeAndContentRangeCompatible(
+                    received_request, make_request.return_value)
+
     def testNonChunkedDownload(self):
         bytes_http = object()
         http = object()


### PR DESCRIPTION
I believe this bug made it impossible to download ranges of size one (start_byte == end_byte).