### PR TITLE
Allow clients to set retry_func for MakeRequest

### DIFF
--- a/apitools/base/py/base_api_test.py
+++ b/apitools/base/py/base_api_test.py
@@ -165,6 +165,26 @@ class BaseApiTest(unittest2.TestCase):
         with mock(base_api.http_wrapper, 'MakeRequest', fakeMakeRequest):
             service._RunMethod(method_config, request)
 
+    def testCustomRetryFunc(self):
+        def retry_func():
+            pass
+
+        def fakeMakeRequest(*_, **kwargs):
+            self.assertEqual(retry_func, kwargs['retry_func'])
+            return http_wrapper.Response(
+                info={'status': '200'}, content='{"field": "abc"}',
+                request_url='http://www.google.com')
+        http_wrapper.MakeRequest = fakeMakeRequest
+        method_config = base_api.ApiMethodInfo(
+            request_type_name='SimpleMessage',
+            response_type_name='SimpleMessage')
+        client = self.__GetFakeClient()
+        client.retry_func = retry_func
+        service = FakeService(client=client)
+        request = SimpleMessage()
+        with mock(base_api.http_wrapper, 'MakeRequest', fakeMakeRequest):
+            service._RunMethod(method_config, request)
+
     def testQueryEncoding(self):
         method_config = base_api.ApiMethodInfo(
             request_type_name='MessageWithTime', query_params=['timestamp'])

--- a/apitools/base/py/http_wrapper_test.py
+++ b/apitools/base/py/http_wrapper_test.py
@@ -77,7 +77,8 @@ class HttpWrapperTest(unittest2.TestCase):
 
             retry_args = http_wrapper.ExceptionRetryArgs(
                 http={'connections': {}}, http_request=_MockHttpRequest(),
-                exc=exception_arg, num_retries=0, max_retry_wait=0)
+                exc=exception_arg, num_retries=0, max_retry_wait=0,
+                total_wait_sec=0)
 
             # Disable time.sleep for this handler as it is called with
             # a minimum value of 1 second.

--- a/default.pylintrc
+++ b/default.pylintrc
@@ -55,6 +55,7 @@ disable =
     no-name-in-module,
     no-self-use,
     super-on-old-class,
+    too-many-arguments,
     too-many-function-args,
 
 


### PR DESCRIPTION
This change:
- Adds an item to ExceptionRetryArgs containing the total number of
  seconds the user has waited since the first request attempt.
- Allows clients to specify a custom retry function for retry logic.

My use case for these changes involves using a wrapper function which performs
some additional logging if total_wait_sec is high enough, then calls the
default retry function.