### PR TITLE
Keep all unknown field keys as strings.

### DIFF
--- a/apitools/base/protorpclite/protojson.py
+++ b/apitools/base/protorpclite/protojson.py
@@ -271,8 +271,6 @@ class ProtoJson(object):
                 # Save unknown values.
                 variant = self.__find_variant(value)
                 if variant:
-                    if key.isdigit():
-                        key = int(key)
                     message.set_unrecognized_field(key, value, variant)
                 else:
                     logging.warning(

--- a/apitools/base/protorpclite/protojson_test.py
+++ b/apitools/base/protorpclite/protojson_test.py
@@ -298,9 +298,10 @@ class ProtojsonTest(test_util.TestCase,
             '"456_mixed": 2}')
         self.assertEquals(decoded.an_integer, 1)
         self.assertEquals(3, len(decoded.all_unrecognized_fields()))
-        self.assertTrue(1001 in decoded.all_unrecognized_fields())
+        self.assertFalse(1001 in decoded.all_unrecognized_fields())
+        self.assertTrue('1001' in decoded.all_unrecognized_fields())
         self.assertEquals(('unknown', messages.Variant.STRING),
-                          decoded.get_unrecognized_field_info(1001))
+                          decoded.get_unrecognized_field_info('1001'))
         self.assertTrue('-123' in decoded.all_unrecognized_fields())
         self.assertEquals(('negative', messages.Variant.STRING),
                           decoded.get_unrecognized_field_info('-123'))

--- a/apitools/base/py/encoding_test.py
+++ b/apitools/base/py/encoding_test.py
@@ -223,6 +223,11 @@ class EncodingTest(unittest2.TestCase):
         self.assertEqual(1, len(new_msg.additional_properties))
         self.assertEqual(2, len(msg.additional_properties))
 
+    def testNumericPropertyName(self):
+        json_msg = '{"nested": {"123": "def"}}'
+        msg = encoding.JsonToMessage(HasNestedMessage, json_msg)
+        self.assertEqual(1, len(msg.nested.additional_properties))
+
     def testAdditionalMessageProperties(self):
         json_msg = '{"input": {"index": 0, "name": "output"}}'
         result = encoding.JsonToMessage(


### PR DESCRIPTION
Previously, protorpc would keep some keys as ints (for compatibility with JS
proto libraries). This doesn't help us, and causes issues, so we drop it.

Fixes #73.

PTAL @thobrla 