### PR TITLE
Ensure apitools.gen.util.Chdir cleans up.

### DIFF
--- a/apitools/gen/util.py
+++ b/apitools/gen/util.py
@@ -141,9 +141,11 @@ def Chdir(dirname, create=True):
         else:
             os.mkdir(dirname)
     previous_directory = os.getcwd()
-    os.chdir(dirname)
-    yield
-    os.chdir(previous_directory)
+    try:
+        os.chdir(dirname)
+        yield
+    finally:
+        os.chdir(previous_directory)
 
 
 def NormalizeVersion(version):


### PR DESCRIPTION
Previously, if a test failed, later tests using `Chdir` would fail, since
they're in a now-nonexistent directory, and `os.getcwd()` fails.

PTAL @cherba 