### PR TITLE
Bump version to 0.4.15

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ py_version = platform.python_version()
 if py_version < '2.7':
     REQUIRED_PACKAGES.append('argparse>=1.2.1')
 
-_APITOOLS_VERSION = '0.4.14'
+_APITOOLS_VERSION = '0.4.15'
 
 with open('README.rst') as fileobj:
     README = fileobj.read()


### PR DESCRIPTION
Bump version to 0.4.15 in preparation for PyPI release. Left out 0.4.14 in order to be able to get a tag in sync with a commit change bumping the version. There have been several commits since I bumped to 0.4.14.