### PR TITLE
Let gen_client run on windows

### DIFF
--- a/apitools/base/py/base_cli.py
+++ b/apitools/base/py/base_cli.py
@@ -58,11 +58,6 @@ def DeclareBaseFlags():
 
     _BASE_FLAGS_DECLARED = True
 
-# NOTE: This is specified here so that it can be read by other files
-# without depending on the flag to be registered.
-TRACE_HELP = (
-    'A tracing token of the form "token:<tokenid>" '
-    'to include in api requests.')
 FLAGS = flags.FLAGS
 
 

--- a/apitools/gen/gen_client_lib.py
+++ b/apitools/gen/gen_client_lib.py
@@ -9,7 +9,6 @@ import datetime
 
 from six.moves import urllib_parse
 
-from apitools.base.py import base_cli
 from apitools.gen import command_registry
 from apitools.gen import message_registry
 from apitools.gen import service_registry
@@ -27,7 +26,8 @@ def _StandardQueryParametersSchema(discovery_doc):
     # We add an entry for the trace, since Discovery doesn't.
     standard_query_schema['properties']['trace'] = {
         'type': 'string',
-        'description': base_cli.TRACE_HELP,
+        'description': ('A tracing token of the form "token:<tokenid>" '
+                        'to include in api requests.'),
         'location': 'query',
     }
     return standard_query_schema


### PR DESCRIPTION
Remove trivial dependence of gen_client on base_cli module, as the former depends on readline which is not supported on windows.