### PR TITLE
Ensuring that a new url is used after refreshing the credentials.

### DIFF
--- a/apitools/base/py/credentials_lib.py
+++ b/apitools/base/py/credentials_lib.py
@@ -570,16 +570,21 @@ def GetUserinfo(credentials, http=None):  # pylint: disable=invalid-name
       aren't available.
     """
     http = http or httplib2.Http()
-    url_root = 'https://www.googleapis.com/oauth2/v2/tokeninfo'
-    query_args = {'access_token': credentials.access_token}
-    url = '?'.join((url_root, urllib.parse.urlencode(query_args)))
+    url = _GetUserinfoUrl(credentials)
     # We ignore communication woes here (i.e. SSL errors, socket
     # timeout), as handling these should be done in a common location.
     response, content = http.request(url)
     if response.status == http_client.BAD_REQUEST:
         credentials.refresh(http)
+        url = _GetUserinfoUrl(credentials)
         response, content = http.request(url)
     return json.loads(content or '{}')  # Save ourselves from an empty reply.
+
+
+def _GetUserinfoUrl(credentials):
+    url_root = 'https://www.googleapis.com/oauth2/v2/tokeninfo'
+    query_args = {'access_token': credentials.access_token}
+    return '?'.join((url_root, urllib.parse.urlencode(query_args)))
 
 
 @_RegisterCredentialsMethod


### PR DESCRIPTION
The function `GetUserinfo` refreshes the credentials and retries once when the server returns `BAD_REQUEST`. The problem is that while it refreshes the credentials it does not re-creates the url with the newly obtained `access_token`, this means that the old URL that failed is used again in the retry.

This PR fixes this by recreating the URL after the credentials are refreshed. It is done by doing a small amount of refactoring so the code that creates the URL is in it's own private function.