### PR TITLE
Import on demand credentials_lib in base_api.

### DIFF
--- a/apitools/base/py/base_api.py
+++ b/apitools/base/py/base_api.py
@@ -30,7 +30,6 @@ from six.moves import urllib
 
 from apitools.base.protorpclite import message_types
 from apitools.base.protorpclite import messages
-from apitools.base.py import credentials_lib
 from apitools.base.py import encoding
 from apitools.base.py import exceptions
 from apitools.base.py import http_wrapper
@@ -293,6 +292,8 @@ class BaseApiClient(object):
             'user_agent': self._USER_AGENT,
         }
         args.update(kwds)
+        # credentials_lib can be expensive to import so do it only if needed.
+        from apitools.base.py import credentials_lib
         # TODO(craigcitro): It's a bit dangerous to pass this
         # still-half-initialized self into this method, but we might need
         # to set attributes on it associated with our credentials.


### PR DESCRIPTION
credentials_lib depends on oauth2client which had support for webflow authentication, which brings a lot of dependencies, all not used if user of the client manages its own credentials.