### PR TITLE
Deprecate X-Google-Metadata-Request in favor new Metadata-Flavor header

### DIFF
--- a/apitools/base/py/credentials_lib_test.py
+++ b/apitools/base/py/credentials_lib_test.py
@@ -26,7 +26,7 @@ from apitools.base.py import util
 
 def CreateUriValidator(uri_regexp, content=''):
     def CheckUri(uri, headers=None):
-        if 'X-Google-Metadata-Request' not in headers:
+        if 'Metadata-Flavor' not in headers:
             raise ValueError('Missing required header')
         if uri_regexp.match(uri):
             message = content


### PR DESCRIPTION
We are deprecating the use of the X-Google-Metadata-Request header in favor
of the latest header, Metadata-Flavor.

The transition is explained here:

https://cloud.google.com/compute/docs/metadata#transitioning