### PR TITLE
Drop gflags/appcommands in oauth2l, support py3.

### DIFF
--- a/apitools/base/py/exceptions.py
+++ b/apitools/base/py/exceptions.py
@@ -58,7 +58,9 @@ class HttpError(CommunicationError):
         self.url = url
 
     def __str__(self):
-        content = self.content.decode('ascii', 'replace')
+        content = self.content
+        if isinstance(content, bytes):
+            content = self.content.decode('ascii', 'replace')
         return 'HttpError accessing <%s>: response: <%s>, content <%s>' % (
             self.url, self.response, content)
 

--- a/apitools/scripts/oauth2l.py
+++ b/apitools/scripts/oauth2l.py
@@ -36,8 +36,9 @@ some sample use:
 
 The `header` command is designed to be easy to use with `curl`:
 
-    $ curl "$(oauth2l header bigquery)" \
-           'https://www.googleapis.com/bigquery/v2/projects'
+    $ curl -H "$(oauth2l header bigquery)" \\
+      'https://www.googleapis.com/bigquery/v2/projects'
+    ... lists all projects ...
 
 The token can also be printed in other formats, for easy chaining
 into other programs:
@@ -49,7 +50,9 @@ into other programs:
 
 """
 
-import httplib
+from __future__ import print_function
+
+import argparse
 import json
 import logging
 import os
@@ -57,14 +60,11 @@ import pkgutil
 import sys
 import textwrap
 
-import gflags as flags
-from google.apputils import appcommands
 import oauth2client.client
+from six.moves import http_client
 
 import apitools.base.py as apitools_base
-from apitools.base.py import cli as apitools_cli
 
-FLAGS = flags.FLAGS
 # We could use a generated client here, but it's used for precisely
 # one URL, with one parameter and no worries about URL encoding. Let's
 # go with simple.
@@ -74,23 +74,10 @@ _OAUTH2_TOKENINFO_TEMPLATE = (
 )
 
 
-flags.DEFINE_string(
-    'client_secrets', '',
-    'If specified, use the client ID/secret from the named '
-    'file, which should be a client_secrets.json file as downloaded '
-    'from the Developer Console.')
-flags.DEFINE_string(
-    'credentials_filename', '',
-    '(optional) Filename for fetching/storing credentials.')
-flags.DEFINE_string(
-    'service_account_json_keyfile', '',
-    'Filename for a JSON service account key downloaded from the Developer '
-    'Console.')
-
-
 def GetDefaultClientInfo():
-    client_secrets = json.loads(pkgutil.get_data(
-        'apitools.data', 'apitools_client_secrets.json'))['installed']
+    client_secrets_json = pkgutil.get_data(
+        'apitools.data', 'apitools_client_secrets.json').decode('utf8')
+    client_secrets = json.loads(client_secrets_json)['installed']
     return {
         'client_id': client_secrets['client_id'],
         'client_secret': client_secrets['client_secret'],
@@ -98,12 +85,13 @@ def GetDefaultClientInfo():
     }
 
 
-def GetClientInfoFromFlags():
-    """Fetch client info from FLAGS."""
-    if FLAGS.client_secrets:
-        client_secrets_path = os.path.expanduser(FLAGS.client_secrets)
+def GetClientInfoFromFlags(args):
+    """Fetch client info from args."""
+    if args.client_secrets:
+        client_secrets_path = os.path.expanduser(args.client_secrets)
         if not os.path.exists(client_secrets_path):
-            raise ValueError('Cannot find file: %s' % FLAGS.client_secrets)
+            raise ValueError(
+                'Cannot find file: {0}'.format(args.client_secrets))
         with open(client_secrets_path) as client_secrets_file:
             client_secrets = json.load(client_secrets_file)
         if 'installed' not in client_secrets:
@@ -132,6 +120,12 @@ def _CompactJson(data):
     return json.dumps(data, sort_keys=True, separators=(',', ':'))
 
 
+def _AsText(text_or_bytes):
+    if isinstance(text_or_bytes, bytes):
+        return text_or_bytes.decode('utf8')
+    return text_or_bytes
+
+
 def _Format(fmt, credentials):
     """Format credentials according to fmt."""
     if fmt == 'bare':
@@ -139,9 +133,9 @@ def _Format(fmt, credentials):
     elif fmt == 'header':
         return 'Authorization: Bearer %s' % credentials.access_token
     elif fmt == 'json':
-        return _PrettyJson(json.loads(credentials.to_json()))
+        return _PrettyJson(json.loads(_AsText(credentials.to_json())))
     elif fmt == 'json_compact':
-        return _CompactJson(json.loads(credentials.to_json()))
+        return _CompactJson(json.loads(_AsText(credentials.to_json())))
     elif fmt == 'pretty':
         format_str = textwrap.dedent('\n'.join([
             'Fetched credentials of type:',
@@ -151,7 +145,7 @@ def _Format(fmt, credentials):
         ]))
         return format_str.format(credentials=credentials,
                                  credentials_type=type(credentials))
-    raise ValueError('Unknown format: {}'.format(fmt))
+    raise ValueError('Unknown format: {0}'.format(fmt))
 
 _FORMATS = set(('bare', 'header', 'json', 'json_compact', 'pretty'))
 
@@ -161,11 +155,11 @@ def _GetTokenScopes(access_token):
     url = _OAUTH2_TOKENINFO_TEMPLATE.format(access_token=access_token)
     response = apitools_base.MakeRequest(
         apitools_base.GetHttp(), apitools_base.Request(url))
-    if response.status_code not in [httplib.OK, httplib.BAD_REQUEST]:
+    if response.status_code not in [http_client.OK, http_client.BAD_REQUEST]:
         raise apitools_base.HttpError.FromResponse(response)
-    if response.status_code == httplib.BAD_REQUEST:
+    if response.status_code == http_client.BAD_REQUEST:
         return []
-    return json.loads(response.content)['scope'].split(' ')
+    return json.loads(_AsText(response.content))['scope'].split(' ')
 
 
 def _ValidateToken(access_token):
@@ -173,20 +167,20 @@ def _ValidateToken(access_token):
     return bool(_GetTokenScopes(access_token))
 
 
-def FetchCredentials(scopes, client_info=None, credentials_filename=None):
+def FetchCredentials(args, client_info=None, credentials_filename=None):
     """Fetch a credential for the given client_info and scopes."""
-    client_info = client_info or GetClientInfoFromFlags()
-    scopes = _ExpandScopes(scopes)
+    client_info = client_info or GetClientInfoFromFlags(args)
+    scopes = _ExpandScopes(args.scope)
     if not scopes:
         raise ValueError('No scopes provided')
-    credentials_filename = credentials_filename or FLAGS.credentials_filename
+    credentials_filename = credentials_filename or args.credentials_filename
     # TODO(craigcitro): Remove this logging nonsense once we quiet the
     # spurious logging in oauth2client.
     old_level = logging.getLogger().level
     logging.getLogger().setLevel(logging.ERROR)
     credentials = apitools_base.GetCredentials(
         'oauth2l', scopes, credentials_filename=credentials_filename,
-        service_account_json_keyfile=FLAGS.service_account_json_keyfile,
+        service_account_json_keyfile=args.service_account_json_keyfile,
         oauth2client_args='', **client_info)
     logging.getLogger().setLevel(old_level)
     if not _ValidateToken(credentials.access_token):
@@ -194,131 +188,152 @@ def FetchCredentials(scopes, client_info=None, credentials_filename=None):
     return credentials
 
 
-class _Email(apitools_cli.NewCmd):
-
-    """Get user email."""
-
-    usage = 'email <access_token>'
-
-    def RunWithArgs(self, access_token):
-        """Print the email address for this token, if possible."""
-        userinfo = apitools_base.GetUserinfo(
-            oauth2client.client.AccessTokenCredentials(access_token,
-                                                       'oauth2l/1.0'))
-        user_email = userinfo.get('email')
-        if user_email:
-            print user_email
+def Email(args):
+    """Print the email address for this token, if possible."""
+    userinfo = apitools_base.GetUserinfo(
+        oauth2client.client.AccessTokenCredentials(args.access_token,
+                                                   'oauth2l/1.0'))
+    user_email = userinfo.get('email')
+    if user_email:
+        print(user_email)
 
 
-class _Fetch(apitools_cli.NewCmd):
-
-    """Fetch credentials."""
-
-    usage = 'fetch <scope> [<scope> ...]'
-
-    def __init__(self, name, flag_values):
-        super(_Fetch, self).__init__(name, flag_values)
-        flags.DEFINE_enum(
-            'credentials_format', 'pretty', sorted(_FORMATS),
-            'Output format for token.',
-            short_name='f', flag_values=flag_values)
-
-    def RunWithArgs(self, *scopes):
-        """Fetch a valid access token and display it."""
-        credentials = FetchCredentials(scopes)
-        print _Format(FLAGS.credentials_format.lower(), credentials)
+def Fetch(args):
+    """Fetch a valid access token and display it."""
+    credentials = FetchCredentials(args)
+    print(_Format(args.credentials_format.lower(), credentials))
 
 
-class _Header(apitools_cli.NewCmd):
-
-    """Print credentials for a header."""
-
-    usage = 'header <scope> [<scope> ...]'
-
-    def RunWithArgs(self, *scopes):
-        """Fetch a valid access token and display it formatted for a header."""
-        print _Format('header', FetchCredentials(scopes))
+def Header(args):
+    """Fetch an access token and display it formatted as an HTTP header."""
+    print(_Format('header', FetchCredentials(args)))
 
 
-class _Scopes(apitools_cli.NewCmd):
-
-    """Get the list of scopes for a token."""
-
-    usage = 'scopes <access_token>'
-
-    def RunWithArgs(self, access_token):
-        """Print the list of scopes for a valid token."""
-        scopes = _GetTokenScopes(access_token)
-        if not scopes:
-            return 1
-        for scope in sorted(scopes):
-            print scope
+def Scopes(args):
+    """Print the list of scopes for a valid token."""
+    scopes = _GetTokenScopes(args.access_token)
+    if not scopes:
+        return 1
+    for scope in sorted(scopes):
+        print(scope)
 
 
-class _Userinfo(apitools_cli.NewCmd):
-
-    """Get userinfo."""
-
-    usage = 'userinfo <access_token>'
-
-    def __init__(self, name, flag_values):
-        super(_Userinfo, self).__init__(name, flag_values)
-        flags.DEFINE_enum(
-            'format', 'json', sorted(('json', 'json_compact')),
-            'Output format for userinfo.',
-            short_name='f', flag_values=flag_values)
-
-    def RunWithArgs(self, access_token):
-        """Print the userinfo for this token (if we have the right scopes)."""
-        userinfo = apitools_base.GetUserinfo(
-            oauth2client.client.AccessTokenCredentials(access_token,
-                                                       'oauth2l/1.0'))
-        if FLAGS.format == 'json':
-            print _PrettyJson(userinfo)
-        else:
-            print _CompactJson(userinfo)
+def Userinfo(args):
+    """Print the userinfo for this token, if possible."""
+    userinfo = apitools_base.GetUserinfo(
+        oauth2client.client.AccessTokenCredentials(args.access_token,
+                                                   'oauth2l/1.0'))
+    if args.format == 'json':
+        print(_PrettyJson(userinfo))
+    else:
+        print(_CompactJson(userinfo))
 
 
-class _Validate(apitools_cli.NewCmd):
-
-    """Validate a token."""
-
-    usage = 'validate <access_token>'
-
-    def RunWithArgs(self, access_token):
-        """Validate an access token. Exits with 0 if valid, 1 otherwise."""
-        return 1 - (_ValidateToken(access_token))
+def Validate(args):
+    """Validate an access token. Exits with 0 if valid, 1 otherwise."""
+    return 1 - (_ValidateToken(args.access_token))
 
 
-def run_main():  # pylint:disable=invalid-name
-    """Function to be used as setuptools script entry point."""
-    # Put the flags for this module somewhere the flags module will look
-    # for them.
+def _GetParser():
 
-    # pylint:disable=protected-access
-    new_name = flags._GetMainModule()
-    sys.modules[new_name] = sys.modules['__main__']
-    for flag in FLAGS.FlagsByModuleDict().get(__name__, []):
-        FLAGS._RegisterFlagByModule(new_name, flag)
-        for key_flag in FLAGS.KeyFlagsByModuleDict().get(__name__, []):
-            FLAGS._RegisterKeyFlagForModule(new_name, key_flag)
-    # pylint:enable=protected-access
+    shared_flags = argparse.ArgumentParser(add_help=False)
+    shared_flags.add_argument(
+        '--client_secrets',
+        default='',
+        help=('If specified, use the client ID/secret from the named '
+              'file, which should be a client_secrets.json file '
+              'downloaded from the Developer Console.'))
+    shared_flags.add_argument(
+        '--credentials_filename',
+        default='',
+        help='(optional) Filename for fetching/storing credentials.')
+    shared_flags.add_argument(
+        '--service_account_json_keyfile',
+        default='',
+        help=('Filename for a JSON service account key downloaded from '
+              'the Google Developer Console.'))
 
-    # Now set __main__ appropriately so that appcommands will be
-    # happy.
-    sys.modules['__main__'] = sys.modules[__name__]
-    appcommands.Run()
-    sys.modules['__main__'] = sys.modules.pop(new_name)
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest='command')
+
+    # email
+    email = subparsers.add_parser('email', help=Email.__doc__,
+                                  parents=[shared_flags])
+    email.set_defaults(func=Email)
+    email.add_argument(
+        'access_token',
+        help=('Access token to print associated email address for. Must have '
+              'the userinfo.email scope.'))
+
+    # fetch
+    fetch = subparsers.add_parser('fetch', help=Fetch.__doc__,
+                                  parents=[shared_flags])
+    fetch.set_defaults(func=Fetch)
+    fetch.add_argument(
+        '-f', '--credentials_format',
+        default='pretty', choices=sorted(_FORMATS),
+        help='Output format for token.')
+    fetch.add_argument(
+        'scope',
+        nargs='*',
+        help='Scope to fetch. May be provided multiple times.')
+
+    # header
+    header = subparsers.add_parser('header', help=Header.__doc__,
+                                   parents=[shared_flags])
+    header.set_defaults(func=Header)
+    header.add_argument(
+        'scope',
+        nargs='*',
+        help='Scope to header. May be provided multiple times.')
+
+    # scopes
+    scopes = subparsers.add_parser('scopes', help=Scopes.__doc__,
+                                   parents=[shared_flags])
+    scopes.set_defaults(func=Scopes)
+    scopes.add_argument(
+        'access_token',
+        help=('Scopes associated with this token will be printed.'))
+
+    # userinfo
+    userinfo = subparsers.add_parser('userinfo', help=Userinfo.__doc__,
+                                     parents=[shared_flags])
+    userinfo.set_defaults(func=Userinfo)
+    userinfo.add_argument(
+        '-f', '--format',
+        default='json', choices=('json', 'json_compact'),
+        help='Output format for userinfo.')
+    userinfo.add_argument(
+        'access_token',
+        help=('Access token to print associated email address for. Must have '
+              'the userinfo.email scope.'))
+
+    # validate
+    validate = subparsers.add_parser('validate', help=Validate.__doc__,
+                                     parents=[shared_flags])
+    validate.set_defaults(func=Validate)
+    validate.add_argument(
+        'access_token',
+        help='Access token to validate.')
+
+    return parser
 
 
-def main(unused_argv):
-    appcommands.AddCmd('email', _Email)
-    appcommands.AddCmd('fetch', _Fetch)
-    appcommands.AddCmd('header', _Header)
-    appcommands.AddCmd('scopes', _Scopes)
-    appcommands.AddCmd('userinfo', _Userinfo)
-    appcommands.AddCmd('validate', _Validate)
+def main(argv=None):
+    argv = argv or sys.argv
+    # Invoke the newly created parser.
+    args = _GetParser().parse_args(argv[1:])
+    try:
+        exit_code = args.func(args)
+    except BaseException as e:
+        print('Error encountered in {0} operation: {1}'.format(
+            args.command, e))
+        return 1
+    return exit_code
 
 
 if __name__ == '__main__':
-    appcommands.Run()
+    sys.exit(main(sys.argv))

--- a/apitools/scripts/oauth2l_test.py
+++ b/apitools/scripts/oauth2l_test.py
@@ -79,7 +79,7 @@ class Oauth2lFormattingTest(unittest2.TestCase):
         return ['--credentials_format=' + credentials_format, 'userinfo.email']
 
     def testFormatBare(self):
-        with mock.patch.object(oauth2l, 'FetchCredentials',
+        with mock.patch.object(oauth2l, '_FetchCredentials',
                                return_value=self.credentials,
                                autospec=True) as mock_credentials:
             output = _GetCommandOutput('fetch', self._Args('bare'))
@@ -87,7 +87,7 @@ class Oauth2lFormattingTest(unittest2.TestCase):
             self.assertEqual(1, mock_credentials.call_count)
 
     def testFormatHeader(self):
-        with mock.patch.object(oauth2l, 'FetchCredentials',
+        with mock.patch.object(oauth2l, '_FetchCredentials',
                                return_value=self.credentials,
                                autospec=True) as mock_credentials:
             output = _GetCommandOutput('fetch', self._Args('header'))
@@ -96,7 +96,7 @@ class Oauth2lFormattingTest(unittest2.TestCase):
             self.assertEqual(1, mock_credentials.call_count)
 
     def testHeaderCommand(self):
-        with mock.patch.object(oauth2l, 'FetchCredentials',
+        with mock.patch.object(oauth2l, '_FetchCredentials',
                                return_value=self.credentials,
                                autospec=True) as mock_credentials:
             output = _GetCommandOutput('header', ['userinfo.email'])
@@ -105,7 +105,7 @@ class Oauth2lFormattingTest(unittest2.TestCase):
             self.assertEqual(1, mock_credentials.call_count)
 
     def testFormatJson(self):
-        with mock.patch.object(oauth2l, 'FetchCredentials',
+        with mock.patch.object(oauth2l, '_FetchCredentials',
                                return_value=self.credentials,
                                autospec=True) as mock_credentials:
             output = _GetCommandOutput('fetch', self._Args('json'))
@@ -119,7 +119,7 @@ class Oauth2lFormattingTest(unittest2.TestCase):
             self.assertEqual(1, mock_credentials.call_count)
 
     def testFormatJsonCompact(self):
-        with mock.patch.object(oauth2l, 'FetchCredentials',
+        with mock.patch.object(oauth2l, '_FetchCredentials',
                                return_value=self.credentials,
                                autospec=True) as mock_credentials:
             output = _GetCommandOutput('fetch', self._Args('json_compact'))
@@ -133,7 +133,7 @@ class Oauth2lFormattingTest(unittest2.TestCase):
             self.assertEqual(1, mock_credentials.call_count)
 
     def testFormatPretty(self):
-        with mock.patch.object(oauth2l, 'FetchCredentials',
+        with mock.patch.object(oauth2l, '_FetchCredentials',
                                return_value=self.credentials,
                                autospec=True) as mock_credentials:
             output = _GetCommandOutput('fetch', self._Args('pretty'))
@@ -217,20 +217,17 @@ class TestFetch(unittest2.TestCase):
                 self.assertEqual(1, mock_validate.call_count)
 
     def testMissingClientSecrets(self):
-        args = mock.MagicMock()
-        args.client_secrets = '/non/existent/file'
         self.assertRaises(
             ValueError,
-            oauth2l.GetClientInfoFromFlags, args)
+            oauth2l.GetClientInfoFromFlags, '/non/existent/file')
 
     def testWrongClientSecretsFormat(self):
-        args = mock.MagicMock()
-        args.client_secrets = os.path.join(
+        client_secrets = os.path.join(
             os.path.dirname(__file__),
             'testdata/noninstalled_client_secrets.json')
         self.assertRaises(
             ValueError,
-            oauth2l.GetClientInfoFromFlags, args)
+            oauth2l.GetClientInfoFromFlags, client_secrets)
 
     def testCustomClientInfo(self):
         client_secrets_path = os.path.join(

--- a/apitools/scripts/oauth2l_test.py
+++ b/apitools/scripts/oauth2l_test.py
@@ -26,15 +26,9 @@ from six.moves import http_client
 import unittest2
 
 import apitools.base.py as apitools_base
+from apitools.scripts import oauth2l
 
 _OAUTH2L_MAIN_RUN = False
-
-if six.PY2:
-    # pylint: disable=wrong-import-position,wrong-import-order
-    import gflags as flags
-    from google.apputils import appcommands
-    from apitools.scripts import oauth2l
-    FLAGS = flags.FLAGS
 
 
 class _FakeResponse(object):
@@ -49,35 +43,29 @@ class _FakeResponse(object):
             self.request_url = 'some-url'
 
 
-def _GetCommandOutput(t, command_name, command_argv):
-    global _OAUTH2L_MAIN_RUN  # pylint: disable=global-statement
-    if not _OAUTH2L_MAIN_RUN:
-        oauth2l.main(None)
-        _OAUTH2L_MAIN_RUN = True
-    command = appcommands.GetCommandByName(command_name)
-    if command is None:
-        t.fail('Unknown command: %s' % command_name)
+def _GetCommandOutput(command_name, command_argv):
     orig_stdout = sys.stdout
+    orig_stderr = sys.stderr
     new_stdout = six.StringIO()
+    new_stderr = six.StringIO()
     try:
         sys.stdout = new_stdout
-        command.CommandRun([command_name] + command_argv)
+        sys.stderr = new_stderr
+        oauth2l.main(['oauth2l', command_name] + command_argv)
     finally:
         sys.stdout = orig_stdout
-        FLAGS.Reset()
+        sys.stderr = orig_stderr
     new_stdout.seek(0)
     return new_stdout.getvalue().rstrip()
 
 
-@unittest2.skipIf(six.PY3, 'oauth2l unsupported in python3')
-class TestTest(unittest2.TestCase):
+class InvalidCommandTest(unittest2.TestCase):
 
     def testOutput(self):
-        self.assertRaises(AssertionError,
-                          _GetCommandOutput, self, 'foo', [])
+        self.assertRaises(SystemExit,
+                          _GetCommandOutput, 'foo', [])
 
 
-@unittest2.skipIf(six.PY3, 'oauth2l unsupported in python3')
 class Oauth2lFormattingTest(unittest2.TestCase):
 
     def setUp(self):
@@ -94,7 +82,7 @@ class Oauth2lFormattingTest(unittest2.TestCase):
         with mock.patch.object(oauth2l, 'FetchCredentials',
                                return_value=self.credentials,
                                autospec=True) as mock_credentials:
-            output = _GetCommandOutput(self, 'fetch', self._Args('bare'))
+            output = _GetCommandOutput('fetch', self._Args('bare'))
             self.assertEqual(self.access_token, output)
             self.assertEqual(1, mock_credentials.call_count)
 
@@ -102,7 +90,7 @@ class Oauth2lFormattingTest(unittest2.TestCase):
         with mock.patch.object(oauth2l, 'FetchCredentials',
                                return_value=self.credentials,
                                autospec=True) as mock_credentials:
-            output = _GetCommandOutput(self, 'fetch', self._Args('header'))
+            output = _GetCommandOutput('fetch', self._Args('header'))
             header = 'Authorization: Bearer %s' % self.access_token
             self.assertEqual(header, output)
             self.assertEqual(1, mock_credentials.call_count)
@@ -111,7 +99,7 @@ class Oauth2lFormattingTest(unittest2.TestCase):
         with mock.patch.object(oauth2l, 'FetchCredentials',
                                return_value=self.credentials,
                                autospec=True) as mock_credentials:
-            output = _GetCommandOutput(self, 'header', ['userinfo.email'])
+            output = _GetCommandOutput('header', ['userinfo.email'])
             header = 'Authorization: Bearer %s' % self.access_token
             self.assertEqual(header, output)
             self.assertEqual(1, mock_credentials.call_count)
@@ -120,7 +108,7 @@ class Oauth2lFormattingTest(unittest2.TestCase):
         with mock.patch.object(oauth2l, 'FetchCredentials',
                                return_value=self.credentials,
                                autospec=True) as mock_credentials:
-            output = _GetCommandOutput(self, 'fetch', self._Args('json'))
+            output = _GetCommandOutput('fetch', self._Args('json'))
             output_lines = [l.strip() for l in output.splitlines()]
             expected_lines = [
                 '"_class": "AccessTokenCredentials",',
@@ -134,8 +122,7 @@ class Oauth2lFormattingTest(unittest2.TestCase):
         with mock.patch.object(oauth2l, 'FetchCredentials',
                                return_value=self.credentials,
                                autospec=True) as mock_credentials:
-            output = _GetCommandOutput(self, 'fetch',
-                                       self._Args('json_compact'))
+            output = _GetCommandOutput('fetch', self._Args('json_compact'))
             expected_clauses = [
                 '"_class":"AccessTokenCredentials",',
                 '"access_token":"%s",' % self.access_token,
@@ -149,7 +136,7 @@ class Oauth2lFormattingTest(unittest2.TestCase):
         with mock.patch.object(oauth2l, 'FetchCredentials',
                                return_value=self.credentials,
                                autospec=True) as mock_credentials:
-            output = _GetCommandOutput(self, 'fetch', self._Args('pretty'))
+            output = _GetCommandOutput('fetch', self._Args('pretty'))
             expecteds = ['oauth2client.client.AccessTokenCredentials',
                          self.access_token]
             for expected in expecteds:
@@ -161,7 +148,6 @@ class Oauth2lFormattingTest(unittest2.TestCase):
                           oauth2l._Format, 'xml', self.credentials)
 
 
-@unittest2.skipIf(six.PY3, 'oauth2l unsupported in python3')
 class TestFetch(unittest2.TestCase):
 
     def setUp(self):
@@ -172,9 +158,9 @@ class TestFetch(unittest2.TestCase):
             self.access_token, self.user_agent)
 
     def testNoScopes(self):
-        output = _GetCommandOutput(self, 'fetch', [])
+        output = _GetCommandOutput('fetch', [])
         self.assertEqual(
-            'Exception raised in fetch operation: No scopes provided',
+            'Error encountered in fetch operation: No scopes provided',
             output)
 
     def testScopes(self):
@@ -189,7 +175,7 @@ class TestFetch(unittest2.TestCase):
                                    return_value=expected_scopes,
                                    autospec=True) as mock_get_scopes:
                 output = _GetCommandOutput(
-                    self, 'fetch', ['userinfo.email', 'cloud-platform'])
+                    'fetch', ['userinfo.email', 'cloud-platform'])
                 self.assertIn(self.access_token, output)
                 self.assertEqual(1, mock_fetch.call_count)
                 args, _ = mock_fetch.call_args
@@ -208,8 +194,7 @@ class TestFetch(unittest2.TestCase):
                 with mock.patch.object(self.credentials, 'refresh',
                                        return_value=None,
                                        autospec=True) as mock_refresh:
-                    output = _GetCommandOutput(self, 'fetch',
-                                               ['userinfo.email'])
+                    output = _GetCommandOutput('fetch', ['userinfo.email'])
                     self.assertIn(self.access_token, output)
                     self.assertEqual(1, mock_fetch.call_count)
                     self.assertEqual(1, mock_validate.call_count)
@@ -222,7 +207,7 @@ class TestFetch(unittest2.TestCase):
             with mock.patch.object(oauth2l, '_ValidateToken',
                                    return_value=True,
                                    autospec=True) as mock_validate:
-                output = _GetCommandOutput(self, 'fetch', ['userinfo.email'])
+                output = _GetCommandOutput('fetch', ['userinfo.email'])
                 self.assertIn(self.access_token, output)
                 self.assertEqual(1, mock_fetch.call_count)
                 _, kwargs = mock_fetch.call_args
@@ -232,25 +217,20 @@ class TestFetch(unittest2.TestCase):
                 self.assertEqual(1, mock_validate.call_count)
 
     def testMissingClientSecrets(self):
-        try:
-            FLAGS.client_secrets = '/non/existent/file'
-            self.assertRaises(
-                ValueError,
-                oauth2l.GetClientInfoFromFlags)
-        finally:
-            FLAGS.Reset()
+        args = mock.MagicMock()
+        args.client_secrets = '/non/existent/file'
+        self.assertRaises(
+            ValueError,
+            oauth2l.GetClientInfoFromFlags, args)
 
     def testWrongClientSecretsFormat(self):
-        client_secrets_path = os.path.join(
+        args = mock.MagicMock()
+        args.client_secrets = os.path.join(
             os.path.dirname(__file__),
             'testdata/noninstalled_client_secrets.json')
-        try:
-            FLAGS.client_secrets = client_secrets_path
-            self.assertRaises(
-                ValueError,
-                oauth2l.GetClientInfoFromFlags)
-        finally:
-            FLAGS.Reset()
+        self.assertRaises(
+            ValueError,
+            oauth2l.GetClientInfoFromFlags, args)
 
     def testCustomClientInfo(self):
         client_secrets_path = os.path.join(
@@ -264,7 +244,7 @@ class TestFetch(unittest2.TestCase):
                 fetch_args = [
                     '--client_secrets=' + client_secrets_path,
                     'userinfo.email']
-                output = _GetCommandOutput(self, 'fetch', fetch_args)
+                output = _GetCommandOutput('fetch', fetch_args)
                 self.assertIn(self.access_token, output)
                 self.assertEqual(1, mock_fetch.call_count)
                 _, kwargs = mock_fetch.call_args
@@ -275,7 +255,6 @@ class TestFetch(unittest2.TestCase):
                 self.assertEqual(1, mock_validate.call_count)
 
 
-@unittest2.skipIf(six.PY3, 'oauth2l unsupported in python3')
 class TestOtherCommands(unittest2.TestCase):
 
     def setUp(self):
@@ -290,7 +269,7 @@ class TestOtherCommands(unittest2.TestCase):
         with mock.patch.object(apitools_base, 'GetUserinfo',
                                return_value=user_info,
                                autospec=True) as mock_get_userinfo:
-            output = _GetCommandOutput(self, 'email', [self.access_token])
+            output = _GetCommandOutput('email', [self.access_token])
             self.assertEqual(user_info['email'], output)
             self.assertEqual(1, mock_get_userinfo.call_count)
             self.assertEqual(self.access_token,
@@ -300,7 +279,7 @@ class TestOtherCommands(unittest2.TestCase):
         with mock.patch.object(apitools_base, 'GetUserinfo',
                                return_value={},
                                autospec=True) as mock_get_userinfo:
-            output = _GetCommandOutput(self, 'email', [self.access_token])
+            output = _GetCommandOutput('email', [self.access_token])
             self.assertEqual('', output)
             self.assertEqual(1, mock_get_userinfo.call_count)
 
@@ -309,7 +288,7 @@ class TestOtherCommands(unittest2.TestCase):
         with mock.patch.object(apitools_base, 'GetUserinfo',
                                return_value=user_info,
                                autospec=True) as mock_get_userinfo:
-            output = _GetCommandOutput(self, 'userinfo', [self.access_token])
+            output = _GetCommandOutput('userinfo', [self.access_token])
             self.assertEqual(json.dumps(user_info, indent=4), output)
             self.assertEqual(1, mock_get_userinfo.call_count)
             self.assertEqual(self.access_token,
@@ -321,7 +300,7 @@ class TestOtherCommands(unittest2.TestCase):
                                return_value=user_info,
                                autospec=True) as mock_get_userinfo:
             output = _GetCommandOutput(
-                self, 'userinfo', ['--format=json_compact', self.access_token])
+                'userinfo', ['--format=json_compact', self.access_token])
             self.assertEqual(json.dumps(user_info, separators=(',', ':')),
                              output)
             self.assertEqual(1, mock_get_userinfo.call_count)
@@ -335,7 +314,7 @@ class TestOtherCommands(unittest2.TestCase):
         with mock.patch.object(apitools_base, 'MakeRequest',
                                return_value=response,
                                autospec=True) as mock_make_request:
-            output = _GetCommandOutput(self, 'scopes', [self.access_token])
+            output = _GetCommandOutput('scopes', [self.access_token])
             self.assertEqual(sorted(scopes), output.splitlines())
             self.assertEqual(1, mock_make_request.call_count)
 
@@ -346,7 +325,7 @@ class TestOtherCommands(unittest2.TestCase):
         with mock.patch.object(apitools_base, 'MakeRequest',
                                return_value=response,
                                autospec=True) as mock_make_request:
-            output = _GetCommandOutput(self, 'validate', [self.access_token])
+            output = _GetCommandOutput('validate', [self.access_token])
             self.assertEqual('', output)
             self.assertEqual(1, mock_make_request.call_count)
 
@@ -355,7 +334,7 @@ class TestOtherCommands(unittest2.TestCase):
         with mock.patch.object(apitools_base, 'MakeRequest',
                                return_value=response,
                                autospec=True) as mock_make_request:
-            output = _GetCommandOutput(self, 'scopes', [self.access_token])
+            output = _GetCommandOutput('scopes', [self.access_token])
             self.assertEqual('', output)
             self.assertEqual(1, mock_make_request.call_count)
 
@@ -364,9 +343,9 @@ class TestOtherCommands(unittest2.TestCase):
         with mock.patch.object(apitools_base, 'MakeRequest',
                                return_value=response,
                                autospec=True) as mock_make_request:
-            output = _GetCommandOutput(self, 'scopes', [self.access_token])
+            output = _GetCommandOutput('scopes', [self.access_token])
             self.assertIn(str(http_client.responses[response.status_code]),
                           output)
-            self.assertIn('Exception raised in scopes operation: HttpError',
+            self.assertIn('Error encountered in scopes operation: HttpError',
                           output)
             self.assertEqual(1, mock_make_request.call_count)

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ TESTING_PACKAGES = [
 
 CONSOLE_SCRIPTS = [
     'gen_client = apitools.gen.gen_client:main',
-    'oauth2l = apitools.scripts.oauth2l:run_main [cli]',
+    'oauth2l = apitools.scripts.oauth2l:main',
 ]
 
 py_version = platform.python_version()
@@ -70,9 +70,7 @@ setuptools.setup(
     author_email='craigcitro@google.com',
     # Contained modules and scripts.
     packages=setuptools.find_packages(),
-    entry_points={
-        'console_scripts': CONSOLE_SCRIPTS,
-        },
+    entry_points={'console_scripts': CONSOLE_SCRIPTS},
     install_requires=REQUIRED_PACKAGES,
     tests_require=REQUIRED_PACKAGES + CLI_PACKAGES + TESTING_PACKAGES,
     extras_require={


### PR DESCRIPTION
We'd only used gflags in oauth2l for vestigial reasons (read: I first wrote
the code internally), but someone ran into related install trouble this
weekend. Swapping out argparse was easy, and as a nice by-product, we pick up
python3 support in oauth2l.

(As a bonus, there's slightly more documentation for a net drop in LOC. w00t.)

PTAL @cherba @wora 