### PR TITLE
Fix an issue with client generation, and a test.

### DIFF
--- a/apitools/gen/client_generation_test.py
+++ b/apitools/gen/client_generation_test.py
@@ -45,11 +45,19 @@ class ClientGenerationTest(unittest2.TestCase):
                 self.assertEqual(0, retcode)
 
                 with tempfile.NamedTemporaryFile() as out:
-                    cmdline_args = [
-                        os.path.join(
-                            'generated', api.replace('.', '_') + '.py'),
-                        'help',
-                    ]
-                    retcode = subprocess.call(cmdline_args, stdout=out)
+                    with tempfile.NamedTemporaryFile() as err:
+                        cmdline_args = [
+                            os.path.join(
+                                'generated', api.replace('.', '_') + '.py'),
+                            'help',
+                        ]
+                        retcode = subprocess.call(
+                            cmdline_args, stdout=out, stderr=err)
+                        with open(err.name, 'rb') as f:
+                            err_output = f.read()
                 # appcommands returns 1 on help
                 self.assertEqual(1, retcode)
+                if 'Traceback (most recent call last):' in err_output:
+                    err = '\n======\n%s======\n' % err_output
+                    self.fail(
+                        'Error raised in generated client:' + err)

--- a/apitools/gen/gen_client.py
+++ b/apitools/gen/gen_client.py
@@ -85,9 +85,8 @@ def _GetCodegenFromFlags(args):
     if not os.path.exists(outdir):
         os.makedirs(outdir)
 
-    root_package = args.root_package or util.GetPackage(outdir)
     return gen_client_lib.DescriptorGenerator(
-        discovery_doc, client_info, names, root_package, outdir,
+        discovery_doc, client_info, names, args.root_package, outdir,
         base_package=args.base_package,
         generate_cli=args.generate_cli,
         use_proto2=args.experimental_proto2_output,

--- a/apitools/gen/util.py
+++ b/apitools/gen/util.py
@@ -223,11 +223,6 @@ class ClientInfo(collections.namedtuple('ClientInfo', (
         return '%s.proto' % self.services_rule_name
 
 
-def GetPackage(path):
-    path_components = path.split(os.path.sep)
-    return '.'.join(path_components)
-
-
 def CleanDescription(description):
     """Return a version of description safe for printing in a docstring."""
     if not isinstance(description, six.string_types):


### PR DESCRIPTION
Previously, the test of client generation was failing, as the exit code for
`./<generated_cli> help` was indistinguishable from a real error. This only
showed up as output running tests.

First, we fix the test by checking the output for a traceback. Not foolproof,
but a good start.

Next, we fix the code itself, by no longer letting `--outdir` be used as the
value for `--root_package_dir`. We have both flags; it's a bit silly to have
wacky logic that tries to use the value of one to outsmart the caller.
Instead, we're explicit, and if we have to repeat ourselves, no big deal. This
also allows us to delete `apitools.gen.util.GetPackage`.

PTAL @cherba 