### PR TITLE
Make sure client.Unmock() undoes client.Mock().

### DIFF
--- a/apitools/base/py/testing/mock.py
+++ b/apitools/base/py/testing/mock.py
@@ -285,6 +285,7 @@ class Client(object):
         self.__real_client = real_client
 
         self._request_responses = []
+        self.__real_include_fields = None
 
     def __enter__(self):
         return self.Mock()
@@ -330,13 +331,17 @@ class Client(object):
     def Unmock(self):
         for name, service_class in self.__real_service_classes.items():
             setattr(self.__client_class, name, service_class)
+            delattr(self, service_class._NAME)
+        self.__real_service_classes = {}
 
         if self._request_responses:
             raise ExpectedRequestsException(
                 [(rq_rs.key, rq_rs.request) for rq_rs
                  in self._request_responses])
+        self._request_responses = []
 
         self.__client_class.IncludeFields = self.__real_include_fields
+        self.__real_include_fields = None
 
     def IncludeFields(self, include_fields):
         if self.__real_client:

--- a/apitools/base/py/testing/mock_test.py
+++ b/apitools/base/py/testing/mock_test.py
@@ -84,6 +84,14 @@ class MockTest(unittest2.TestCase):
         client = fusiontables.FusiontablesV1(get_credentials=False)
         self.assertNotEqual(type(client.column), mocked_service_type)
 
+    def testClientUnmock(self):
+        mock_client = mock.Client(fusiontables.FusiontablesV1)
+        attributes = set(mock_client.__dict__.keys())
+        mock_client = mock_client.Mock()
+        self.assertTrue(set(mock_client.__dict__.keys()) - attributes)
+        mock_client.Unmock()
+        self.assertEqual(attributes, set(mock_client.__dict__.keys()))
+
 
 class _NestedMessage(messages.Message):
     nested = messages.StringField(1)


### PR DESCRIPTION
Mocked clients after being unmocked can still hold references to client instance.