### PR TITLE
Cleanup package data, and fix a warning.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include *.py
 include *.txt
 include *.md
 recursive-include apitools *.py
+recursive-include apitools *.json

--- a/apitools/base/py/credentials_lib.py
+++ b/apitools/base/py/credentials_lib.py
@@ -257,7 +257,10 @@ class GceAssertionCredentials(gce.AppAssertionCredentials):
         if cache_filename and not cached_scopes:
             self._WriteCacheFile(cache_filename, scopes)
 
-        super(GceAssertionCredentials, self).__init__(scopes, **kwds)
+        # We check the scopes above, but don't need them again after
+        # this point; in addition, the parent class spits out a
+        # warning if we pass them here, so we purposely drop them.
+        super(GceAssertionCredentials, self).__init__(**kwds)
 
     @classmethod
     def Get(cls, *args, **kwds):


### PR DESCRIPTION
This does two small-but-independent cleanups:

1. Fixes MANIFEST.in to always pick up the client_secrets.json file.

2. Tweaks a call in credentials_lib to avoid a (useful) warning in
oauth2client.contrib.gce.

PTAL @silviulica @cherba 