### PR TITLE
Fix an ADC-related bug, and make an install tweak.

### DIFF
--- a/apitools/base/py/credentials_lib.py
+++ b/apitools/base/py/credentials_lib.py
@@ -642,5 +642,5 @@ def _GetApplicationDefaultCredentials(
     # ADC will work.
     cp = 'https://www.googleapis.com/auth/cloud-platform'
     if not isinstance(credentials, gc) or cp in scopes:
-        return credentials
+        return credentials.create_scoped(scopes)
     return None

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ TESTING_PACKAGES = [
 
 CONSOLE_SCRIPTS = [
     'gen_client = apitools.gen.gen_client:main',
-    'oauth2l = apitools.scripts.oauth2l:main',
 ]
 
 py_version = platform.python_version()


### PR DESCRIPTION
When getting the application default credentials from a file, we need to make
sure we call create_scoped(), otherwise we'll get back invalid access tokens.

While I was here, I dropped the hook to add an oauth2l script, since it's now
its own package on PyPI. I'll drop the code in a separate PR.

PTAL @wora 