### PR TITLE
Fix a bug in upload support, and do some cleanup.

### DIFF
--- a/apitools/base/py/transfer.py
+++ b/apitools/base/py/transfer.py
@@ -331,7 +331,7 @@ class Download(_Transfer):
         else:
             if start < 0:
                 start = max(0, start + self.total_size)
-            return start, self.total_size
+            return start, self.total_size - 1
 
     def __SetRangeHeader(self, request, start, end=None):
         if start < 0:
@@ -364,6 +364,10 @@ class Download(_Transfer):
 
         """
         end_byte = end
+
+        if start < 0 and not self.total_size:
+            return end_byte
+
         if use_chunks:
             alternate = start + self.chunksize - 1
             if end_byte is not None:
@@ -446,7 +450,9 @@ class Download(_Transfer):
             progress_end_normalized = True
         else:
             progress = start
-        while not progress_end_normalized or progress <= end_byte:
+            end_byte = end
+        while (not progress_end_normalized or end_byte is None or
+               progress <= end_byte):
             end_byte = self.__ComputeEndByte(progress, end=end_byte,
                                              use_chunks=use_chunks)
             response = self.__GetChunk(progress, end_byte,

--- a/samples/storage_sample/downloads_test.py
+++ b/samples/storage_sample/downloads_test.py
@@ -37,7 +37,9 @@ class DownloadsTest(unittest.TestCase):
             self.__buffer, auto_transfer=auto_transfer)
 
     def __GetTestdataFileContents(self, filename):
-        file_contents = open('testdata/%s' % filename).read()
+        file_path = os.path.join(
+            os.path.dirname(__file__), self._TESTDATA_PREFIX, filename)
+        file_contents = open(file_path).read()
         self.assertIsNotNone(
             file_contents, msg=('Could not read file %s' % filename))
         return file_contents

--- a/samples/storage_sample/uploads_test.py
+++ b/samples/storage_sample/uploads_test.py
@@ -103,6 +103,20 @@ class UploadsTest(unittest.TestCase):
         response = self.__InsertFile(filename, request=request)
         self.assertEqual(size, response.size)
 
+    def testStreamMedia(self):
+        filename = 'ten_meg_file'
+        size = 10 << 20
+        self.__ResetUpload(size, auto_transfer=False)
+        self.__upload.strategy = 'resumable'
+        self.__upload.total_size = size
+        request = self.__InsertRequest(filename)
+        initial_response = self.__client.objects.Insert(
+            request, upload=self.__upload)
+        self.assertIsNotNone(initial_response)
+        self.assertEqual(0, self.__buffer.tell())
+        self.__upload.StreamMedia()
+        self.assertEqual(size, self.__buffer.tell())
+
     def testBreakAndResumeUpload(self):
         filename = ('ten_meg_file_' +
                     ''.join(random.sample(string.ascii_letters, 5)))

--- a/tox.ini
+++ b/tox.ini
@@ -61,3 +61,18 @@ deps =
     {[testenv:cover]deps}
     coveralls
 passenv = TRAVIS*
+
+[testenv:transfer_coverage]
+basepython =
+    python2.7
+deps =
+    mock
+    nose
+    unittest2
+    coverage
+commands =
+    coverage run --branch -p samples/storage_sample/downloads_test.py
+    coverage run --branch -p samples/storage_sample/uploads_test.py
+    coverage run --branch -p apitools/base/py/transfer_test.py
+    coverage combine
+    coverage html


### PR DESCRIPTION
A recent cleanup introduced a NameError in a corner case; this was covered by
integration tests (yay!) that aren't run by default (boo!).

We clean this up (and fix a revealed corner-case bug), and clean up the tests
to run independent of the directory they're invoked from. Last, we add a tox
env (still for testing purposes) that computes coverage for the storage
integration tests; we're currently at 75%, covering most of the relevant code
in transfer.py.

PTAL @brandonsalmon22 @thobrla 