### PR TITLE
Update service_account support for oauth2clientv2.

### DIFF
--- a/apitools/base/py/credentials_lib.py
+++ b/apitools/base/py/credentials_lib.py
@@ -25,7 +25,7 @@ import threading
 import httplib2
 import oauth2client
 import oauth2client.client
-import oauth2client.service_account
+from oauth2client import service_account
 from oauth2client import tools  # for gflags declarations
 from six.moves import http_client
 from six.moves import urllib
@@ -56,7 +56,6 @@ __all__ = [
     'GceAssertionCredentials',
     'GetCredentials',
     'GetUserinfo',
-    'ServiceAccountCredentials',
     'ServiceAccountCredentialsFromFile',
 ]
 
@@ -130,21 +129,57 @@ def GetCredentials(package_name, scopes, client_id, client_secret, user_agent,
     raise exceptions.CredentialsError('Could not create valid credentials')
 
 
-def ServiceAccountCredentialsFromFile(
-        service_account_name, private_key_filename, scopes,
-        service_account_kwargs=None):
-    with open(private_key_filename) as key_file:
-        return ServiceAccountCredentials(
-            service_account_name, key_file.read(), scopes,
-            service_account_kwargs=service_account_kwargs)
+def ServiceAccountCredentialsFromFile(filename, scopes, user_agent=None):
+    """Use the credentials in filename to create a token for scopes."""
+    filename = os.path.expanduser(filename)
+    # We have two options, based on our version of oauth2client.
+    if oauth2client.__version__ > '1.5.2':
+        # oauth2client >= 2.0.0
+        credentials = (
+            service_account.ServiceAccountCredentials.from_json_keyfile_name(
+                filename, scopes=scopes))
+        if credentials is not None:
+            if user_agent is not None:
+                credentials.user_agent = user_agent
+        return credentials
+    else:
+        # oauth2client < 2.0.0
+        with open(filename) as keyfile:
+            service_account_info = json.load(keyfile)
+        account_type = service_account_info.get('type')
+        if account_type != oauth2client.client.SERVICE_ACCOUNT:
+            raise exceptions.CredentialsError(
+                'Invalid service account credentials: %s' % (filename,))
+        # pylint: disable=protected-access
+        credentials = service_account._ServiceAccountCredentials(
+            service_account_id=service_account_info['client_id'],
+            service_account_email=service_account_info['client_email'],
+            private_key_id=service_account_info['private_key_id'],
+            private_key_pkcs8_text=service_account_info['private_key'],
+            scopes=scopes, user_agent=user_agent)
+        # pylint: enable=protected-access
+        return credentials
 
 
-def ServiceAccountCredentials(service_account_name, private_key, scopes,
-                              service_account_kwargs=None):
-    service_account_kwargs = service_account_kwargs or {}
+def ServiceAccountCredentialsFromP12File(
+        service_account_name, private_key_filename, scopes, user_agent):
+    """Create a new credential from the named .p12 keyfile."""
+    private_key_filename = os.path.expanduser(private_key_filename)
     scopes = util.NormalizeScopes(scopes)
-    return oauth2client.client.SignedJwtAssertionCredentials(
-        service_account_name, private_key, scopes, **service_account_kwargs)
+    if oauth2client.__version__ > '1.5.2':
+        # oauth2client >= 2.0.0
+        credentials = (
+            service_account.ServiceAccountCredentials.from_p12_keyfile(
+                service_account_name, private_key_filename, scopes=scopes))
+        if credentials is not None:
+            credentials.user_agent = user_agent
+        return credentials
+    else:
+        # oauth2client < 2.0.0
+        with open(private_key_filename) as key_file:
+            return oauth2client.client.SignedJwtAssertionCredentials(
+                service_account_name, key_file.read(), scopes,
+                user_agent=user_agent)
 
 
 def _EnsureFileExists(filename):
@@ -524,30 +559,14 @@ def _GetServiceAccountCredentials(
             'Service account name or keyfile provided without the other')
     scopes = client_info['scope'].split()
     user_agent = client_info['user_agent']
+    # Use the .json credentials, if provided.
     if service_account_json_keyfile:
-        with open(service_account_json_keyfile) as keyfile:
-            service_account_info = json.load(keyfile)
-        account_type = service_account_info.get('type')
-        if account_type != oauth2client.client.SERVICE_ACCOUNT:
-            raise exceptions.CredentialsError(
-                'Invalid service account credentials: %s' % (
-                    service_account_json_keyfile,))
-        # pylint: disable=protected-access
-        credentials = oauth2client.service_account._ServiceAccountCredentials(
-            service_account_id=service_account_info['client_id'],
-            service_account_email=service_account_info['client_email'],
-            private_key_id=service_account_info['private_key_id'],
-            private_key_pkcs8_text=service_account_info['private_key'],
-            scopes=scopes, user_agent=user_agent)
-        # pylint: enable=protected-access
-        return credentials
+        return ServiceAccountCredentialsFromFile(
+            service_account_json_keyfile, scopes, user_agent=user_agent)
+    # Fall back to .p12 if there's no .json credentials.
     if service_account_name is not None:
-        # pylint: disable=redefined-variable-type
-        credentials = ServiceAccountCredentialsFromFile(
-            service_account_name, service_account_keyfile, scopes,
-            service_account_kwargs={'user_agent': user_agent})
-        if credentials is not None:
-            return credentials
+        return ServiceAccountCredentialsFromP12File(
+            service_account_name, service_account_keyfile, scopes, user_agent)
 
 
 @_RegisterCredentialsMethod

--- a/apitools/gen/util.py
+++ b/apitools/gen/util.py
@@ -319,7 +319,7 @@ def FetchDiscoveryDoc(discovery_url, retries=5):
                 discovery_doc = json.loads(urllib_request.urlopen(url).read())
                 break
             except (urllib_error.HTTPError, urllib_error.URLError) as e:
-                logging.warning(
+                logging.info(
                     'Attempting to fetch discovery doc again after "%s"', e)
                 last_exception = e
     if discovery_doc is None:


### PR DESCRIPTION
This makes three changes:

* Make the code for loading either .json or .p12 credentials work under either
  oauth2client 2.0.0post1+ or oauth2client < 2.0.0. In particular, this mostly
  amounts to picking up a few renames from the oauth2client changelog.

* Drop `credentials_lib.ServiceAccount()`. From some searching, no one at all
  is using this function, and supporting it makes the case of .p12 keys
  significantly more awkward.

* Change `credentials_lib.ServiceAccountFromFile()` to handle .json keys, not
  .p12 keys. I'm fairly certain that apitools itself was the only caller of
  this code.

Tested by hand (via oauth2l).

PTAL @silviulica -- this should mean we're good to go on a release.

FYI @thobrla -- I've confirmed from looking at code that this won't break you, but I thought you might be interested in using some of the same code in gsutil if/when you want to support a newer oauth2client.  