### PR TITLE
Remove google.apputils/gflags usage in favor of argparse.

### DIFF
--- a/apitools/gen/client_generation_test.py
+++ b/apitools/gen/client_generation_test.py
@@ -1,13 +1,11 @@
 """Test gen_client against all the APIs we use regularly."""
 
-import contextlib
 import logging
 import os
-import shutil
 import subprocess
-import sys
 import tempfile
 
+from apitools.gen import test_utils
 
 import unittest2
 
@@ -19,31 +17,16 @@ _API_LIST = [
 ]
 
 
-@contextlib.contextmanager
-def TempDir():
-    original_dir = os.getcwd()
-    path = tempfile.mkdtemp()
-    try:
-        os.chdir(path)
-        yield path
-    finally:
-        os.chdir(original_dir)
-        shutil.rmtree(path)
-
-
 class ClientGenerationTest(unittest2.TestCase):
 
     def setUp(self):
         super(ClientGenerationTest, self).setUp()
         self.gen_client_binary = 'gen_client'
 
-    # unittest in 2.6 doesn't have skipIf.
-    @unittest2.skipUnless(sys.version_info[0] == 2 and
-                          sys.version_info[1] == 7,
-                          'Only runs in Python 2.7')
+    @test_utils.RunOnlyOnPython27
     def testGeneration(self):
         for api in _API_LIST:
-            with TempDir():
+            with test_utils.TempDir(change_to=True):
                 args = [
                     self.gen_client_binary,
                     '--client_id=12345',

--- a/apitools/gen/gen_client.py
+++ b/apitools/gen/gen_client.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Command-line interface to gen_client."""
 
+import argparse
 import contextlib
 import json
 import logging
@@ -8,89 +9,9 @@ import os
 import pkgutil
 import sys
 
-from google.apputils import appcommands
-import gflags as flags
-
 from apitools.base.py import exceptions
 from apitools.gen import gen_client_lib
 from apitools.gen import util
-
-flags.DEFINE_string(
-    'infile', '',
-    'Filename for the discovery document. Mutually exclusive with '
-    '--discovery_url.')
-flags.DEFINE_string(
-    'discovery_url', '',
-    'URL (or "name.version") of the discovery document to use. '
-    'Mutually exclusive with --infile.')
-
-flags.DEFINE_string(
-    'base_package',
-    'apitools.base.py',
-    'Base package path of apitools (defaults to '
-    'apitools.base.py)'
-)
-flags.DEFINE_string(
-    'outdir', '',
-    'Directory name for output files. (Defaults to the API name.)')
-flags.DEFINE_boolean(
-    'overwrite', False,
-    'Only overwrite the output directory if this flag is specified.')
-flags.DEFINE_string(
-    'root_package', '',
-    'Python import path for where these modules should be imported from.')
-
-
-flags.DEFINE_multistring(
-    'strip_prefix', [],
-    'Prefix to strip from type names in the discovery document. (May '
-    'be specified multiple times.)')
-flags.DEFINE_string(
-    'api_key', None,
-    'API key to use for API access.')
-flags.DEFINE_string(
-    'client_json', None,
-    'Use the given file downloaded from the dev. console for client_id '
-    'and client_secret.')
-flags.DEFINE_string(
-    'client_id', '1042881264118.apps.googleusercontent.com',
-    'Client ID to use for the generated client.')
-flags.DEFINE_string(
-    'client_secret', 'x_Tw5K8nnjoRAqULM9PFAC2b',
-    'Client secret for the generated client.')
-flags.DEFINE_multistring(
-    'scope', [],
-    'Scopes to request in the generated client. May be specified more than '
-    'once.')
-flags.DEFINE_string(
-    'user_agent', '',
-    'User agent for the generated client. Defaults to <api>-generated/0.1.')
-flags.DEFINE_boolean(
-    'generate_cli', True, 'If True, a CLI is also generated.')
-flags.DEFINE_list(
-    'unelidable_request_methods', [],
-    'Full method IDs of methods for which we should NOT try to elide '
-    'the request type. (Should be a comma-separated list.)')
-
-flags.DEFINE_boolean(
-    'experimental_capitalize_enums', False,
-    'Dangerous: attempt to rewrite enum values to be uppercase.')
-flags.DEFINE_enum(
-    'experimental_name_convention', util.Names.DEFAULT_NAME_CONVENTION,
-    util.Names.NAME_CONVENTIONS,
-    'Dangerous: use a particular style for generated names.')
-flags.DEFINE_boolean(
-    'experimental_proto2_output', False,
-    'Dangerous: also output a proto2 message file.')
-
-FLAGS = flags.FLAGS
-
-flags.RegisterValidator(
-    'infile', lambda i: not (i and FLAGS.discovery_url),
-    'Cannot specify both --infile and --discovery_url')
-flags.RegisterValidator(
-    'discovery_url', lambda i: not (i and FLAGS.infile),
-    'Cannot specify both --infile and --discovery_url')
 
 
 def _CopyLocalFile(filename):
@@ -106,44 +27,44 @@ def _CopyLocalFile(filename):
 _DISCOVERY_DOC = None
 
 
-def _GetDiscoveryDocFromFlags():
+def _GetDiscoveryDocFromFlags(args):
     """Get the discovery doc from flags."""
     global _DISCOVERY_DOC  # pylint: disable=global-statement
     if _DISCOVERY_DOC is None:
-        if FLAGS.discovery_url:
+        if args.discovery_url:
             try:
-                discovery_doc = util.FetchDiscoveryDoc(FLAGS.discovery_url)
+                discovery_doc = util.FetchDiscoveryDoc(args.discovery_url)
             except exceptions.CommunicationError:
                 raise exceptions.GeneratedClientError(
                     'Could not fetch discovery doc')
         else:
-            infile = os.path.expanduser(FLAGS.infile) or '/dev/stdin'
+            infile = os.path.expanduser(args.infile) or '/dev/stdin'
             discovery_doc = json.load(open(infile))
         _DISCOVERY_DOC = discovery_doc
     return _DISCOVERY_DOC
 
 
-def _GetCodegenFromFlags():
+def _GetCodegenFromFlags(args):
     """Create a codegen object from flags."""
-    discovery_doc = _GetDiscoveryDocFromFlags()
+    discovery_doc = _GetDiscoveryDocFromFlags(args)
     names = util.Names(
-        FLAGS.strip_prefix,
-        FLAGS.experimental_name_convention,
-        FLAGS.experimental_capitalize_enums)
+        args.strip_prefix,
+        args.experimental_name_convention,
+        args.experimental_capitalize_enums)
 
-    if FLAGS.client_json:
+    if args.client_json:
         try:
-            with open(FLAGS.client_json) as client_json:
+            with open(args.client_json) as client_json:
                 f = json.loads(client_json.read())
                 web = f.get('installed', f.get('web', {}))
                 client_id = web.get('client_id')
                 client_secret = web.get('client_secret')
         except IOError:
             raise exceptions.NotFoundError(
-                'Failed to open client json file: %s' % FLAGS.client_json)
+                'Failed to open client json file: %s' % args.client_json)
     else:
-        client_id = FLAGS.client_id
-        client_secret = FLAGS.client_secret
+        client_id = args.client_id
+        client_secret = args.client_secret
 
     if not client_id:
         logging.warning('No client ID supplied')
@@ -154,23 +75,23 @@ def _GetCodegenFromFlags():
         client_secret = ''
 
     client_info = util.ClientInfo.Create(
-        discovery_doc, FLAGS.scope, client_id, client_secret,
-        FLAGS.user_agent, names, FLAGS.api_key)
-    outdir = os.path.expanduser(FLAGS.outdir) or client_info.default_directory
-    if os.path.exists(outdir) and not FLAGS.overwrite:
+        discovery_doc, args.scope, client_id, client_secret,
+        args.user_agent, names, args.api_key)
+    outdir = os.path.expanduser(args.outdir) or client_info.default_directory
+    if os.path.exists(outdir) and not args.overwrite:
         raise exceptions.ConfigurationValueError(
             'Output directory exists, pass --overwrite to replace '
             'the existing files.')
     if not os.path.exists(outdir):
         os.makedirs(outdir)
 
-    root_package = FLAGS.root_package or util.GetPackage(outdir)
+    root_package = args.root_package or util.GetPackage(outdir)
     return gen_client_lib.DescriptorGenerator(
         discovery_doc, client_info, names, root_package, outdir,
-        base_package=FLAGS.base_package,
-        generate_cli=FLAGS.generate_cli,
-        use_proto2=FLAGS.experimental_proto2_output,
-        unelidable_request_methods=FLAGS.unelidable_request_methods)
+        base_package=args.base_package,
+        generate_cli=args.generate_cli,
+        use_proto2=args.experimental_proto2_output,
+        unelidable_request_methods=args.unelidable_request_methods)
 
 
 # TODO(craigcitro): Delete this if we don't need this functionality.
@@ -196,7 +117,7 @@ def _WriteProtoFiles(codegen):
             codegen.WriteServicesProtoFile(out)
 
 
-def _WriteGeneratedFiles(codegen):
+def _WriteGeneratedFiles(args, codegen):
     if codegen.use_proto2:
         _WriteProtoFiles(codegen)
     with util.Chdir(codegen.outdir):
@@ -204,7 +125,7 @@ def _WriteGeneratedFiles(codegen):
             codegen.WriteMessagesFile(out)
         with open(codegen.client_info.client_file_name, 'w') as out:
             codegen.WriteClientLibrary(out)
-        if FLAGS.generate_cli:
+        if args.generate_cli:
             with open(codegen.client_info.cli_file_name, 'w') as out:
                 codegen.WriteCli(out)
             os.chmod(codegen.client_info.cli_file_name, 0o755)
@@ -221,86 +142,171 @@ def _WriteSetupPy(codegen):
         codegen.WriteSetupPy(out)
 
 
-class GenerateClient(appcommands.Cmd):
+def GenerateClient(args):
 
     """Driver for client code generation."""
 
-    def Run(self, _):
-        """Create a client library."""
-        codegen = _GetCodegenFromFlags()
-        if codegen is None:
-            logging.error('Failed to create codegen, exiting.')
-            return 128
-        _WriteGeneratedFiles(codegen)
-        _WriteInit(codegen)
+    codegen = _GetCodegenFromFlags(args)
+    if codegen is None:
+        logging.error('Failed to create codegen, exiting.')
+        return 128
+    _WriteGeneratedFiles(args, codegen)
+    _WriteInit(codegen)
 
 
-class GeneratePipPackage(appcommands.Cmd):
+def GeneratePipPackage(args):
 
     """Generate a client as a pip-installable tarball."""
 
-    def Run(self, _):
-        """Create a client in a pip package."""
-        discovery_doc = _GetDiscoveryDocFromFlags()
-        package = discovery_doc['name']
-        original_outdir = os.path.expanduser(FLAGS.outdir)
-        FLAGS.outdir = os.path.join(
-            FLAGS.outdir, 'apitools/clients/%s' % package)
-        FLAGS.root_package = 'apitools.clients.%s' % package
-        FLAGS.generate_cli = False
-        codegen = _GetCodegenFromFlags()
-        if codegen is None:
-            logging.error('Failed to create codegen, exiting.')
-            return 1
-        _WriteGeneratedFiles(codegen)
-        _WriteInit(codegen)
-        with util.Chdir(original_outdir):
-            _WriteSetupPy(codegen)
-            with util.Chdir('apitools'):
+    discovery_doc = _GetDiscoveryDocFromFlags(args)
+    package = discovery_doc['name']
+    original_outdir = os.path.expanduser(args.outdir)
+    args.outdir = os.path.join(
+        args.outdir, 'apitools/clients/%s' % package)
+    args.root_package = 'apitools.clients.%s' % package
+    args.generate_cli = False
+    codegen = _GetCodegenFromFlags(args)
+    if codegen is None:
+        logging.error('Failed to create codegen, exiting.')
+        return 1
+    _WriteGeneratedFiles(args, codegen)
+    _WriteInit(codegen)
+    with util.Chdir(original_outdir):
+        _WriteSetupPy(codegen)
+        with util.Chdir('apitools'):
+            _WriteIntermediateInit(codegen)
+            with util.Chdir('clients'):
                 _WriteIntermediateInit(codegen)
-                with util.Chdir('clients'):
-                    _WriteIntermediateInit(codegen)
 
 
-class GenerateProto(appcommands.Cmd):
-
+def GenerateProto(args):
     """Generate just the two proto files for a given API."""
 
-    def Run(self, _):
-        """Create proto definitions for an API."""
-        codegen = _GetCodegenFromFlags()
-        _WriteProtoFiles(codegen)
+    codegen = _GetCodegenFromFlags(args)
+    _WriteProtoFiles(codegen)
 
 
-# pylint:disable=invalid-name
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv
+    parser = argparse.ArgumentParser(
+        description='Apitools Client Code Generator')
 
+    discovery_group = parser.add_mutually_exclusive_group()
+    discovery_group.add_argument(
+        '--infile',
+        help=('Filename for the discovery document. Mutually exclusive with '
+              '--discovery_url'))
 
-def run_main():
-    """Function to be used as setuptools script entry point."""
-    # Put the flags for this module somewhere the flags module will look
-    # for them.
+    discovery_group.add_argument(
+        '--discovery_url',
+        help=('URL (or "name.version") of the discovery document to use. '
+              'Mutually exclusive with --infile.'))
 
-    # pylint:disable=protected-access
-    new_name = flags._GetMainModule()
-    sys.modules[new_name] = sys.modules['__main__']
-    for flag in FLAGS.FlagsByModuleDict().get(__name__, []):
-        FLAGS._RegisterFlagByModule(new_name, flag)
-        for key_flag in FLAGS.KeyFlagsByModuleDict().get(__name__, []):
-            FLAGS._RegisterKeyFlagForModule(new_name, key_flag)
-    # pylint:enable=protected-access
+    parser.add_argument(
+        '--base_package',
+        default='apitools.base.py',
+        help='Base package path of apitools (defaults to apitools.base.py')
 
-    # Now set __main__ appropriately so that appcommands will be
-    # happy.
-    sys.modules['__main__'] = sys.modules[__name__]
-    appcommands.Run()
-    sys.modules['__main__'] = sys.modules.pop(new_name)
+    parser.add_argument(
+        '--outdir',
+        default='',
+        help='Directory name for output files. (Defaults to the API name.)')
 
+    parser.add_argument(
+        '--overwrite',
+        default=False, action='store_true',
+        help='Only overwrite the output directory if this flag is specified.')
 
-def main(_):
-    appcommands.AddCmd('client', GenerateClient)
-    appcommands.AddCmd('pip_package', GeneratePipPackage)
-    appcommands.AddCmd('proto', GenerateProto)
+    parser.add_argument(
+        '--root_package',
+        default='',
+        help=('Python import path for where these modules '
+              'should be imported from.'))
 
+    parser.add_argument(
+        '--strip_prefix', nargs='*',
+        default=[],
+        help=('Prefix to strip from type names in the discovery document. '
+              '(May be specified multiple times.)'))
+
+    parser.add_argument(
+        '--api_key',
+        help=('API key to use for API access.'))
+
+    parser.add_argument(
+        '--client_json',
+        help=('Use the given file downloaded from the dev. console for '
+              'client_id and client_secret.'))
+
+    parser.add_argument(
+        '--client_id',
+        default='1042881264118.apps.googleusercontent.com',
+        help='Client ID to use for the generated client.')
+
+    parser.add_argument(
+        '--client_secret',
+        default='x_Tw5K8nnjoRAqULM9PFAC2b',
+        help='Client secret for the generated client.')
+
+    parser.add_argument(
+        '--scope', nargs='*',
+        default=[],
+        help=('Scopes to request in the generated client. '
+              'May be specified more than once.'))
+
+    parser.add_argument(
+        '--user_agent',
+        default='x_Tw5K8nnjoRAqULM9PFAC2b',
+        help=('User agent for the generated client. '
+              'Defaults to <api>-generated/0.1.'))
+
+    parser.add_argument(
+        '--generate_cli', dest='generate_cli', action='store_true',
+        help='If specified (default), a CLI is also generated.')
+    parser.add_argument(
+        '--nogenerate_cli', dest='generate_cli', action='store_false',
+        help='CLI will not be generated.')
+    parser.set_defaults(generate_cli=True)
+
+    parser.add_argument(
+        '--unelidable_request_methods', nargs='*',
+        default=[],
+        help=('Full method IDs of methods for which we should NOT try to '
+              'elide the request type. (Should be a comma-separated list.'))
+
+    parser.add_argument(
+        '--experimental_capitalize_enums',
+        default=False, action='store_true',
+        help='Dangerous: attempt to rewrite enum values to be uppercase.')
+
+    parser.add_argument(
+        '--experimental_name_convention',
+        choices=util.Names.NAME_CONVENTIONS,
+        default=util.Names.DEFAULT_NAME_CONVENTION,
+        help='Dangerous: use a particular style for generated names.')
+
+    parser.add_argument(
+        '--experimental_proto2_output',
+        default=False, action='store_true',
+        help='Dangerous: also output a proto2 message file.')
+
+    subparsers = parser.add_subparsers(help='Type of generated code')
+
+    client_parser = subparsers.add_parser(
+        'client', help='Generate apitools client in destination folder')
+    client_parser.set_defaults(func=GenerateClient)
+
+    pip_package_parser = subparsers.add_parser(
+        'pip_package', help='Generate apitools client pip package')
+    pip_package_parser.set_defaults(func=GeneratePipPackage)
+
+    proto_parser = subparsers.add_parser(
+        'proto', help='Generate apitools client protos')
+    proto_parser.set_defaults(func=GenerateProto)
+
+    args = parser.parse_args(argv[1:])
+    return args.func(args) or 0
 
 if __name__ == '__main__':
-    appcommands.Run()
+    sys.exit(main())

--- a/apitools/gen/gen_client_test.py
+++ b/apitools/gen/gen_client_test.py
@@ -1,0 +1,68 @@
+"""Test for gen_client module."""
+
+from apitools.gen import gen_client
+from apitools.gen import test_utils
+
+import unittest2
+import os
+
+
+def GetDocPath(name):
+    return os.path.join(os.path.dirname(__file__), 'testdata', name)
+
+
+@test_utils.RunOnlyOnPython27
+class ClientGenCliTest(unittest2.TestCase):
+
+    def testHelp_NotEnoughArguments(self):
+        with self.assertRaisesRegexp(SystemExit, '0'):
+            with test_utils.CaptureOutput() as (_, err):
+                gen_client.main([gen_client.__file__, '-h'])
+                err_output = err.getvalue()
+                self.assertIn('usage:', err_output)
+                self.assertIn('error: too few arguments', err_output)
+
+    def testGenClient_SimpleDoc(self):
+        with test_utils.TempDir() as tmp_dir_path:
+            gen_client.main([
+                gen_client.__file__,
+                '--nogenerate_cli',
+                '--infile', GetDocPath('dns_v1.json'),
+                '--outdir', tmp_dir_path,
+                '--overwrite',
+                '--root_package', 'google.apis',
+                'client'
+            ])
+            self.assertEquals(
+                set(['dns_v1_client.py', 'dns_v1_messages.py', '__init__.py']),
+                set(os.listdir(tmp_dir_path)))
+
+    def testGenPipPackage_SimpleDoc(self):
+        with test_utils.TempDir() as tmp_dir_path:
+            gen_client.main([
+                gen_client.__file__,
+                '--nogenerate_cli',
+                '--infile', GetDocPath('dns_v1.json'),
+                '--outdir', tmp_dir_path,
+                '--overwrite',
+                '--root_package', 'google.apis',
+                'pip_package'
+            ])
+            self.assertEquals(
+                set(['apitools', 'setup.py']),
+                set(os.listdir(tmp_dir_path)))
+
+    def testGenProto_SimpleDoc(self):
+        with test_utils.TempDir() as tmp_dir_path:
+            gen_client.main([
+                gen_client.__file__,
+                '--nogenerate_cli',
+                '--infile', GetDocPath('dns_v1.json'),
+                '--outdir', tmp_dir_path,
+                '--overwrite',
+                '--root_package', 'google.apis',
+                'proto'
+            ])
+            self.assertEquals(
+                set(['dns_v1_messages.proto', 'dns_v1_services.proto']),
+                set(os.listdir(tmp_dir_path)))

--- a/apitools/gen/test_utils.py
+++ b/apitools/gen/test_utils.py
@@ -1,0 +1,40 @@
+"""Various utilities used in tests."""
+
+import contextlib
+import os
+import tempfile
+import shutil
+import sys
+
+import six
+import unittest2
+
+
+RunOnlyOnPython27 = unittest2.skipUnless(
+    sys.version_info[:2] == (2, 7), 'Only runs in Python 2.7')
+
+
+@contextlib.contextmanager
+def TempDir(change_to=False):
+    if change_to:
+        original_dir = os.getcwd()
+    path = tempfile.mkdtemp()
+    try:
+        if change_to:
+            os.chdir(path)
+        yield path
+    finally:
+        if change_to:
+            os.chdir(original_dir)
+        shutil.rmtree(path)
+
+
+@contextlib.contextmanager
+def CaptureOutput():
+    new_stdout, new_stderr = six.StringIO(), six.StringIO()
+    old_stdout, old_stderr = sys.stdout, sys.stderr
+    try:
+        sys.stdout, sys.stderr = new_stdout, new_stderr
+        yield new_stdout, new_stderr
+    finally:
+        sys.stdout, sys.stderr = old_stdout, old_stderr

--- a/apitools/gen/testdata/dns_v1.json
+++ b/apitools/gen/testdata/dns_v1.json
@@ -1,0 +1,707 @@
+{
+ "kind": "discovery#restDescription",
+ "discoveryVersion": "v1",
+ "id": "dns:v1",
+ "name": "dns",
+ "version": "v1",
+ "revision": "20150807",
+ "title": "Google Cloud DNS API",
+ "description": "The Google Cloud DNS API provides services for configuring and serving authoritative DNS records.",
+ "ownerDomain": "google.com",
+ "ownerName": "Google",
+ "icons": {
+  "x16": "http://www.google.com/images/icons/product/search-16.gif",
+  "x32": "http://www.google.com/images/icons/product/search-32.gif"
+ },
+ "documentationLink": "https://developers.google.com/cloud-dns",
+ "protocol": "rest",
+ "baseUrl": "https://www.googleapis.com/dns/v1/projects/",
+ "basePath": "/dns/v1/projects/",
+ "rootUrl": "https://www.googleapis.com/",
+ "servicePath": "dns/v1/projects/",
+ "batchPath": "batch",
+ "parameters": {
+  "alt": {
+   "type": "string",
+   "description": "Data format for the response.",
+   "default": "json",
+   "enum": [
+    "json"
+   ],
+   "enumDescriptions": [
+    "Responses with Content-Type of application/json"
+   ],
+   "location": "query"
+  },
+  "fields": {
+   "type": "string",
+   "description": "Selector specifying which fields to include in a partial response.",
+   "location": "query"
+  },
+  "key": {
+   "type": "string",
+   "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+   "location": "query"
+  },
+  "oauth_token": {
+   "type": "string",
+   "description": "OAuth 2.0 token for the current user.",
+   "location": "query"
+  },
+  "prettyPrint": {
+   "type": "boolean",
+   "description": "Returns response with indentations and line breaks.",
+   "default": "true",
+   "location": "query"
+  },
+  "quotaUser": {
+   "type": "string",
+   "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.",
+   "location": "query"
+  },
+  "userIp": {
+   "type": "string",
+   "description": "IP address of the site where the request originates. Use this if you want to enforce per-user limits.",
+   "location": "query"
+  }
+ },
+ "auth": {
+  "oauth2": {
+   "scopes": {
+    "https://www.googleapis.com/auth/cloud-platform": {
+     "description": "View and manage your data across Google Cloud Platform services"
+    },
+    "https://www.googleapis.com/auth/cloud-platform.read-only": {
+     "description": "MESSAGE UNDER CONSTRUCTION View your data across Google Cloud Platform services"
+    },
+    "https://www.googleapis.com/auth/ndev.clouddns.readonly": {
+     "description": "View your DNS records hosted by Google Cloud DNS"
+    },
+    "https://www.googleapis.com/auth/ndev.clouddns.readwrite": {
+     "description": "View and manage your DNS records hosted by Google Cloud DNS"
+    }
+   }
+  }
+ },
+ "schemas": {
+  "Change": {
+   "id": "Change",
+   "type": "object",
+   "description": "An atomic update to a collection of ResourceRecordSets.",
+   "properties": {
+    "additions": {
+     "type": "array",
+     "description": "Which ResourceRecordSets to add?",
+     "items": {
+      "$ref": "ResourceRecordSet"
+     }
+    },
+    "deletions": {
+     "type": "array",
+     "description": "Which ResourceRecordSets to remove? Must match existing data exactly.",
+     "items": {
+      "$ref": "ResourceRecordSet"
+     }
+    },
+    "id": {
+     "type": "string",
+     "description": "Unique identifier for the resource; defined by the server (output only)."
+    },
+    "kind": {
+     "type": "string",
+     "description": "Identifies what kind of resource this is. Value: the fixed string \"dns#change\".",
+     "default": "dns#change"
+    },
+    "startTime": {
+     "type": "string",
+     "description": "The time that this operation was started by the server. This is in RFC3339 text format."
+    },
+    "status": {
+     "type": "string",
+     "description": "Status of the operation (output only).",
+     "enum": [
+      "done",
+      "pending"
+     ],
+     "enumDescriptions": [
+      "",
+      ""
+     ]
+    }
+   }
+  },
+  "ChangesListResponse": {
+   "id": "ChangesListResponse",
+   "type": "object",
+   "description": "The response to a request to enumerate Changes to a ResourceRecordSets collection.",
+   "properties": {
+    "changes": {
+     "type": "array",
+     "description": "The requested changes.",
+     "items": {
+      "$ref": "Change"
+     }
+    },
+    "kind": {
+     "type": "string",
+     "description": "Type of resource.",
+     "default": "dns#changesListResponse"
+    },
+    "nextPageToken": {
+     "type": "string",
+     "description": "The presence of this field indicates that there exist more results following your last page of results in pagination order. To fetch them, make another list request using this value as your pagination token.\n\nIn this way you can retrieve the complete contents of even very large collections one page at a time. However, if the contents of the collection change between the first and last paginated list request, the set of all elements returned will be an inconsistent view of the collection. There is no way to retrieve a \"snapshot\" of collections larger than the maximum page size."
+    }
+   }
+  },
+  "ManagedZone": {
+   "id": "ManagedZone",
+   "type": "object",
+   "description": "A zone is a subtree of the DNS namespace under one administrative responsibility. A ManagedZone is a resource that represents a DNS zone hosted by the Cloud DNS service.",
+   "properties": {
+    "creationTime": {
+     "type": "string",
+     "description": "The time that this resource was created on the server. This is in RFC3339 text format. Output only."
+    },
+    "description": {
+     "type": "string",
+     "description": "A mutable string of at most 1024 characters associated with this resource for the user's convenience. Has no effect on the managed zone's function."
+    },
+    "dnsName": {
+     "type": "string",
+     "description": "The DNS name of this managed zone, for instance \"example.com.\"."
+    },
+    "id": {
+     "type": "string",
+     "description": "Unique identifier for the resource; defined by the server (output only)",
+     "format": "uint64"
+    },
+    "kind": {
+     "type": "string",
+     "description": "Identifies what kind of resource this is. Value: the fixed string \"dns#managedZone\".",
+     "default": "dns#managedZone"
+    },
+    "name": {
+     "type": "string",
+     "description": "User assigned name for this resource. Must be unique within the project. The name must be 1-32 characters long, must begin with a letter, end with a letter or digit, and only contain lowercase letters, digits or dashes."
+    },
+    "nameServerSet": {
+     "type": "string",
+     "description": "Optionally specifies the NameServerSet for this ManagedZone. A NameServerSet is a set of DNS name servers that all host the same ManagedZones. Most users will leave this field unset."
+    },
+    "nameServers": {
+     "type": "array",
+     "description": "Delegate your managed_zone to these virtual name servers; defined by the server (output only)",
+     "items": {
+      "type": "string"
+     }
+    }
+   }
+  },
+  "ManagedZonesListResponse": {
+   "id": "ManagedZonesListResponse",
+   "type": "object",
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Type of resource.",
+     "default": "dns#managedZonesListResponse"
+    },
+    "managedZones": {
+     "type": "array",
+     "description": "The managed zone resources.",
+     "items": {
+      "$ref": "ManagedZone"
+     }
+    },
+    "nextPageToken": {
+     "type": "string",
+     "description": "The presence of this field indicates that there exist more results following your last page of results in pagination order. To fetch them, make another list request using this value as your page token.\n\nIn this way you can retrieve the complete contents of even very large collections one page at a time. However, if the contents of the collection change between the first and last paginated list request, the set of all elements returned will be an inconsistent view of the collection. There is no way to retrieve a consistent snapshot of a collection larger than the maximum page size."
+    }
+   }
+  },
+  "Project": {
+   "id": "Project",
+   "type": "object",
+   "description": "A project resource. The project is a top level container for resources including Cloud DNS ManagedZones. Projects can be created only in the APIs console.",
+   "properties": {
+    "id": {
+     "type": "string",
+     "description": "User assigned unique identifier for the resource (output only)."
+    },
+    "kind": {
+     "type": "string",
+     "description": "Identifies what kind of resource this is. Value: the fixed string \"dns#project\".",
+     "default": "dns#project"
+    },
+    "number": {
+     "type": "string",
+     "description": "Unique numeric identifier for the resource; defined by the server (output only).",
+     "format": "uint64"
+    },
+    "quota": {
+     "$ref": "Quota",
+     "description": "Quotas assigned to this project (output only)."
+    }
+   }
+  },
+  "Quota": {
+   "id": "Quota",
+   "type": "object",
+   "description": "Limits associated with a Project.",
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Identifies what kind of resource this is. Value: the fixed string \"dns#quota\".",
+     "default": "dns#quota"
+    },
+    "managedZones": {
+     "type": "integer",
+     "description": "Maximum allowed number of managed zones in the project.",
+     "format": "int32"
+    },
+    "resourceRecordsPerRrset": {
+     "type": "integer",
+     "description": "Maximum allowed number of ResourceRecords per ResourceRecordSet.",
+     "format": "int32"
+    },
+    "rrsetAdditionsPerChange": {
+     "type": "integer",
+     "description": "Maximum allowed number of ResourceRecordSets to add per ChangesCreateRequest.",
+     "format": "int32"
+    },
+    "rrsetDeletionsPerChange": {
+     "type": "integer",
+     "description": "Maximum allowed number of ResourceRecordSets to delete per ChangesCreateRequest.",
+     "format": "int32"
+    },
+    "rrsetsPerManagedZone": {
+     "type": "integer",
+     "description": "Maximum allowed number of ResourceRecordSets per zone in the project.",
+     "format": "int32"
+    },
+    "totalRrdataSizePerChange": {
+     "type": "integer",
+     "description": "Maximum allowed size for total rrdata in one ChangesCreateRequest in bytes.",
+     "format": "int32"
+    }
+   }
+  },
+  "ResourceRecordSet": {
+   "id": "ResourceRecordSet",
+   "type": "object",
+   "description": "A unit of data that will be returned by the DNS servers.",
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Identifies what kind of resource this is. Value: the fixed string \"dns#resourceRecordSet\".",
+     "default": "dns#resourceRecordSet"
+    },
+    "name": {
+     "type": "string",
+     "description": "For example, www.example.com."
+    },
+    "rrdatas": {
+     "type": "array",
+     "description": "As defined in RFC 1035 (section 5) and RFC 1034 (section 3.6.1).",
+     "items": {
+      "type": "string"
+     }
+    },
+    "ttl": {
+     "type": "integer",
+     "description": "Number of seconds that this ResourceRecordSet can be cached by resolvers.",
+     "format": "int32"
+    },
+    "type": {
+     "type": "string",
+     "description": "The identifier of a supported record type, for example, A, AAAA, MX, TXT, and so on."
+    }
+   }
+  },
+  "ResourceRecordSetsListResponse": {
+   "id": "ResourceRecordSetsListResponse",
+   "type": "object",
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Type of resource.",
+     "default": "dns#resourceRecordSetsListResponse"
+    },
+    "nextPageToken": {
+     "type": "string",
+     "description": "The presence of this field indicates that there exist more results following your last page of results in pagination order. To fetch them, make another list request using this value as your pagination token.\n\nIn this way you can retrieve the complete contents of even very large collections one page at a time. However, if the contents of the collection change between the first and last paginated list request, the set of all elements returned will be an inconsistent view of the collection. There is no way to retrieve a consistent snapshot of a collection larger than the maximum page size."
+    },
+    "rrsets": {
+     "type": "array",
+     "description": "The resource record set resources.",
+     "items": {
+      "$ref": "ResourceRecordSet"
+     }
+    }
+   }
+  }
+ },
+ "resources": {
+  "changes": {
+   "methods": {
+    "create": {
+     "id": "dns.changes.create",
+     "path": "{project}/managedZones/{managedZone}/changes",
+     "httpMethod": "POST",
+     "description": "Atomically update the ResourceRecordSet collection.",
+     "parameters": {
+      "managedZone": {
+       "type": "string",
+       "description": "Identifies the managed zone addressed by this request. Can be the managed zone name or id.",
+       "required": true,
+       "location": "path"
+      },
+      "project": {
+       "type": "string",
+       "description": "Identifies the project addressed by this request.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "project",
+      "managedZone"
+     ],
+     "request": {
+      "$ref": "Change"
+     },
+     "response": {
+      "$ref": "Change"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/ndev.clouddns.readwrite"
+     ]
+    },
+    "get": {
+     "id": "dns.changes.get",
+     "path": "{project}/managedZones/{managedZone}/changes/{changeId}",
+     "httpMethod": "GET",
+     "description": "Fetch the representation of an existing Change.",
+     "parameters": {
+      "changeId": {
+       "type": "string",
+       "description": "The identifier of the requested change, from a previous ResourceRecordSetsChangeResponse.",
+       "required": true,
+       "location": "path"
+      },
+      "managedZone": {
+       "type": "string",
+       "description": "Identifies the managed zone addressed by this request. Can be the managed zone name or id.",
+       "required": true,
+       "location": "path"
+      },
+      "project": {
+       "type": "string",
+       "description": "Identifies the project addressed by this request.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "project",
+      "managedZone",
+      "changeId"
+     ],
+     "response": {
+      "$ref": "Change"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/cloud-platform.read-only",
+      "https://www.googleapis.com/auth/ndev.clouddns.readonly",
+      "https://www.googleapis.com/auth/ndev.clouddns.readwrite"
+     ]
+    },
+    "list": {
+     "id": "dns.changes.list",
+     "path": "{project}/managedZones/{managedZone}/changes",
+     "httpMethod": "GET",
+     "description": "Enumerate Changes to a ResourceRecordSet collection.",
+     "parameters": {
+      "managedZone": {
+       "type": "string",
+       "description": "Identifies the managed zone addressed by this request. Can be the managed zone name or id.",
+       "required": true,
+       "location": "path"
+      },
+      "maxResults": {
+       "type": "integer",
+       "description": "Optional. Maximum number of results to be returned. If unspecified, the server will decide how many results to return.",
+       "format": "int32",
+       "location": "query"
+      },
+      "pageToken": {
+       "type": "string",
+       "description": "Optional. A tag returned by a previous list request that was truncated. Use this parameter to continue a previous list request.",
+       "location": "query"
+      },
+      "project": {
+       "type": "string",
+       "description": "Identifies the project addressed by this request.",
+       "required": true,
+       "location": "path"
+      },
+      "sortBy": {
+       "type": "string",
+       "description": "Sorting criterion. The only supported value is change sequence.",
+       "default": "changeSequence",
+       "enum": [
+        "changeSequence"
+       ],
+       "enumDescriptions": [
+        ""
+       ],
+       "location": "query"
+      },
+      "sortOrder": {
+       "type": "string",
+       "description": "Sorting order direction: 'ascending' or 'descending'.",
+       "location": "query"
+      }
+     },
+     "parameterOrder": [
+      "project",
+      "managedZone"
+     ],
+     "response": {
+      "$ref": "ChangesListResponse"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/cloud-platform.read-only",
+      "https://www.googleapis.com/auth/ndev.clouddns.readonly",
+      "https://www.googleapis.com/auth/ndev.clouddns.readwrite"
+     ]
+    }
+   }
+  },
+  "managedZones": {
+   "methods": {
+    "create": {
+     "id": "dns.managedZones.create",
+     "path": "{project}/managedZones",
+     "httpMethod": "POST",
+     "description": "Create a new ManagedZone.",
+     "parameters": {
+      "project": {
+       "type": "string",
+       "description": "Identifies the project addressed by this request.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "project"
+     ],
+     "request": {
+      "$ref": "ManagedZone"
+     },
+     "response": {
+      "$ref": "ManagedZone"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/ndev.clouddns.readwrite"
+     ]
+    },
+    "delete": {
+     "id": "dns.managedZones.delete",
+     "path": "{project}/managedZones/{managedZone}",
+     "httpMethod": "DELETE",
+     "description": "Delete a previously created ManagedZone.",
+     "parameters": {
+      "managedZone": {
+       "type": "string",
+       "description": "Identifies the managed zone addressed by this request. Can be the managed zone name or id.",
+       "required": true,
+       "location": "path"
+      },
+      "project": {
+       "type": "string",
+       "description": "Identifies the project addressed by this request.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "project",
+      "managedZone"
+     ],
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/ndev.clouddns.readwrite"
+     ]
+    },
+    "get": {
+     "id": "dns.managedZones.get",
+     "path": "{project}/managedZones/{managedZone}",
+     "httpMethod": "GET",
+     "description": "Fetch the representation of an existing ManagedZone.",
+     "parameters": {
+      "managedZone": {
+       "type": "string",
+       "description": "Identifies the managed zone addressed by this request. Can be the managed zone name or id.",
+       "required": true,
+       "location": "path"
+      },
+      "project": {
+       "type": "string",
+       "description": "Identifies the project addressed by this request.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "project",
+      "managedZone"
+     ],
+     "response": {
+      "$ref": "ManagedZone"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/cloud-platform.read-only",
+      "https://www.googleapis.com/auth/ndev.clouddns.readonly",
+      "https://www.googleapis.com/auth/ndev.clouddns.readwrite"
+     ]
+    },
+    "list": {
+     "id": "dns.managedZones.list",
+     "path": "{project}/managedZones",
+     "httpMethod": "GET",
+     "description": "Enumerate ManagedZones that have been created but not yet deleted.",
+     "parameters": {
+      "dnsName": {
+       "type": "string",
+       "description": "Restricts the list to return only zones with this domain name.",
+       "location": "query"
+      },
+      "maxResults": {
+       "type": "integer",
+       "description": "Optional. Maximum number of results to be returned. If unspecified, the server will decide how many results to return.",
+       "format": "int32",
+       "location": "query"
+      },
+      "pageToken": {
+       "type": "string",
+       "description": "Optional. A tag returned by a previous list request that was truncated. Use this parameter to continue a previous list request.",
+       "location": "query"
+      },
+      "project": {
+       "type": "string",
+       "description": "Identifies the project addressed by this request.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "project"
+     ],
+     "response": {
+      "$ref": "ManagedZonesListResponse"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/cloud-platform.read-only",
+      "https://www.googleapis.com/auth/ndev.clouddns.readonly",
+      "https://www.googleapis.com/auth/ndev.clouddns.readwrite"
+     ]
+    }
+   }
+  },
+  "projects": {
+   "methods": {
+    "get": {
+     "id": "dns.projects.get",
+     "path": "{project}",
+     "httpMethod": "GET",
+     "description": "Fetch the representation of an existing Project.",
+     "parameters": {
+      "project": {
+       "type": "string",
+       "description": "Identifies the project addressed by this request.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "project"
+     ],
+     "response": {
+      "$ref": "Project"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/cloud-platform.read-only",
+      "https://www.googleapis.com/auth/ndev.clouddns.readonly",
+      "https://www.googleapis.com/auth/ndev.clouddns.readwrite"
+     ]
+    }
+   }
+  },
+  "resourceRecordSets": {
+   "methods": {
+    "list": {
+     "id": "dns.resourceRecordSets.list",
+     "path": "{project}/managedZones/{managedZone}/rrsets",
+     "httpMethod": "GET",
+     "description": "Enumerate ResourceRecordSets that have been created but not yet deleted.",
+     "parameters": {
+      "managedZone": {
+       "type": "string",
+       "description": "Identifies the managed zone addressed by this request. Can be the managed zone name or id.",
+       "required": true,
+       "location": "path"
+      },
+      "maxResults": {
+       "type": "integer",
+       "description": "Optional. Maximum number of results to be returned. If unspecified, the server will decide how many results to return.",
+       "format": "int32",
+       "location": "query"
+      },
+      "name": {
+       "type": "string",
+       "description": "Restricts the list to return only records with this fully qualified domain name.",
+       "location": "query"
+      },
+      "pageToken": {
+       "type": "string",
+       "description": "Optional. A tag returned by a previous list request that was truncated. Use this parameter to continue a previous list request.",
+       "location": "query"
+      },
+      "project": {
+       "type": "string",
+       "description": "Identifies the project addressed by this request.",
+       "required": true,
+       "location": "path"
+      },
+      "type": {
+       "type": "string",
+       "description": "Restricts the list to return only records of this type. If present, the \"name\" parameter must also be present.",
+       "location": "query"
+      }
+     },
+     "parameterOrder": [
+      "project",
+      "managedZone"
+     ],
+     "response": {
+      "$ref": "ResourceRecordSetsListResponse"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/cloud-platform.read-only",
+      "https://www.googleapis.com/auth/ndev.clouddns.readonly",
+      "https://www.googleapis.com/auth/ndev.clouddns.readwrite"
+     ]
+    }
+   }
+  }
+ }
+}

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ TESTING_PACKAGES = [
 ]
 
 CONSOLE_SCRIPTS = [
-    'gen_client = apitools.gen.gen_client:run_main',
+    'gen_client = apitools.gen.gen_client:main',
     'oauth2l = apitools.scripts.oauth2l:run_main [cli]',
 ]
 


### PR DESCRIPTION
This PR converts apitools.gen.gen/gen_client.py to use python standard argparse for command line argument parsing. Note that now type of generation argument must occur last on the command line.