### PR TITLE
Make `tox -e lint` faster in the common case.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps = nose
 commands =
     pip install google-apitools[testing]
     nosetests []
+passenv = TRAVIS*
 
 [testenv:py33]
 basepython = python3.3
@@ -24,7 +25,7 @@ deps =
 commands = nosetests []
 
 [pep8]
-exclude = samples/storage_sample/storage,samples/storage_sample/testdata,*.egg/,.*/,ez_setup.py
+exclude = samples/storage_sample/storage,samples/storage_sample/testdata,*.egg/,*.egg-info/,.*/,ez_setup.py,build
 verbose = 1
 
 [testenv:lint]
@@ -32,7 +33,7 @@ basepython =
     python2.7
 commands =
     pep8
-    python run_pylint.py
+    python run_pylint.py master
 deps =
     pep8
     pylint
@@ -60,7 +61,6 @@ commands =
 deps =
     {[testenv:cover]deps}
     coveralls
-passenv = TRAVIS*
 
 [testenv:transfer_coverage]
 basepython =


### PR DESCRIPTION
This cuts lint checks down from ~28s to ~4s on my machine (with a massive
sample size of N=3).

PTAL @gbin -- this should at least *mostly* improve the situation you were hitting. :wink: 