### PR TITLE
Handle transient oauth2client refresh failures in http_wrapper

### DIFF
--- a/apitools/base/py/http_wrapper.py
+++ b/apitools/base/py/http_wrapper.py
@@ -27,6 +27,7 @@ import socket
 import time
 
 import httplib2
+import oauth2client
 import six
 from six.moves import http_client
 from six.moves.urllib import parse
@@ -277,6 +278,13 @@ def HandleExceptionsAndRebuildHttpConnections(retry_args):
         # oauth2client, need to handle it here.
         logging.debug('Response content was invalid (%s), retrying',
                       retry_args.exc)
+    elif (isinstance(retry_args.exc,
+                     oauth2client.client.HttpAccessTokenRefreshError) and
+          (retry_args.exc.status == TOO_MANY_REQUESTS or
+           retry_args.exc.status >= 500)):
+        logging.debug(
+            'Caught transient credential refresh error (%s), retrying',
+            retry_args.exc)
     elif isinstance(retry_args.exc, exceptions.RequestError):
         logging.debug('Request returned no response, retrying')
     # API-level failures

--- a/apitools/base/py/http_wrapper_test.py
+++ b/apitools/base/py/http_wrapper_test.py
@@ -14,9 +14,28 @@
 # limitations under the License.
 
 """Tests for http_wrapper."""
+import httplib2
+import oauth2client
+import socket
 import unittest2
 
+from mock import patch
+
+from apitools.base.py import exceptions
 from apitools.base.py import http_wrapper
+
+from six.moves import http_client
+
+
+class _MockHttpRequest(object):
+
+    url = None
+
+
+class _MockHttpResponse(object):
+
+    def __init__(self, status_code):
+        self.response = {'status': status_code}
 
 
 class RaisesExceptionOnLen(object):
@@ -37,3 +56,31 @@ class HttpWrapperTest(unittest2.TestCase):
 
     def testRequestBodyWithLen(self):
         http_wrapper.Request(body='burrito')
+
+    def testDefaultExceptionHandler(self):
+        """Ensures exception handles swallows (retries)"""
+        mock_http_content = 'content'.encode('utf8')
+        for exception_arg in (
+                http_client.BadStatusLine('line'),
+                http_client.IncompleteRead('partial'),
+                http_client.ResponseNotReady(),
+                socket.error(),
+                socket.gaierror(),
+                httplib2.ServerNotFoundError(),
+                ValueError(),
+                oauth2client.client.HttpAccessTokenRefreshError(status=503),
+                exceptions.RequestError(),
+                exceptions.BadStatusCodeError(
+                    {'status': 503}, mock_http_content, 'url'),
+                exceptions.RetryAfterError(
+                    {'status': 429}, mock_http_content, 'url', 0)):
+
+            retry_args = http_wrapper.ExceptionRetryArgs(
+                http={'connections': {}}, http_request=_MockHttpRequest(),
+                exc=exception_arg, num_retries=0, max_retry_wait=0)
+
+            # Disable time.sleep for this handler as it is called with
+            # a minimum value of 1 second.
+            with patch('time.sleep', return_value=None):
+                http_wrapper.HandleExceptionsAndRebuildHttpConnections(
+                    retry_args)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ except ImportError:
 # Python version and OS.
 REQUIRED_PACKAGES = [
     'httplib2>=0.8',
-    'oauth2client>=1.4.8',
+    'oauth2client>=1.5.2',
     'six>=1.9.0',
     ]
 


### PR DESCRIPTION
Fixes https://github.com/google/apitools/issues/75

This changes http_wrapper's default retry function to recover
gracefully when encountering an HttpAccessTokenRefreshError.

Sync oauth2client to >= v1.5.2, since it has this new exception type.