### PR TITLE
Update our use of protorpc metaclasses.

### DIFF
--- a/apitools/base/py/extra_types.py
+++ b/apitools/base/py/extra_types.py
@@ -35,23 +35,25 @@ DateTimeMessage = message_types.DateTimeMessage
 # pylint:enable=invalid-name
 
 
-class DateField(messages.Field):
+# We insert our own metaclass here to avoid letting ProtoRPC
+# register this as the default field type for strings.
+#  * since ProtoRPC does this via metaclasses, we don't have any
+#    choice but to use one ourselves
+#  * since a subclass's metaclass must inherit from its superclass's
+#    metaclass, we're forced to have this hard-to-read inheritance.
+#
+# pylint: disable=protected-access
+class _FieldMeta(messages._FieldMeta):
+
+    def __init__(cls, name, bases, dct):  # pylint: disable=no-self-argument
+        # pylint: disable=super-init-not-called,non-parent-init-called
+        type.__init__(cls, name, bases, dct)
+# pylint: enable=protected-access
+
+
+class DateField(six.with_metaclass(_FieldMeta, messages.Field)):
 
     """Field definition for Date values."""
-
-    # We insert our own metaclass here to avoid letting ProtoRPC
-    # register this as the default field type for strings.
-    #  * since ProtoRPC does this via metaclasses, we don't have any
-    #    choice but to use one ourselves
-    #  * since a subclass's metaclass must inherit from its superclass's
-    #    metaclass, we're forced to have this hard-to-read inheritance.
-    #
-    # pylint: disable=invalid-name
-    class __metaclass__(messages.Field.__metaclass__):
-
-        def __init__(cls, name, bases, dct):
-            super(messages.Field.__metaclass__, cls).__init__(name, bases, dct)
-    # pylint: enable=invalid-name
 
     VARIANTS = frozenset([messages.Variant.STRING])
     DEFAULT_VARIANT = messages.Variant.STRING

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ except ImportError:
 REQUIRED_PACKAGES = [
     'httplib2>=0.8',
     'oauth2client>=1.4.8',
-    'protorpc>=0.9.1',
+    'protorpc>=0.11.0',
     'six>=1.9.0',
     ]
 


### PR DESCRIPTION
We need to subclass a given protorpc metaclass in extra_types.py; as luck
would have it, that had to be tweaked and updated for python3, which means
we've got to do something here, too.

This updates us to require a new minimum protorpc version, and switches from
`protorpc.messages.Field.__metaclass__` to `protorpc.messages._FieldMeta` for
the metaclass we inherit from.

PTAL @cherba 