### PR TITLE
Attempt to import newer versions of oauth2client libraries first.

### DIFF
--- a/apitools/base/py/credentials_lib.py
+++ b/apitools/base/py/credentials_lib.py
@@ -39,9 +39,19 @@ from apitools.base.py import util
 #
 # pylint: disable=wrong-import-order,ungrouped-imports
 try:
-    from oauth2client import gce, locked_file, multistore_file
+    from oauth2client.contrib import gce
 except ImportError:
-    from oauth2client.contrib import gce, locked_file, multistore_file
+    from oauth2client import gce
+
+try:
+    from oauth2client.contrib import locked_file
+except ImportError:
+    from oauth2client import locked_file
+
+try:
+    from oauth2client.contrib import multistore_file
+except ImportError:
+    from oauth2client import multistore_file
 
 try:
     import gflags

--- a/apitools/base/py/credentials_lib.py
+++ b/apitools/base/py/credentials_lib.py
@@ -472,6 +472,22 @@ class GaeAssertionCredentials(oauth2client.client.AssertionCredentials):
             raise exceptions.CredentialsError(str(e))
         self.access_token = token
 
+    def sign_blob(self, blob):
+        """Cryptographically sign a blob (of bytes).
+
+        This method is provided to support a common interface, but
+        the actual key used for a Google Compute Engine service account
+        is not available, so it can't be used to sign content.
+
+        Args:
+            blob: bytes, Message to be signed.
+
+        Raises:
+            NotImplementedError, always.
+        """
+        raise NotImplementedError(
+            'Compute Engine service accounts cannot sign blobs')
+
 
 def _GetRunFlowFlags(args=None):
     # There's one rare situation where gsutil will not have argparse


### PR DESCRIPTION
We have instances of this library being used in environments where only a
portion of the oauth2client library has been updated.  This change allows
us to find the latest versions of these libraries, when available.