### PR TITLE
Make method_config class level accessible.

### DIFF
--- a/apitools/base/py/base_api.py
+++ b/apitools/base/py/base_api.py
@@ -472,7 +472,23 @@ class BaseApiService(object):
         return self.__client
 
     def GetMethodConfig(self, method):
-        return self._method_configs[method]
+        """Returns service cached method config for given method."""
+        method_config = self._method_configs.get(method)
+        if method_config:
+            return method_config
+        func = getattr(self, method, None)
+        if func is None:
+            raise KeyError(method)
+        method_config = getattr(func, 'method_config', None)
+        if method_config is None:
+            raise KeyError(method)
+        self._method_configs[method] = config = method_config()
+        return config
+
+    @classmethod
+    def GetMethodsList(cls):
+        return [f.__name__ for f in six.itervalues(cls.__dict__)
+                if getattr(f, 'method_config', None)]
 
     def GetUploadConfig(self, method):
         return self._upload_configs.get(method)

--- a/apitools/base/py/testing/mock.py
+++ b/apitools/base/py/testing/mock.py
@@ -203,6 +203,7 @@ class _MockedMethod(object):
         self.__key = key
         self.__mocked_client = mocked_client
         self.__real_method = real_method
+        self.method_config = real_method.method_config
 
     def Expect(self, request, response=None, exception=None, **unused_kwargs):
         """Add an expectation on the mocked method.
@@ -312,7 +313,7 @@ class Client(object):
                                   self.__client_class._URL_VERSION)
             mocked_service = _MockedService(
                 api_name + '.' + collection_name, self,
-                service._method_configs.keys(),
+                service.GetMethodsList(),
                 service if self.__real_client else None)
             mocked_constructor = _MakeMockedServiceConstructor(mocked_service)
             setattr(self.__client_class, name, mocked_constructor)

--- a/apitools/gen/service_registry.py
+++ b/apitools/gen/service_registry.py
@@ -104,22 +104,6 @@ class ServiceRegistry(object):
             with printer.Indent():
                 printer('super(%s.%s, self).__init__(client)',
                         client_class_name, class_name)
-                printer('self._method_configs = {')
-                with printer.Indent(indent='    '):
-                    for method_name, method_info in method_info_map.items():
-                        printer("'%s': base_api.ApiMethodInfo(", method_name)
-                        with printer.Indent(indent='    '):
-                            attrs = sorted(
-                                x.name for x in method_info.all_fields())
-                            for attr in attrs:
-                                if attr in ('upload_config', 'description'):
-                                    continue
-                                value = getattr(method_info, attr)
-                                if value is not None:
-                                    printer('%s=%r,', attr, value)
-                        printer('),')
-                    printer('}')
-                printer()
                 printer('self._upload_configs = {')
                 with printer.Indent(indent='    '):
                     for method_name, method_info in method_info_map.items():
@@ -165,6 +149,20 @@ class ServiceRegistry(object):
                         for line in arg_lines[:-1]:
                             printer('%s,', line)
                         printer('%s)', arg_lines[-1])
+                printer()
+                printer('{0}.method_config = lambda: base_api.ApiMethodInfo('
+                        .format(method_name))
+                with printer.Indent(indent='    '):
+                    method_info = method_info_map[method_name]
+                    attrs = sorted(
+                        x.name for x in method_info.all_fields())
+                    for attr in attrs:
+                        if attr in ('upload_config', 'description'):
+                            continue
+                        value = getattr(method_info, attr)
+                        if value is not None:
+                            printer('%s=%r,', attr, value)
+                printer(')')
 
     def __WriteProtoServiceDeclaration(self, printer, name, method_info_map):
         """Write a single service declaration to a proto file."""

--- a/samples/dns_sample/dns_v1/dns_v1_client.py
+++ b/samples/dns_sample/dns_v1/dns_v1_client.py
@@ -46,45 +46,6 @@ class DnsV1(base_api.BaseApiClient):
 
     def __init__(self, client):
       super(DnsV1.ChangesService, self).__init__(client)
-      self._method_configs = {
-          'Create': base_api.ApiMethodInfo(
-              http_method=u'POST',
-              method_id=u'dns.changes.create',
-              ordered_params=[u'project', u'managedZone'],
-              path_params=[u'managedZone', u'project'],
-              query_params=[],
-              relative_path=u'projects/{project}/managedZones/{managedZone}/changes',
-              request_field=u'change',
-              request_type_name=u'DnsChangesCreateRequest',
-              response_type_name=u'Change',
-              supports_download=False,
-          ),
-          'Get': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'dns.changes.get',
-              ordered_params=[u'project', u'managedZone', u'changeId'],
-              path_params=[u'changeId', u'managedZone', u'project'],
-              query_params=[],
-              relative_path=u'projects/{project}/managedZones/{managedZone}/changes/{changeId}',
-              request_field='',
-              request_type_name=u'DnsChangesGetRequest',
-              response_type_name=u'Change',
-              supports_download=False,
-          ),
-          'List': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'dns.changes.list',
-              ordered_params=[u'project', u'managedZone'],
-              path_params=[u'managedZone', u'project'],
-              query_params=[u'maxResults', u'pageToken', u'sortBy', u'sortOrder'],
-              relative_path=u'projects/{project}/managedZones/{managedZone}/changes',
-              request_field='',
-              request_type_name=u'DnsChangesListRequest',
-              response_type_name=u'ChangesListResponse',
-              supports_download=False,
-          ),
-          }
-
       self._upload_configs = {
           }
 
@@ -101,6 +62,19 @@ class DnsV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Create.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'POST',
+        method_id=u'dns.changes.create',
+        ordered_params=[u'project', u'managedZone'],
+        path_params=[u'managedZone', u'project'],
+        query_params=[],
+        relative_path=u'projects/{project}/managedZones/{managedZone}/changes',
+        request_field=u'change',
+        request_type_name=u'DnsChangesCreateRequest',
+        response_type_name=u'Change',
+        supports_download=False,
+    )
+
     def Get(self, request, global_params=None):
       """Fetch the representation of an existing Change.
 
@@ -113,6 +87,19 @@ class DnsV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('Get')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    Get.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'dns.changes.get',
+        ordered_params=[u'project', u'managedZone', u'changeId'],
+        path_params=[u'changeId', u'managedZone', u'project'],
+        query_params=[],
+        relative_path=u'projects/{project}/managedZones/{managedZone}/changes/{changeId}',
+        request_field='',
+        request_type_name=u'DnsChangesGetRequest',
+        response_type_name=u'Change',
+        supports_download=False,
+    )
 
     def List(self, request, global_params=None):
       """Enumerate Changes to a ResourceRecordSet collection.
@@ -127,6 +114,19 @@ class DnsV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    List.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'dns.changes.list',
+        ordered_params=[u'project', u'managedZone'],
+        path_params=[u'managedZone', u'project'],
+        query_params=[u'maxResults', u'pageToken', u'sortBy', u'sortOrder'],
+        relative_path=u'projects/{project}/managedZones/{managedZone}/changes',
+        request_field='',
+        request_type_name=u'DnsChangesListRequest',
+        response_type_name=u'ChangesListResponse',
+        supports_download=False,
+    )
+
   class ManagedZonesService(base_api.BaseApiService):
     """Service class for the managedZones resource."""
 
@@ -134,57 +134,6 @@ class DnsV1(base_api.BaseApiClient):
 
     def __init__(self, client):
       super(DnsV1.ManagedZonesService, self).__init__(client)
-      self._method_configs = {
-          'Create': base_api.ApiMethodInfo(
-              http_method=u'POST',
-              method_id=u'dns.managedZones.create',
-              ordered_params=[u'project'],
-              path_params=[u'project'],
-              query_params=[],
-              relative_path=u'projects/{project}/managedZones',
-              request_field=u'managedZone',
-              request_type_name=u'DnsManagedZonesCreateRequest',
-              response_type_name=u'ManagedZone',
-              supports_download=False,
-          ),
-          'Delete': base_api.ApiMethodInfo(
-              http_method=u'DELETE',
-              method_id=u'dns.managedZones.delete',
-              ordered_params=[u'project', u'managedZone'],
-              path_params=[u'managedZone', u'project'],
-              query_params=[],
-              relative_path=u'projects/{project}/managedZones/{managedZone}',
-              request_field='',
-              request_type_name=u'DnsManagedZonesDeleteRequest',
-              response_type_name=u'DnsManagedZonesDeleteResponse',
-              supports_download=False,
-          ),
-          'Get': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'dns.managedZones.get',
-              ordered_params=[u'project', u'managedZone'],
-              path_params=[u'managedZone', u'project'],
-              query_params=[],
-              relative_path=u'projects/{project}/managedZones/{managedZone}',
-              request_field='',
-              request_type_name=u'DnsManagedZonesGetRequest',
-              response_type_name=u'ManagedZone',
-              supports_download=False,
-          ),
-          'List': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'dns.managedZones.list',
-              ordered_params=[u'project'],
-              path_params=[u'project'],
-              query_params=[u'dnsName', u'maxResults', u'pageToken'],
-              relative_path=u'projects/{project}/managedZones',
-              request_field='',
-              request_type_name=u'DnsManagedZonesListRequest',
-              response_type_name=u'ManagedZonesListResponse',
-              supports_download=False,
-          ),
-          }
-
       self._upload_configs = {
           }
 
@@ -201,6 +150,19 @@ class DnsV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Create.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'POST',
+        method_id=u'dns.managedZones.create',
+        ordered_params=[u'project'],
+        path_params=[u'project'],
+        query_params=[],
+        relative_path=u'projects/{project}/managedZones',
+        request_field=u'managedZone',
+        request_type_name=u'DnsManagedZonesCreateRequest',
+        response_type_name=u'ManagedZone',
+        supports_download=False,
+    )
+
     def Delete(self, request, global_params=None):
       """Delete a previously created ManagedZone.
 
@@ -213,6 +175,19 @@ class DnsV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('Delete')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    Delete.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'DELETE',
+        method_id=u'dns.managedZones.delete',
+        ordered_params=[u'project', u'managedZone'],
+        path_params=[u'managedZone', u'project'],
+        query_params=[],
+        relative_path=u'projects/{project}/managedZones/{managedZone}',
+        request_field='',
+        request_type_name=u'DnsManagedZonesDeleteRequest',
+        response_type_name=u'DnsManagedZonesDeleteResponse',
+        supports_download=False,
+    )
 
     def Get(self, request, global_params=None):
       """Fetch the representation of an existing ManagedZone.
@@ -227,6 +202,19 @@ class DnsV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Get.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'dns.managedZones.get',
+        ordered_params=[u'project', u'managedZone'],
+        path_params=[u'managedZone', u'project'],
+        query_params=[],
+        relative_path=u'projects/{project}/managedZones/{managedZone}',
+        request_field='',
+        request_type_name=u'DnsManagedZonesGetRequest',
+        response_type_name=u'ManagedZone',
+        supports_download=False,
+    )
+
     def List(self, request, global_params=None):
       """Enumerate ManagedZones that have been created but not yet deleted.
 
@@ -240,6 +228,19 @@ class DnsV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    List.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'dns.managedZones.list',
+        ordered_params=[u'project'],
+        path_params=[u'project'],
+        query_params=[u'dnsName', u'maxResults', u'pageToken'],
+        relative_path=u'projects/{project}/managedZones',
+        request_field='',
+        request_type_name=u'DnsManagedZonesListRequest',
+        response_type_name=u'ManagedZonesListResponse',
+        supports_download=False,
+    )
+
   class ProjectsService(base_api.BaseApiService):
     """Service class for the projects resource."""
 
@@ -247,21 +248,6 @@ class DnsV1(base_api.BaseApiClient):
 
     def __init__(self, client):
       super(DnsV1.ProjectsService, self).__init__(client)
-      self._method_configs = {
-          'Get': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'dns.projects.get',
-              ordered_params=[u'project'],
-              path_params=[u'project'],
-              query_params=[],
-              relative_path=u'projects/{project}',
-              request_field='',
-              request_type_name=u'DnsProjectsGetRequest',
-              response_type_name=u'Project',
-              supports_download=False,
-          ),
-          }
-
       self._upload_configs = {
           }
 
@@ -278,6 +264,19 @@ class DnsV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Get.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'dns.projects.get',
+        ordered_params=[u'project'],
+        path_params=[u'project'],
+        query_params=[],
+        relative_path=u'projects/{project}',
+        request_field='',
+        request_type_name=u'DnsProjectsGetRequest',
+        response_type_name=u'Project',
+        supports_download=False,
+    )
+
   class ResourceRecordSetsService(base_api.BaseApiService):
     """Service class for the resourceRecordSets resource."""
 
@@ -285,21 +284,6 @@ class DnsV1(base_api.BaseApiClient):
 
     def __init__(self, client):
       super(DnsV1.ResourceRecordSetsService, self).__init__(client)
-      self._method_configs = {
-          'List': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'dns.resourceRecordSets.list',
-              ordered_params=[u'project', u'managedZone'],
-              path_params=[u'managedZone', u'project'],
-              query_params=[u'maxResults', u'name', u'pageToken', u'type'],
-              relative_path=u'projects/{project}/managedZones/{managedZone}/rrsets',
-              request_field='',
-              request_type_name=u'DnsResourceRecordSetsListRequest',
-              response_type_name=u'ResourceRecordSetsListResponse',
-              supports_download=False,
-          ),
-          }
-
       self._upload_configs = {
           }
 
@@ -315,3 +299,16 @@ class DnsV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('List')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    List.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'dns.resourceRecordSets.list',
+        ordered_params=[u'project', u'managedZone'],
+        path_params=[u'managedZone', u'project'],
+        query_params=[u'maxResults', u'name', u'pageToken', u'type'],
+        relative_path=u'projects/{project}/managedZones/{managedZone}/rrsets',
+        request_field='',
+        request_type_name=u'DnsResourceRecordSetsListRequest',
+        response_type_name=u'ResourceRecordSetsListResponse',
+        supports_download=False,
+    )

--- a/samples/fusiontables_sample/fusiontables_v1/fusiontables_v1_client.py
+++ b/samples/fusiontables_sample/fusiontables_v1/fusiontables_v1_client.py
@@ -48,81 +48,6 @@ class FusiontablesV1(base_api.BaseApiClient):
 
     def __init__(self, client):
       super(FusiontablesV1.ColumnService, self).__init__(client)
-      self._method_configs = {
-          'Delete': base_api.ApiMethodInfo(
-              http_method=u'DELETE',
-              method_id=u'fusiontables.column.delete',
-              ordered_params=[u'tableId', u'columnId'],
-              path_params=[u'columnId', u'tableId'],
-              query_params=[],
-              relative_path=u'tables/{tableId}/columns/{columnId}',
-              request_field='',
-              request_type_name=u'FusiontablesColumnDeleteRequest',
-              response_type_name=u'FusiontablesColumnDeleteResponse',
-              supports_download=False,
-          ),
-          'Get': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'fusiontables.column.get',
-              ordered_params=[u'tableId', u'columnId'],
-              path_params=[u'columnId', u'tableId'],
-              query_params=[],
-              relative_path=u'tables/{tableId}/columns/{columnId}',
-              request_field='',
-              request_type_name=u'FusiontablesColumnGetRequest',
-              response_type_name=u'Column',
-              supports_download=False,
-          ),
-          'Insert': base_api.ApiMethodInfo(
-              http_method=u'POST',
-              method_id=u'fusiontables.column.insert',
-              ordered_params=[u'tableId'],
-              path_params=[u'tableId'],
-              query_params=[],
-              relative_path=u'tables/{tableId}/columns',
-              request_field=u'column',
-              request_type_name=u'FusiontablesColumnInsertRequest',
-              response_type_name=u'Column',
-              supports_download=False,
-          ),
-          'List': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'fusiontables.column.list',
-              ordered_params=[u'tableId'],
-              path_params=[u'tableId'],
-              query_params=[u'maxResults', u'pageToken'],
-              relative_path=u'tables/{tableId}/columns',
-              request_field='',
-              request_type_name=u'FusiontablesColumnListRequest',
-              response_type_name=u'ColumnList',
-              supports_download=False,
-          ),
-          'Patch': base_api.ApiMethodInfo(
-              http_method=u'PATCH',
-              method_id=u'fusiontables.column.patch',
-              ordered_params=[u'tableId', u'columnId'],
-              path_params=[u'columnId', u'tableId'],
-              query_params=[],
-              relative_path=u'tables/{tableId}/columns/{columnId}',
-              request_field=u'column',
-              request_type_name=u'FusiontablesColumnPatchRequest',
-              response_type_name=u'Column',
-              supports_download=False,
-          ),
-          'Update': base_api.ApiMethodInfo(
-              http_method=u'PUT',
-              method_id=u'fusiontables.column.update',
-              ordered_params=[u'tableId', u'columnId'],
-              path_params=[u'columnId', u'tableId'],
-              query_params=[],
-              relative_path=u'tables/{tableId}/columns/{columnId}',
-              request_field=u'column',
-              request_type_name=u'FusiontablesColumnUpdateRequest',
-              response_type_name=u'Column',
-              supports_download=False,
-          ),
-          }
-
       self._upload_configs = {
           }
 
@@ -139,6 +64,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Delete.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'DELETE',
+        method_id=u'fusiontables.column.delete',
+        ordered_params=[u'tableId', u'columnId'],
+        path_params=[u'columnId', u'tableId'],
+        query_params=[],
+        relative_path=u'tables/{tableId}/columns/{columnId}',
+        request_field='',
+        request_type_name=u'FusiontablesColumnDeleteRequest',
+        response_type_name=u'FusiontablesColumnDeleteResponse',
+        supports_download=False,
+    )
+
     def Get(self, request, global_params=None):
       """Retrieves a specific column by its id.
 
@@ -151,6 +89,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('Get')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    Get.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'fusiontables.column.get',
+        ordered_params=[u'tableId', u'columnId'],
+        path_params=[u'columnId', u'tableId'],
+        query_params=[],
+        relative_path=u'tables/{tableId}/columns/{columnId}',
+        request_field='',
+        request_type_name=u'FusiontablesColumnGetRequest',
+        response_type_name=u'Column',
+        supports_download=False,
+    )
 
     def Insert(self, request, global_params=None):
       """Adds a new column to the table.
@@ -165,6 +116,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Insert.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'POST',
+        method_id=u'fusiontables.column.insert',
+        ordered_params=[u'tableId'],
+        path_params=[u'tableId'],
+        query_params=[],
+        relative_path=u'tables/{tableId}/columns',
+        request_field=u'column',
+        request_type_name=u'FusiontablesColumnInsertRequest',
+        response_type_name=u'Column',
+        supports_download=False,
+    )
+
     def List(self, request, global_params=None):
       """Retrieves a list of columns.
 
@@ -177,6 +141,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('List')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    List.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'fusiontables.column.list',
+        ordered_params=[u'tableId'],
+        path_params=[u'tableId'],
+        query_params=[u'maxResults', u'pageToken'],
+        relative_path=u'tables/{tableId}/columns',
+        request_field='',
+        request_type_name=u'FusiontablesColumnListRequest',
+        response_type_name=u'ColumnList',
+        supports_download=False,
+    )
 
     def Patch(self, request, global_params=None):
       """Updates the name or type of an existing column. This method supports patch semantics.
@@ -191,6 +168,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Patch.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'PATCH',
+        method_id=u'fusiontables.column.patch',
+        ordered_params=[u'tableId', u'columnId'],
+        path_params=[u'columnId', u'tableId'],
+        query_params=[],
+        relative_path=u'tables/{tableId}/columns/{columnId}',
+        request_field=u'column',
+        request_type_name=u'FusiontablesColumnPatchRequest',
+        response_type_name=u'Column',
+        supports_download=False,
+    )
+
     def Update(self, request, global_params=None):
       """Updates the name or type of an existing column.
 
@@ -204,6 +194,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Update.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'PUT',
+        method_id=u'fusiontables.column.update',
+        ordered_params=[u'tableId', u'columnId'],
+        path_params=[u'columnId', u'tableId'],
+        query_params=[],
+        relative_path=u'tables/{tableId}/columns/{columnId}',
+        request_field=u'column',
+        request_type_name=u'FusiontablesColumnUpdateRequest',
+        response_type_name=u'Column',
+        supports_download=False,
+    )
+
   class QueryService(base_api.BaseApiService):
     """Service class for the query resource."""
 
@@ -211,33 +214,6 @@ class FusiontablesV1(base_api.BaseApiClient):
 
     def __init__(self, client):
       super(FusiontablesV1.QueryService, self).__init__(client)
-      self._method_configs = {
-          'Sql': base_api.ApiMethodInfo(
-              http_method=u'POST',
-              method_id=u'fusiontables.query.sql',
-              ordered_params=[u'sql'],
-              path_params=[],
-              query_params=[u'hdrs', u'sql', u'typed'],
-              relative_path=u'query',
-              request_field='',
-              request_type_name=u'FusiontablesQuerySqlRequest',
-              response_type_name=u'Sqlresponse',
-              supports_download=True,
-          ),
-          'SqlGet': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'fusiontables.query.sqlGet',
-              ordered_params=[u'sql'],
-              path_params=[],
-              query_params=[u'hdrs', u'sql', u'typed'],
-              relative_path=u'query',
-              request_field='',
-              request_type_name=u'FusiontablesQuerySqlGetRequest',
-              response_type_name=u'Sqlresponse',
-              supports_download=True,
-          ),
-          }
-
       self._upload_configs = {
           }
 
@@ -257,6 +233,19 @@ class FusiontablesV1(base_api.BaseApiClient):
           config, request, global_params=global_params,
           download=download)
 
+    Sql.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'POST',
+        method_id=u'fusiontables.query.sql',
+        ordered_params=[u'sql'],
+        path_params=[],
+        query_params=[u'hdrs', u'sql', u'typed'],
+        relative_path=u'query',
+        request_field='',
+        request_type_name=u'FusiontablesQuerySqlRequest',
+        response_type_name=u'Sqlresponse',
+        supports_download=True,
+    )
+
     def SqlGet(self, request, global_params=None, download=None):
       """Executes an SQL SELECT/SHOW/DESCRIBE statement.
 
@@ -273,6 +262,19 @@ class FusiontablesV1(base_api.BaseApiClient):
           config, request, global_params=global_params,
           download=download)
 
+    SqlGet.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'fusiontables.query.sqlGet',
+        ordered_params=[u'sql'],
+        path_params=[],
+        query_params=[u'hdrs', u'sql', u'typed'],
+        relative_path=u'query',
+        request_field='',
+        request_type_name=u'FusiontablesQuerySqlGetRequest',
+        response_type_name=u'Sqlresponse',
+        supports_download=True,
+    )
+
   class StyleService(base_api.BaseApiService):
     """Service class for the style resource."""
 
@@ -280,81 +282,6 @@ class FusiontablesV1(base_api.BaseApiClient):
 
     def __init__(self, client):
       super(FusiontablesV1.StyleService, self).__init__(client)
-      self._method_configs = {
-          'Delete': base_api.ApiMethodInfo(
-              http_method=u'DELETE',
-              method_id=u'fusiontables.style.delete',
-              ordered_params=[u'tableId', u'styleId'],
-              path_params=[u'styleId', u'tableId'],
-              query_params=[],
-              relative_path=u'tables/{tableId}/styles/{styleId}',
-              request_field='',
-              request_type_name=u'FusiontablesStyleDeleteRequest',
-              response_type_name=u'FusiontablesStyleDeleteResponse',
-              supports_download=False,
-          ),
-          'Get': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'fusiontables.style.get',
-              ordered_params=[u'tableId', u'styleId'],
-              path_params=[u'styleId', u'tableId'],
-              query_params=[],
-              relative_path=u'tables/{tableId}/styles/{styleId}',
-              request_field='',
-              request_type_name=u'FusiontablesStyleGetRequest',
-              response_type_name=u'StyleSetting',
-              supports_download=False,
-          ),
-          'Insert': base_api.ApiMethodInfo(
-              http_method=u'POST',
-              method_id=u'fusiontables.style.insert',
-              ordered_params=[u'tableId'],
-              path_params=[u'tableId'],
-              query_params=[],
-              relative_path=u'tables/{tableId}/styles',
-              request_field='<request>',
-              request_type_name=u'StyleSetting',
-              response_type_name=u'StyleSetting',
-              supports_download=False,
-          ),
-          'List': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'fusiontables.style.list',
-              ordered_params=[u'tableId'],
-              path_params=[u'tableId'],
-              query_params=[u'maxResults', u'pageToken'],
-              relative_path=u'tables/{tableId}/styles',
-              request_field='',
-              request_type_name=u'FusiontablesStyleListRequest',
-              response_type_name=u'StyleSettingList',
-              supports_download=False,
-          ),
-          'Patch': base_api.ApiMethodInfo(
-              http_method=u'PATCH',
-              method_id=u'fusiontables.style.patch',
-              ordered_params=[u'tableId', u'styleId'],
-              path_params=[u'styleId', u'tableId'],
-              query_params=[],
-              relative_path=u'tables/{tableId}/styles/{styleId}',
-              request_field='<request>',
-              request_type_name=u'StyleSetting',
-              response_type_name=u'StyleSetting',
-              supports_download=False,
-          ),
-          'Update': base_api.ApiMethodInfo(
-              http_method=u'PUT',
-              method_id=u'fusiontables.style.update',
-              ordered_params=[u'tableId', u'styleId'],
-              path_params=[u'styleId', u'tableId'],
-              query_params=[],
-              relative_path=u'tables/{tableId}/styles/{styleId}',
-              request_field='<request>',
-              request_type_name=u'StyleSetting',
-              response_type_name=u'StyleSetting',
-              supports_download=False,
-          ),
-          }
-
       self._upload_configs = {
           }
 
@@ -371,6 +298,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Delete.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'DELETE',
+        method_id=u'fusiontables.style.delete',
+        ordered_params=[u'tableId', u'styleId'],
+        path_params=[u'styleId', u'tableId'],
+        query_params=[],
+        relative_path=u'tables/{tableId}/styles/{styleId}',
+        request_field='',
+        request_type_name=u'FusiontablesStyleDeleteRequest',
+        response_type_name=u'FusiontablesStyleDeleteResponse',
+        supports_download=False,
+    )
+
     def Get(self, request, global_params=None):
       """Gets a specific style.
 
@@ -383,6 +323,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('Get')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    Get.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'fusiontables.style.get',
+        ordered_params=[u'tableId', u'styleId'],
+        path_params=[u'styleId', u'tableId'],
+        query_params=[],
+        relative_path=u'tables/{tableId}/styles/{styleId}',
+        request_field='',
+        request_type_name=u'FusiontablesStyleGetRequest',
+        response_type_name=u'StyleSetting',
+        supports_download=False,
+    )
 
     def Insert(self, request, global_params=None):
       """Adds a new style for the table.
@@ -397,6 +350,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Insert.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'POST',
+        method_id=u'fusiontables.style.insert',
+        ordered_params=[u'tableId'],
+        path_params=[u'tableId'],
+        query_params=[],
+        relative_path=u'tables/{tableId}/styles',
+        request_field='<request>',
+        request_type_name=u'StyleSetting',
+        response_type_name=u'StyleSetting',
+        supports_download=False,
+    )
+
     def List(self, request, global_params=None):
       """Retrieves a list of styles.
 
@@ -409,6 +375,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('List')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    List.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'fusiontables.style.list',
+        ordered_params=[u'tableId'],
+        path_params=[u'tableId'],
+        query_params=[u'maxResults', u'pageToken'],
+        relative_path=u'tables/{tableId}/styles',
+        request_field='',
+        request_type_name=u'FusiontablesStyleListRequest',
+        response_type_name=u'StyleSettingList',
+        supports_download=False,
+    )
 
     def Patch(self, request, global_params=None):
       """Updates an existing style. This method supports patch semantics.
@@ -423,6 +402,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Patch.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'PATCH',
+        method_id=u'fusiontables.style.patch',
+        ordered_params=[u'tableId', u'styleId'],
+        path_params=[u'styleId', u'tableId'],
+        query_params=[],
+        relative_path=u'tables/{tableId}/styles/{styleId}',
+        request_field='<request>',
+        request_type_name=u'StyleSetting',
+        response_type_name=u'StyleSetting',
+        supports_download=False,
+    )
+
     def Update(self, request, global_params=None):
       """Updates an existing style.
 
@@ -436,6 +428,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Update.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'PUT',
+        method_id=u'fusiontables.style.update',
+        ordered_params=[u'tableId', u'styleId'],
+        path_params=[u'styleId', u'tableId'],
+        query_params=[],
+        relative_path=u'tables/{tableId}/styles/{styleId}',
+        request_field='<request>',
+        request_type_name=u'StyleSetting',
+        response_type_name=u'StyleSetting',
+        supports_download=False,
+    )
+
   class TableService(base_api.BaseApiService):
     """Service class for the table resource."""
 
@@ -443,117 +448,6 @@ class FusiontablesV1(base_api.BaseApiClient):
 
     def __init__(self, client):
       super(FusiontablesV1.TableService, self).__init__(client)
-      self._method_configs = {
-          'Copy': base_api.ApiMethodInfo(
-              http_method=u'POST',
-              method_id=u'fusiontables.table.copy',
-              ordered_params=[u'tableId'],
-              path_params=[u'tableId'],
-              query_params=[u'copyPresentation'],
-              relative_path=u'tables/{tableId}/copy',
-              request_field='',
-              request_type_name=u'FusiontablesTableCopyRequest',
-              response_type_name=u'Table',
-              supports_download=False,
-          ),
-          'Delete': base_api.ApiMethodInfo(
-              http_method=u'DELETE',
-              method_id=u'fusiontables.table.delete',
-              ordered_params=[u'tableId'],
-              path_params=[u'tableId'],
-              query_params=[],
-              relative_path=u'tables/{tableId}',
-              request_field='',
-              request_type_name=u'FusiontablesTableDeleteRequest',
-              response_type_name=u'FusiontablesTableDeleteResponse',
-              supports_download=False,
-          ),
-          'Get': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'fusiontables.table.get',
-              ordered_params=[u'tableId'],
-              path_params=[u'tableId'],
-              query_params=[],
-              relative_path=u'tables/{tableId}',
-              request_field='',
-              request_type_name=u'FusiontablesTableGetRequest',
-              response_type_name=u'Table',
-              supports_download=False,
-          ),
-          'ImportRows': base_api.ApiMethodInfo(
-              http_method=u'POST',
-              method_id=u'fusiontables.table.importRows',
-              ordered_params=[u'tableId'],
-              path_params=[u'tableId'],
-              query_params=[u'delimiter', u'encoding', u'endLine', u'isStrict', u'startLine'],
-              relative_path=u'tables/{tableId}/import',
-              request_field='',
-              request_type_name=u'FusiontablesTableImportRowsRequest',
-              response_type_name=u'Import',
-              supports_download=False,
-          ),
-          'ImportTable': base_api.ApiMethodInfo(
-              http_method=u'POST',
-              method_id=u'fusiontables.table.importTable',
-              ordered_params=[u'name'],
-              path_params=[],
-              query_params=[u'delimiter', u'encoding', u'name'],
-              relative_path=u'tables/import',
-              request_field='',
-              request_type_name=u'FusiontablesTableImportTableRequest',
-              response_type_name=u'Table',
-              supports_download=False,
-          ),
-          'Insert': base_api.ApiMethodInfo(
-              http_method=u'POST',
-              method_id=u'fusiontables.table.insert',
-              ordered_params=[],
-              path_params=[],
-              query_params=[],
-              relative_path=u'tables',
-              request_field='<request>',
-              request_type_name=u'Table',
-              response_type_name=u'Table',
-              supports_download=False,
-          ),
-          'List': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'fusiontables.table.list',
-              ordered_params=[],
-              path_params=[],
-              query_params=[u'maxResults', u'pageToken'],
-              relative_path=u'tables',
-              request_field='',
-              request_type_name=u'FusiontablesTableListRequest',
-              response_type_name=u'TableList',
-              supports_download=False,
-          ),
-          'Patch': base_api.ApiMethodInfo(
-              http_method=u'PATCH',
-              method_id=u'fusiontables.table.patch',
-              ordered_params=[u'tableId'],
-              path_params=[u'tableId'],
-              query_params=[u'replaceViewDefinition'],
-              relative_path=u'tables/{tableId}',
-              request_field=u'table',
-              request_type_name=u'FusiontablesTablePatchRequest',
-              response_type_name=u'Table',
-              supports_download=False,
-          ),
-          'Update': base_api.ApiMethodInfo(
-              http_method=u'PUT',
-              method_id=u'fusiontables.table.update',
-              ordered_params=[u'tableId'],
-              path_params=[u'tableId'],
-              query_params=[u'replaceViewDefinition'],
-              relative_path=u'tables/{tableId}',
-              request_field=u'table',
-              request_type_name=u'FusiontablesTableUpdateRequest',
-              response_type_name=u'Table',
-              supports_download=False,
-          ),
-          }
-
       self._upload_configs = {
           'ImportRows': base_api.ApiUploadInfo(
               accept=['application/octet-stream'],
@@ -586,6 +480,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Copy.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'POST',
+        method_id=u'fusiontables.table.copy',
+        ordered_params=[u'tableId'],
+        path_params=[u'tableId'],
+        query_params=[u'copyPresentation'],
+        relative_path=u'tables/{tableId}/copy',
+        request_field='',
+        request_type_name=u'FusiontablesTableCopyRequest',
+        response_type_name=u'Table',
+        supports_download=False,
+    )
+
     def Delete(self, request, global_params=None):
       """Deletes a table.
 
@@ -599,6 +506,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Delete.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'DELETE',
+        method_id=u'fusiontables.table.delete',
+        ordered_params=[u'tableId'],
+        path_params=[u'tableId'],
+        query_params=[],
+        relative_path=u'tables/{tableId}',
+        request_field='',
+        request_type_name=u'FusiontablesTableDeleteRequest',
+        response_type_name=u'FusiontablesTableDeleteResponse',
+        supports_download=False,
+    )
+
     def Get(self, request, global_params=None):
       """Retrieves a specific table by its id.
 
@@ -611,6 +531,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('Get')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    Get.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'fusiontables.table.get',
+        ordered_params=[u'tableId'],
+        path_params=[u'tableId'],
+        query_params=[],
+        relative_path=u'tables/{tableId}',
+        request_field='',
+        request_type_name=u'FusiontablesTableGetRequest',
+        response_type_name=u'Table',
+        supports_download=False,
+    )
 
     def ImportRows(self, request, global_params=None, upload=None):
       """Import more rows into a table.
@@ -629,6 +562,19 @@ class FusiontablesV1(base_api.BaseApiClient):
           config, request, global_params=global_params,
           upload=upload, upload_config=upload_config)
 
+    ImportRows.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'POST',
+        method_id=u'fusiontables.table.importRows',
+        ordered_params=[u'tableId'],
+        path_params=[u'tableId'],
+        query_params=[u'delimiter', u'encoding', u'endLine', u'isStrict', u'startLine'],
+        relative_path=u'tables/{tableId}/import',
+        request_field='',
+        request_type_name=u'FusiontablesTableImportRowsRequest',
+        response_type_name=u'Import',
+        supports_download=False,
+    )
+
     def ImportTable(self, request, global_params=None, upload=None):
       """Import a new table.
 
@@ -646,6 +592,19 @@ class FusiontablesV1(base_api.BaseApiClient):
           config, request, global_params=global_params,
           upload=upload, upload_config=upload_config)
 
+    ImportTable.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'POST',
+        method_id=u'fusiontables.table.importTable',
+        ordered_params=[u'name'],
+        path_params=[],
+        query_params=[u'delimiter', u'encoding', u'name'],
+        relative_path=u'tables/import',
+        request_field='',
+        request_type_name=u'FusiontablesTableImportTableRequest',
+        response_type_name=u'Table',
+        supports_download=False,
+    )
+
     def Insert(self, request, global_params=None):
       """Creates a new table.
 
@@ -658,6 +617,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('Insert')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    Insert.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'POST',
+        method_id=u'fusiontables.table.insert',
+        ordered_params=[],
+        path_params=[],
+        query_params=[],
+        relative_path=u'tables',
+        request_field='<request>',
+        request_type_name=u'Table',
+        response_type_name=u'Table',
+        supports_download=False,
+    )
 
     def List(self, request, global_params=None):
       """Retrieves a list of tables a user owns.
@@ -672,6 +644,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    List.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'fusiontables.table.list',
+        ordered_params=[],
+        path_params=[],
+        query_params=[u'maxResults', u'pageToken'],
+        relative_path=u'tables',
+        request_field='',
+        request_type_name=u'FusiontablesTableListRequest',
+        response_type_name=u'TableList',
+        supports_download=False,
+    )
+
     def Patch(self, request, global_params=None):
       """Updates an existing table. Unless explicitly requested, only the name, description, and attribution will be updated. This method supports patch semantics.
 
@@ -684,6 +669,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('Patch')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    Patch.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'PATCH',
+        method_id=u'fusiontables.table.patch',
+        ordered_params=[u'tableId'],
+        path_params=[u'tableId'],
+        query_params=[u'replaceViewDefinition'],
+        relative_path=u'tables/{tableId}',
+        request_field=u'table',
+        request_type_name=u'FusiontablesTablePatchRequest',
+        response_type_name=u'Table',
+        supports_download=False,
+    )
 
     def Update(self, request, global_params=None):
       """Updates an existing table. Unless explicitly requested, only the name, description, and attribution will be updated.
@@ -698,6 +696,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Update.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'PUT',
+        method_id=u'fusiontables.table.update',
+        ordered_params=[u'tableId'],
+        path_params=[u'tableId'],
+        query_params=[u'replaceViewDefinition'],
+        relative_path=u'tables/{tableId}',
+        request_field=u'table',
+        request_type_name=u'FusiontablesTableUpdateRequest',
+        response_type_name=u'Table',
+        supports_download=False,
+    )
+
   class TaskService(base_api.BaseApiService):
     """Service class for the task resource."""
 
@@ -705,45 +716,6 @@ class FusiontablesV1(base_api.BaseApiClient):
 
     def __init__(self, client):
       super(FusiontablesV1.TaskService, self).__init__(client)
-      self._method_configs = {
-          'Delete': base_api.ApiMethodInfo(
-              http_method=u'DELETE',
-              method_id=u'fusiontables.task.delete',
-              ordered_params=[u'tableId', u'taskId'],
-              path_params=[u'tableId', u'taskId'],
-              query_params=[],
-              relative_path=u'tables/{tableId}/tasks/{taskId}',
-              request_field='',
-              request_type_name=u'FusiontablesTaskDeleteRequest',
-              response_type_name=u'FusiontablesTaskDeleteResponse',
-              supports_download=False,
-          ),
-          'Get': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'fusiontables.task.get',
-              ordered_params=[u'tableId', u'taskId'],
-              path_params=[u'tableId', u'taskId'],
-              query_params=[],
-              relative_path=u'tables/{tableId}/tasks/{taskId}',
-              request_field='',
-              request_type_name=u'FusiontablesTaskGetRequest',
-              response_type_name=u'Task',
-              supports_download=False,
-          ),
-          'List': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'fusiontables.task.list',
-              ordered_params=[u'tableId'],
-              path_params=[u'tableId'],
-              query_params=[u'maxResults', u'pageToken', u'startIndex'],
-              relative_path=u'tables/{tableId}/tasks',
-              request_field='',
-              request_type_name=u'FusiontablesTaskListRequest',
-              response_type_name=u'TaskList',
-              supports_download=False,
-          ),
-          }
-
       self._upload_configs = {
           }
 
@@ -760,6 +732,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Delete.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'DELETE',
+        method_id=u'fusiontables.task.delete',
+        ordered_params=[u'tableId', u'taskId'],
+        path_params=[u'tableId', u'taskId'],
+        query_params=[],
+        relative_path=u'tables/{tableId}/tasks/{taskId}',
+        request_field='',
+        request_type_name=u'FusiontablesTaskDeleteRequest',
+        response_type_name=u'FusiontablesTaskDeleteResponse',
+        supports_download=False,
+    )
+
     def Get(self, request, global_params=None):
       """Retrieves a specific task by its id.
 
@@ -772,6 +757,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('Get')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    Get.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'fusiontables.task.get',
+        ordered_params=[u'tableId', u'taskId'],
+        path_params=[u'tableId', u'taskId'],
+        query_params=[],
+        relative_path=u'tables/{tableId}/tasks/{taskId}',
+        request_field='',
+        request_type_name=u'FusiontablesTaskGetRequest',
+        response_type_name=u'Task',
+        supports_download=False,
+    )
 
     def List(self, request, global_params=None):
       """Retrieves a list of tasks.
@@ -786,6 +784,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    List.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'fusiontables.task.list',
+        ordered_params=[u'tableId'],
+        path_params=[u'tableId'],
+        query_params=[u'maxResults', u'pageToken', u'startIndex'],
+        relative_path=u'tables/{tableId}/tasks',
+        request_field='',
+        request_type_name=u'FusiontablesTaskListRequest',
+        response_type_name=u'TaskList',
+        supports_download=False,
+    )
+
   class TemplateService(base_api.BaseApiService):
     """Service class for the template resource."""
 
@@ -793,81 +804,6 @@ class FusiontablesV1(base_api.BaseApiClient):
 
     def __init__(self, client):
       super(FusiontablesV1.TemplateService, self).__init__(client)
-      self._method_configs = {
-          'Delete': base_api.ApiMethodInfo(
-              http_method=u'DELETE',
-              method_id=u'fusiontables.template.delete',
-              ordered_params=[u'tableId', u'templateId'],
-              path_params=[u'tableId', u'templateId'],
-              query_params=[],
-              relative_path=u'tables/{tableId}/templates/{templateId}',
-              request_field='',
-              request_type_name=u'FusiontablesTemplateDeleteRequest',
-              response_type_name=u'FusiontablesTemplateDeleteResponse',
-              supports_download=False,
-          ),
-          'Get': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'fusiontables.template.get',
-              ordered_params=[u'tableId', u'templateId'],
-              path_params=[u'tableId', u'templateId'],
-              query_params=[],
-              relative_path=u'tables/{tableId}/templates/{templateId}',
-              request_field='',
-              request_type_name=u'FusiontablesTemplateGetRequest',
-              response_type_name=u'Template',
-              supports_download=False,
-          ),
-          'Insert': base_api.ApiMethodInfo(
-              http_method=u'POST',
-              method_id=u'fusiontables.template.insert',
-              ordered_params=[u'tableId'],
-              path_params=[u'tableId'],
-              query_params=[],
-              relative_path=u'tables/{tableId}/templates',
-              request_field='<request>',
-              request_type_name=u'Template',
-              response_type_name=u'Template',
-              supports_download=False,
-          ),
-          'List': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'fusiontables.template.list',
-              ordered_params=[u'tableId'],
-              path_params=[u'tableId'],
-              query_params=[u'maxResults', u'pageToken'],
-              relative_path=u'tables/{tableId}/templates',
-              request_field='',
-              request_type_name=u'FusiontablesTemplateListRequest',
-              response_type_name=u'TemplateList',
-              supports_download=False,
-          ),
-          'Patch': base_api.ApiMethodInfo(
-              http_method=u'PATCH',
-              method_id=u'fusiontables.template.patch',
-              ordered_params=[u'tableId', u'templateId'],
-              path_params=[u'tableId', u'templateId'],
-              query_params=[],
-              relative_path=u'tables/{tableId}/templates/{templateId}',
-              request_field='<request>',
-              request_type_name=u'Template',
-              response_type_name=u'Template',
-              supports_download=False,
-          ),
-          'Update': base_api.ApiMethodInfo(
-              http_method=u'PUT',
-              method_id=u'fusiontables.template.update',
-              ordered_params=[u'tableId', u'templateId'],
-              path_params=[u'tableId', u'templateId'],
-              query_params=[],
-              relative_path=u'tables/{tableId}/templates/{templateId}',
-              request_field='<request>',
-              request_type_name=u'Template',
-              response_type_name=u'Template',
-              supports_download=False,
-          ),
-          }
-
       self._upload_configs = {
           }
 
@@ -884,6 +820,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Delete.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'DELETE',
+        method_id=u'fusiontables.template.delete',
+        ordered_params=[u'tableId', u'templateId'],
+        path_params=[u'tableId', u'templateId'],
+        query_params=[],
+        relative_path=u'tables/{tableId}/templates/{templateId}',
+        request_field='',
+        request_type_name=u'FusiontablesTemplateDeleteRequest',
+        response_type_name=u'FusiontablesTemplateDeleteResponse',
+        supports_download=False,
+    )
+
     def Get(self, request, global_params=None):
       """Retrieves a specific template by its id.
 
@@ -896,6 +845,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('Get')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    Get.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'fusiontables.template.get',
+        ordered_params=[u'tableId', u'templateId'],
+        path_params=[u'tableId', u'templateId'],
+        query_params=[],
+        relative_path=u'tables/{tableId}/templates/{templateId}',
+        request_field='',
+        request_type_name=u'FusiontablesTemplateGetRequest',
+        response_type_name=u'Template',
+        supports_download=False,
+    )
 
     def Insert(self, request, global_params=None):
       """Creates a new template for the table.
@@ -910,6 +872,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Insert.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'POST',
+        method_id=u'fusiontables.template.insert',
+        ordered_params=[u'tableId'],
+        path_params=[u'tableId'],
+        query_params=[],
+        relative_path=u'tables/{tableId}/templates',
+        request_field='<request>',
+        request_type_name=u'Template',
+        response_type_name=u'Template',
+        supports_download=False,
+    )
+
     def List(self, request, global_params=None):
       """Retrieves a list of templates.
 
@@ -922,6 +897,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('List')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    List.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'fusiontables.template.list',
+        ordered_params=[u'tableId'],
+        path_params=[u'tableId'],
+        query_params=[u'maxResults', u'pageToken'],
+        relative_path=u'tables/{tableId}/templates',
+        request_field='',
+        request_type_name=u'FusiontablesTemplateListRequest',
+        response_type_name=u'TemplateList',
+        supports_download=False,
+    )
 
     def Patch(self, request, global_params=None):
       """Updates an existing template. This method supports patch semantics.
@@ -936,6 +924,19 @@ class FusiontablesV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Patch.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'PATCH',
+        method_id=u'fusiontables.template.patch',
+        ordered_params=[u'tableId', u'templateId'],
+        path_params=[u'tableId', u'templateId'],
+        query_params=[],
+        relative_path=u'tables/{tableId}/templates/{templateId}',
+        request_field='<request>',
+        request_type_name=u'Template',
+        response_type_name=u'Template',
+        supports_download=False,
+    )
+
     def Update(self, request, global_params=None):
       """Updates an existing template.
 
@@ -948,3 +949,16 @@ class FusiontablesV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('Update')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    Update.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'PUT',
+        method_id=u'fusiontables.template.update',
+        ordered_params=[u'tableId', u'templateId'],
+        path_params=[u'tableId', u'templateId'],
+        query_params=[],
+        relative_path=u'tables/{tableId}/templates/{templateId}',
+        request_field='<request>',
+        request_type_name=u'Template',
+        response_type_name=u'Template',
+        supports_download=False,
+    )

--- a/samples/iam_sample/iam_v1/iam_v1_client.py
+++ b/samples/iam_sample/iam_v1/iam_v1_client.py
@@ -47,21 +47,6 @@ class IamV1(base_api.BaseApiClient):
 
     def __init__(self, client):
       super(IamV1.IamPoliciesService, self).__init__(client)
-      self._method_configs = {
-          'GetPolicyDetails': base_api.ApiMethodInfo(
-              http_method=u'POST',
-              method_id=u'iam.iamPolicies.getPolicyDetails',
-              ordered_params=[],
-              path_params=[],
-              query_params=[],
-              relative_path=u'v1/iamPolicies:getPolicyDetails',
-              request_field='<request>',
-              request_type_name=u'GetPolicyDetailsRequest',
-              response_type_name=u'GetPolicyDetailsResponse',
-              supports_download=False,
-          ),
-          }
-
       self._upload_configs = {
           }
 
@@ -79,6 +64,19 @@ that the user has access to.
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    GetPolicyDetails.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'POST',
+        method_id=u'iam.iamPolicies.getPolicyDetails',
+        ordered_params=[],
+        path_params=[],
+        query_params=[],
+        relative_path=u'v1/iamPolicies:getPolicyDetails',
+        request_field='<request>',
+        request_type_name=u'GetPolicyDetailsRequest',
+        response_type_name=u'GetPolicyDetailsResponse',
+        supports_download=False,
+    )
+
   class ProjectsServiceAccountsKeysService(base_api.BaseApiService):
     """Service class for the projects_serviceAccounts_keys resource."""
 
@@ -86,61 +84,6 @@ that the user has access to.
 
     def __init__(self, client):
       super(IamV1.ProjectsServiceAccountsKeysService, self).__init__(client)
-      self._method_configs = {
-          'Create': base_api.ApiMethodInfo(
-              flat_path=u'v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}/keys',
-              http_method=u'POST',
-              method_id=u'iam.projects.serviceAccounts.keys.create',
-              ordered_params=[u'name'],
-              path_params=[u'name'],
-              query_params=[],
-              relative_path=u'v1/{+name}/keys',
-              request_field=u'createServiceAccountKeyRequest',
-              request_type_name=u'IamProjectsServiceAccountsKeysCreateRequest',
-              response_type_name=u'ServiceAccountKey',
-              supports_download=False,
-          ),
-          'Delete': base_api.ApiMethodInfo(
-              flat_path=u'v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}/keys/{keysId}',
-              http_method=u'DELETE',
-              method_id=u'iam.projects.serviceAccounts.keys.delete',
-              ordered_params=[u'name'],
-              path_params=[u'name'],
-              query_params=[],
-              relative_path=u'v1/{+name}',
-              request_field='',
-              request_type_name=u'IamProjectsServiceAccountsKeysDeleteRequest',
-              response_type_name=u'Empty',
-              supports_download=False,
-          ),
-          'Get': base_api.ApiMethodInfo(
-              flat_path=u'v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}/keys/{keysId}',
-              http_method=u'GET',
-              method_id=u'iam.projects.serviceAccounts.keys.get',
-              ordered_params=[u'name'],
-              path_params=[u'name'],
-              query_params=[u'publicKeyType'],
-              relative_path=u'v1/{+name}',
-              request_field='',
-              request_type_name=u'IamProjectsServiceAccountsKeysGetRequest',
-              response_type_name=u'ServiceAccountKey',
-              supports_download=False,
-          ),
-          'List': base_api.ApiMethodInfo(
-              flat_path=u'v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}/keys',
-              http_method=u'GET',
-              method_id=u'iam.projects.serviceAccounts.keys.list',
-              ordered_params=[u'name'],
-              path_params=[u'name'],
-              query_params=[u'keyTypes'],
-              relative_path=u'v1/{+name}/keys',
-              request_field='',
-              request_type_name=u'IamProjectsServiceAccountsKeysListRequest',
-              response_type_name=u'ListServiceAccountKeysResponse',
-              supports_download=False,
-          ),
-          }
-
       self._upload_configs = {
           }
 
@@ -158,6 +101,20 @@ and returns it.
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Create.method_config = lambda: base_api.ApiMethodInfo(
+        flat_path=u'v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}/keys',
+        http_method=u'POST',
+        method_id=u'iam.projects.serviceAccounts.keys.create',
+        ordered_params=[u'name'],
+        path_params=[u'name'],
+        query_params=[],
+        relative_path=u'v1/{+name}/keys',
+        request_field=u'createServiceAccountKeyRequest',
+        request_type_name=u'IamProjectsServiceAccountsKeysCreateRequest',
+        response_type_name=u'ServiceAccountKey',
+        supports_download=False,
+    )
+
     def Delete(self, request, global_params=None):
       """Deletes a ServiceAccountKey.
 
@@ -170,6 +127,20 @@ and returns it.
       config = self.GetMethodConfig('Delete')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    Delete.method_config = lambda: base_api.ApiMethodInfo(
+        flat_path=u'v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}/keys/{keysId}',
+        http_method=u'DELETE',
+        method_id=u'iam.projects.serviceAccounts.keys.delete',
+        ordered_params=[u'name'],
+        path_params=[u'name'],
+        query_params=[],
+        relative_path=u'v1/{+name}',
+        request_field='',
+        request_type_name=u'IamProjectsServiceAccountsKeysDeleteRequest',
+        response_type_name=u'Empty',
+        supports_download=False,
+    )
 
     def Get(self, request, global_params=None):
       """Gets the ServiceAccountKey.
@@ -185,6 +156,20 @@ by key id.
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Get.method_config = lambda: base_api.ApiMethodInfo(
+        flat_path=u'v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}/keys/{keysId}',
+        http_method=u'GET',
+        method_id=u'iam.projects.serviceAccounts.keys.get',
+        ordered_params=[u'name'],
+        path_params=[u'name'],
+        query_params=[u'publicKeyType'],
+        relative_path=u'v1/{+name}',
+        request_field='',
+        request_type_name=u'IamProjectsServiceAccountsKeysGetRequest',
+        response_type_name=u'ServiceAccountKey',
+        supports_download=False,
+    )
+
     def List(self, request, global_params=None):
       """Lists ServiceAccountKeys.
 
@@ -198,6 +183,20 @@ by key id.
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    List.method_config = lambda: base_api.ApiMethodInfo(
+        flat_path=u'v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}/keys',
+        http_method=u'GET',
+        method_id=u'iam.projects.serviceAccounts.keys.list',
+        ordered_params=[u'name'],
+        path_params=[u'name'],
+        query_params=[u'keyTypes'],
+        relative_path=u'v1/{+name}/keys',
+        request_field='',
+        request_type_name=u'IamProjectsServiceAccountsKeysListRequest',
+        response_type_name=u'ListServiceAccountKeysResponse',
+        supports_download=False,
+    )
+
   class ProjectsServiceAccountsService(base_api.BaseApiService):
     """Service class for the projects_serviceAccounts resource."""
 
@@ -205,139 +204,6 @@ by key id.
 
     def __init__(self, client):
       super(IamV1.ProjectsServiceAccountsService, self).__init__(client)
-      self._method_configs = {
-          'Create': base_api.ApiMethodInfo(
-              flat_path=u'v1/projects/{projectsId}/serviceAccounts',
-              http_method=u'POST',
-              method_id=u'iam.projects.serviceAccounts.create',
-              ordered_params=[u'name'],
-              path_params=[u'name'],
-              query_params=[],
-              relative_path=u'v1/{+name}/serviceAccounts',
-              request_field=u'createServiceAccountRequest',
-              request_type_name=u'IamProjectsServiceAccountsCreateRequest',
-              response_type_name=u'ServiceAccount',
-              supports_download=False,
-          ),
-          'Delete': base_api.ApiMethodInfo(
-              flat_path=u'v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}',
-              http_method=u'DELETE',
-              method_id=u'iam.projects.serviceAccounts.delete',
-              ordered_params=[u'name'],
-              path_params=[u'name'],
-              query_params=[],
-              relative_path=u'v1/{+name}',
-              request_field='',
-              request_type_name=u'IamProjectsServiceAccountsDeleteRequest',
-              response_type_name=u'Empty',
-              supports_download=False,
-          ),
-          'Get': base_api.ApiMethodInfo(
-              flat_path=u'v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}',
-              http_method=u'GET',
-              method_id=u'iam.projects.serviceAccounts.get',
-              ordered_params=[u'name'],
-              path_params=[u'name'],
-              query_params=[],
-              relative_path=u'v1/{+name}',
-              request_field='',
-              request_type_name=u'IamProjectsServiceAccountsGetRequest',
-              response_type_name=u'ServiceAccount',
-              supports_download=False,
-          ),
-          'GetIamPolicy': base_api.ApiMethodInfo(
-              flat_path=u'v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}:getIamPolicy',
-              http_method=u'POST',
-              method_id=u'iam.projects.serviceAccounts.getIamPolicy',
-              ordered_params=[u'resource'],
-              path_params=[u'resource'],
-              query_params=[],
-              relative_path=u'v1/{+resource}:getIamPolicy',
-              request_field='',
-              request_type_name=u'IamProjectsServiceAccountsGetIamPolicyRequest',
-              response_type_name=u'Policy',
-              supports_download=False,
-          ),
-          'List': base_api.ApiMethodInfo(
-              flat_path=u'v1/projects/{projectsId}/serviceAccounts',
-              http_method=u'GET',
-              method_id=u'iam.projects.serviceAccounts.list',
-              ordered_params=[u'name'],
-              path_params=[u'name'],
-              query_params=[u'pageSize', u'pageToken', u'removeDeletedServiceAccounts'],
-              relative_path=u'v1/{+name}/serviceAccounts',
-              request_field='',
-              request_type_name=u'IamProjectsServiceAccountsListRequest',
-              response_type_name=u'ListServiceAccountsResponse',
-              supports_download=False,
-          ),
-          'SetIamPolicy': base_api.ApiMethodInfo(
-              flat_path=u'v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}:setIamPolicy',
-              http_method=u'POST',
-              method_id=u'iam.projects.serviceAccounts.setIamPolicy',
-              ordered_params=[u'resource'],
-              path_params=[u'resource'],
-              query_params=[],
-              relative_path=u'v1/{+resource}:setIamPolicy',
-              request_field=u'setIamPolicyRequest',
-              request_type_name=u'IamProjectsServiceAccountsSetIamPolicyRequest',
-              response_type_name=u'Policy',
-              supports_download=False,
-          ),
-          'SignBlob': base_api.ApiMethodInfo(
-              flat_path=u'v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}:signBlob',
-              http_method=u'POST',
-              method_id=u'iam.projects.serviceAccounts.signBlob',
-              ordered_params=[u'name'],
-              path_params=[u'name'],
-              query_params=[],
-              relative_path=u'v1/{+name}:signBlob',
-              request_field=u'signBlobRequest',
-              request_type_name=u'IamProjectsServiceAccountsSignBlobRequest',
-              response_type_name=u'SignBlobResponse',
-              supports_download=False,
-          ),
-          'SignJwt': base_api.ApiMethodInfo(
-              flat_path=u'v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}:signJwt',
-              http_method=u'POST',
-              method_id=u'iam.projects.serviceAccounts.signJwt',
-              ordered_params=[u'name'],
-              path_params=[u'name'],
-              query_params=[],
-              relative_path=u'v1/{+name}:signJwt',
-              request_field=u'signJwtRequest',
-              request_type_name=u'IamProjectsServiceAccountsSignJwtRequest',
-              response_type_name=u'SignJwtResponse',
-              supports_download=False,
-          ),
-          'TestIamPermissions': base_api.ApiMethodInfo(
-              flat_path=u'v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}:testIamPermissions',
-              http_method=u'POST',
-              method_id=u'iam.projects.serviceAccounts.testIamPermissions',
-              ordered_params=[u'resource'],
-              path_params=[u'resource'],
-              query_params=[],
-              relative_path=u'v1/{+resource}:testIamPermissions',
-              request_field=u'testIamPermissionsRequest',
-              request_type_name=u'IamProjectsServiceAccountsTestIamPermissionsRequest',
-              response_type_name=u'TestIamPermissionsResponse',
-              supports_download=False,
-          ),
-          'Update': base_api.ApiMethodInfo(
-              flat_path=u'v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}',
-              http_method=u'PUT',
-              method_id=u'iam.projects.serviceAccounts.update',
-              ordered_params=[u'name'],
-              path_params=[u'name'],
-              query_params=[],
-              relative_path=u'v1/{+name}',
-              request_field='<request>',
-              request_type_name=u'ServiceAccount',
-              response_type_name=u'ServiceAccount',
-              supports_download=False,
-          ),
-          }
-
       self._upload_configs = {
           }
 
@@ -355,6 +221,20 @@ and returns it.
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Create.method_config = lambda: base_api.ApiMethodInfo(
+        flat_path=u'v1/projects/{projectsId}/serviceAccounts',
+        http_method=u'POST',
+        method_id=u'iam.projects.serviceAccounts.create',
+        ordered_params=[u'name'],
+        path_params=[u'name'],
+        query_params=[],
+        relative_path=u'v1/{+name}/serviceAccounts',
+        request_field=u'createServiceAccountRequest',
+        request_type_name=u'IamProjectsServiceAccountsCreateRequest',
+        response_type_name=u'ServiceAccount',
+        supports_download=False,
+    )
+
     def Delete(self, request, global_params=None):
       """Deletes a ServiceAccount.
 
@@ -367,6 +247,20 @@ and returns it.
       config = self.GetMethodConfig('Delete')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    Delete.method_config = lambda: base_api.ApiMethodInfo(
+        flat_path=u'v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}',
+        http_method=u'DELETE',
+        method_id=u'iam.projects.serviceAccounts.delete',
+        ordered_params=[u'name'],
+        path_params=[u'name'],
+        query_params=[],
+        relative_path=u'v1/{+name}',
+        request_field='',
+        request_type_name=u'IamProjectsServiceAccountsDeleteRequest',
+        response_type_name=u'Empty',
+        supports_download=False,
+    )
 
     def Get(self, request, global_params=None):
       """Gets a ServiceAccount.
@@ -381,6 +275,20 @@ and returns it.
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Get.method_config = lambda: base_api.ApiMethodInfo(
+        flat_path=u'v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}',
+        http_method=u'GET',
+        method_id=u'iam.projects.serviceAccounts.get',
+        ordered_params=[u'name'],
+        path_params=[u'name'],
+        query_params=[],
+        relative_path=u'v1/{+name}',
+        request_field='',
+        request_type_name=u'IamProjectsServiceAccountsGetRequest',
+        response_type_name=u'ServiceAccount',
+        supports_download=False,
+    )
+
     def GetIamPolicy(self, request, global_params=None):
       """Returns the IAM access control policy for specified IAM resource.
 
@@ -393,6 +301,20 @@ and returns it.
       config = self.GetMethodConfig('GetIamPolicy')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    GetIamPolicy.method_config = lambda: base_api.ApiMethodInfo(
+        flat_path=u'v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}:getIamPolicy',
+        http_method=u'POST',
+        method_id=u'iam.projects.serviceAccounts.getIamPolicy',
+        ordered_params=[u'resource'],
+        path_params=[u'resource'],
+        query_params=[],
+        relative_path=u'v1/{+resource}:getIamPolicy',
+        request_field='',
+        request_type_name=u'IamProjectsServiceAccountsGetIamPolicyRequest',
+        response_type_name=u'Policy',
+        supports_download=False,
+    )
 
     def List(self, request, global_params=None):
       """Lists ServiceAccounts for a project.
@@ -407,6 +329,20 @@ and returns it.
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    List.method_config = lambda: base_api.ApiMethodInfo(
+        flat_path=u'v1/projects/{projectsId}/serviceAccounts',
+        http_method=u'GET',
+        method_id=u'iam.projects.serviceAccounts.list',
+        ordered_params=[u'name'],
+        path_params=[u'name'],
+        query_params=[u'pageSize', u'pageToken', u'removeDeletedServiceAccounts'],
+        relative_path=u'v1/{+name}/serviceAccounts',
+        request_field='',
+        request_type_name=u'IamProjectsServiceAccountsListRequest',
+        response_type_name=u'ListServiceAccountsResponse',
+        supports_download=False,
+    )
+
     def SetIamPolicy(self, request, global_params=None):
       """Sets the IAM access control policy for the specified IAM resource.
 
@@ -420,6 +356,20 @@ and returns it.
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    SetIamPolicy.method_config = lambda: base_api.ApiMethodInfo(
+        flat_path=u'v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}:setIamPolicy',
+        http_method=u'POST',
+        method_id=u'iam.projects.serviceAccounts.setIamPolicy',
+        ordered_params=[u'resource'],
+        path_params=[u'resource'],
+        query_params=[],
+        relative_path=u'v1/{+resource}:setIamPolicy',
+        request_field=u'setIamPolicyRequest',
+        request_type_name=u'IamProjectsServiceAccountsSetIamPolicyRequest',
+        response_type_name=u'Policy',
+        supports_download=False,
+    )
+
     def SignBlob(self, request, global_params=None):
       """Signs a blob using a service account's system-managed private key.
 
@@ -432,6 +382,20 @@ and returns it.
       config = self.GetMethodConfig('SignBlob')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    SignBlob.method_config = lambda: base_api.ApiMethodInfo(
+        flat_path=u'v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}:signBlob',
+        http_method=u'POST',
+        method_id=u'iam.projects.serviceAccounts.signBlob',
+        ordered_params=[u'name'],
+        path_params=[u'name'],
+        query_params=[],
+        relative_path=u'v1/{+name}:signBlob',
+        request_field=u'signBlobRequest',
+        request_type_name=u'IamProjectsServiceAccountsSignBlobRequest',
+        response_type_name=u'SignBlobResponse',
+        supports_download=False,
+    )
 
     def SignJwt(self, request, global_params=None):
       """Signs a JWT using a service account's system-managed private key.
@@ -451,6 +415,20 @@ will fail.
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    SignJwt.method_config = lambda: base_api.ApiMethodInfo(
+        flat_path=u'v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}:signJwt',
+        http_method=u'POST',
+        method_id=u'iam.projects.serviceAccounts.signJwt',
+        ordered_params=[u'name'],
+        path_params=[u'name'],
+        query_params=[],
+        relative_path=u'v1/{+name}:signJwt',
+        request_field=u'signJwtRequest',
+        request_type_name=u'IamProjectsServiceAccountsSignJwtRequest',
+        response_type_name=u'SignJwtResponse',
+        supports_download=False,
+    )
+
     def TestIamPermissions(self, request, global_params=None):
       """Tests the specified permissions against the IAM access control policy.
 for the specified IAM resource.
@@ -464,6 +442,20 @@ for the specified IAM resource.
       config = self.GetMethodConfig('TestIamPermissions')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    TestIamPermissions.method_config = lambda: base_api.ApiMethodInfo(
+        flat_path=u'v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}:testIamPermissions',
+        http_method=u'POST',
+        method_id=u'iam.projects.serviceAccounts.testIamPermissions',
+        ordered_params=[u'resource'],
+        path_params=[u'resource'],
+        query_params=[],
+        relative_path=u'v1/{+resource}:testIamPermissions',
+        request_field=u'testIamPermissionsRequest',
+        request_type_name=u'IamProjectsServiceAccountsTestIamPermissionsRequest',
+        response_type_name=u'TestIamPermissionsResponse',
+        supports_download=False,
+    )
 
     def Update(self, request, global_params=None):
       """Updates a ServiceAccount.
@@ -482,6 +474,20 @@ The `etag` is mandatory.
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Update.method_config = lambda: base_api.ApiMethodInfo(
+        flat_path=u'v1/projects/{projectsId}/serviceAccounts/{serviceAccountsId}',
+        http_method=u'PUT',
+        method_id=u'iam.projects.serviceAccounts.update',
+        ordered_params=[u'name'],
+        path_params=[u'name'],
+        query_params=[],
+        relative_path=u'v1/{+name}',
+        request_field='<request>',
+        request_type_name=u'ServiceAccount',
+        response_type_name=u'ServiceAccount',
+        supports_download=False,
+    )
+
   class ProjectsService(base_api.BaseApiService):
     """Service class for the projects resource."""
 
@@ -489,9 +495,6 @@ The `etag` is mandatory.
 
     def __init__(self, client):
       super(IamV1.ProjectsService, self).__init__(client)
-      self._method_configs = {
-          }
-
       self._upload_configs = {
           }
 
@@ -502,21 +505,6 @@ The `etag` is mandatory.
 
     def __init__(self, client):
       super(IamV1.RolesService, self).__init__(client)
-      self._method_configs = {
-          'QueryGrantableRoles': base_api.ApiMethodInfo(
-              http_method=u'POST',
-              method_id=u'iam.roles.queryGrantableRoles',
-              ordered_params=[],
-              path_params=[],
-              query_params=[],
-              relative_path=u'v1/roles:queryGrantableRoles',
-              request_field='<request>',
-              request_type_name=u'QueryGrantableRolesRequest',
-              response_type_name=u'QueryGrantableRolesResponse',
-              supports_download=False,
-          ),
-          }
-
       self._upload_configs = {
           }
 
@@ -532,3 +520,16 @@ The `etag` is mandatory.
       config = self.GetMethodConfig('QueryGrantableRoles')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    QueryGrantableRoles.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'POST',
+        method_id=u'iam.roles.queryGrantableRoles',
+        ordered_params=[],
+        path_params=[],
+        query_params=[],
+        relative_path=u'v1/roles:queryGrantableRoles',
+        request_field='<request>',
+        request_type_name=u'QueryGrantableRolesRequest',
+        response_type_name=u'QueryGrantableRolesResponse',
+        supports_download=False,
+    )

--- a/samples/storage_sample/storage_v1/storage_v1_client.py
+++ b/samples/storage_sample/storage_v1/storage_v1_client.py
@@ -49,81 +49,6 @@ class StorageV1(base_api.BaseApiClient):
 
     def __init__(self, client):
       super(StorageV1.BucketAccessControlsService, self).__init__(client)
-      self._method_configs = {
-          'Delete': base_api.ApiMethodInfo(
-              http_method=u'DELETE',
-              method_id=u'storage.bucketAccessControls.delete',
-              ordered_params=[u'bucket', u'entity'],
-              path_params=[u'bucket', u'entity'],
-              query_params=[],
-              relative_path=u'b/{bucket}/acl/{entity}',
-              request_field='',
-              request_type_name=u'StorageBucketAccessControlsDeleteRequest',
-              response_type_name=u'StorageBucketAccessControlsDeleteResponse',
-              supports_download=False,
-          ),
-          'Get': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'storage.bucketAccessControls.get',
-              ordered_params=[u'bucket', u'entity'],
-              path_params=[u'bucket', u'entity'],
-              query_params=[],
-              relative_path=u'b/{bucket}/acl/{entity}',
-              request_field='',
-              request_type_name=u'StorageBucketAccessControlsGetRequest',
-              response_type_name=u'BucketAccessControl',
-              supports_download=False,
-          ),
-          'Insert': base_api.ApiMethodInfo(
-              http_method=u'POST',
-              method_id=u'storage.bucketAccessControls.insert',
-              ordered_params=[u'bucket'],
-              path_params=[u'bucket'],
-              query_params=[],
-              relative_path=u'b/{bucket}/acl',
-              request_field='<request>',
-              request_type_name=u'BucketAccessControl',
-              response_type_name=u'BucketAccessControl',
-              supports_download=False,
-          ),
-          'List': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'storage.bucketAccessControls.list',
-              ordered_params=[u'bucket'],
-              path_params=[u'bucket'],
-              query_params=[],
-              relative_path=u'b/{bucket}/acl',
-              request_field='',
-              request_type_name=u'StorageBucketAccessControlsListRequest',
-              response_type_name=u'BucketAccessControls',
-              supports_download=False,
-          ),
-          'Patch': base_api.ApiMethodInfo(
-              http_method=u'PATCH',
-              method_id=u'storage.bucketAccessControls.patch',
-              ordered_params=[u'bucket', u'entity'],
-              path_params=[u'bucket', u'entity'],
-              query_params=[],
-              relative_path=u'b/{bucket}/acl/{entity}',
-              request_field='<request>',
-              request_type_name=u'BucketAccessControl',
-              response_type_name=u'BucketAccessControl',
-              supports_download=False,
-          ),
-          'Update': base_api.ApiMethodInfo(
-              http_method=u'PUT',
-              method_id=u'storage.bucketAccessControls.update',
-              ordered_params=[u'bucket', u'entity'],
-              path_params=[u'bucket', u'entity'],
-              query_params=[],
-              relative_path=u'b/{bucket}/acl/{entity}',
-              request_field='<request>',
-              request_type_name=u'BucketAccessControl',
-              response_type_name=u'BucketAccessControl',
-              supports_download=False,
-          ),
-          }
-
       self._upload_configs = {
           }
 
@@ -140,6 +65,19 @@ class StorageV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Delete.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'DELETE',
+        method_id=u'storage.bucketAccessControls.delete',
+        ordered_params=[u'bucket', u'entity'],
+        path_params=[u'bucket', u'entity'],
+        query_params=[],
+        relative_path=u'b/{bucket}/acl/{entity}',
+        request_field='',
+        request_type_name=u'StorageBucketAccessControlsDeleteRequest',
+        response_type_name=u'StorageBucketAccessControlsDeleteResponse',
+        supports_download=False,
+    )
+
     def Get(self, request, global_params=None):
       """Returns the ACL entry for the specified entity on the specified bucket.
 
@@ -152,6 +90,19 @@ class StorageV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('Get')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    Get.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'storage.bucketAccessControls.get',
+        ordered_params=[u'bucket', u'entity'],
+        path_params=[u'bucket', u'entity'],
+        query_params=[],
+        relative_path=u'b/{bucket}/acl/{entity}',
+        request_field='',
+        request_type_name=u'StorageBucketAccessControlsGetRequest',
+        response_type_name=u'BucketAccessControl',
+        supports_download=False,
+    )
 
     def Insert(self, request, global_params=None):
       """Creates a new ACL entry on the specified bucket.
@@ -166,6 +117,19 @@ class StorageV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Insert.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'POST',
+        method_id=u'storage.bucketAccessControls.insert',
+        ordered_params=[u'bucket'],
+        path_params=[u'bucket'],
+        query_params=[],
+        relative_path=u'b/{bucket}/acl',
+        request_field='<request>',
+        request_type_name=u'BucketAccessControl',
+        response_type_name=u'BucketAccessControl',
+        supports_download=False,
+    )
+
     def List(self, request, global_params=None):
       """Retrieves ACL entries on the specified bucket.
 
@@ -178,6 +142,19 @@ class StorageV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('List')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    List.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'storage.bucketAccessControls.list',
+        ordered_params=[u'bucket'],
+        path_params=[u'bucket'],
+        query_params=[],
+        relative_path=u'b/{bucket}/acl',
+        request_field='',
+        request_type_name=u'StorageBucketAccessControlsListRequest',
+        response_type_name=u'BucketAccessControls',
+        supports_download=False,
+    )
 
     def Patch(self, request, global_params=None):
       """Updates an ACL entry on the specified bucket. This method supports patch semantics.
@@ -192,6 +169,19 @@ class StorageV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Patch.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'PATCH',
+        method_id=u'storage.bucketAccessControls.patch',
+        ordered_params=[u'bucket', u'entity'],
+        path_params=[u'bucket', u'entity'],
+        query_params=[],
+        relative_path=u'b/{bucket}/acl/{entity}',
+        request_field='<request>',
+        request_type_name=u'BucketAccessControl',
+        response_type_name=u'BucketAccessControl',
+        supports_download=False,
+    )
+
     def Update(self, request, global_params=None):
       """Updates an ACL entry on the specified bucket.
 
@@ -205,6 +195,19 @@ class StorageV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Update.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'PUT',
+        method_id=u'storage.bucketAccessControls.update',
+        ordered_params=[u'bucket', u'entity'],
+        path_params=[u'bucket', u'entity'],
+        query_params=[],
+        relative_path=u'b/{bucket}/acl/{entity}',
+        request_field='<request>',
+        request_type_name=u'BucketAccessControl',
+        response_type_name=u'BucketAccessControl',
+        supports_download=False,
+    )
+
   class BucketsService(base_api.BaseApiService):
     """Service class for the buckets resource."""
 
@@ -212,117 +215,6 @@ class StorageV1(base_api.BaseApiClient):
 
     def __init__(self, client):
       super(StorageV1.BucketsService, self).__init__(client)
-      self._method_configs = {
-          'Delete': base_api.ApiMethodInfo(
-              http_method=u'DELETE',
-              method_id=u'storage.buckets.delete',
-              ordered_params=[u'bucket'],
-              path_params=[u'bucket'],
-              query_params=[u'ifMetagenerationMatch', u'ifMetagenerationNotMatch'],
-              relative_path=u'b/{bucket}',
-              request_field='',
-              request_type_name=u'StorageBucketsDeleteRequest',
-              response_type_name=u'StorageBucketsDeleteResponse',
-              supports_download=False,
-          ),
-          'Get': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'storage.buckets.get',
-              ordered_params=[u'bucket'],
-              path_params=[u'bucket'],
-              query_params=[u'ifMetagenerationMatch', u'ifMetagenerationNotMatch', u'projection'],
-              relative_path=u'b/{bucket}',
-              request_field='',
-              request_type_name=u'StorageBucketsGetRequest',
-              response_type_name=u'Bucket',
-              supports_download=False,
-          ),
-          'GetIamPolicy': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'storage.buckets.getIamPolicy',
-              ordered_params=[u'bucket'],
-              path_params=[u'bucket'],
-              query_params=[],
-              relative_path=u'b/{bucket}/iam',
-              request_field='',
-              request_type_name=u'StorageBucketsGetIamPolicyRequest',
-              response_type_name=u'Policy',
-              supports_download=False,
-          ),
-          'Insert': base_api.ApiMethodInfo(
-              http_method=u'POST',
-              method_id=u'storage.buckets.insert',
-              ordered_params=[u'project'],
-              path_params=[],
-              query_params=[u'predefinedAcl', u'predefinedDefaultObjectAcl', u'project', u'projection'],
-              relative_path=u'b',
-              request_field=u'bucket',
-              request_type_name=u'StorageBucketsInsertRequest',
-              response_type_name=u'Bucket',
-              supports_download=False,
-          ),
-          'List': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'storage.buckets.list',
-              ordered_params=[u'project'],
-              path_params=[],
-              query_params=[u'maxResults', u'pageToken', u'prefix', u'project', u'projection'],
-              relative_path=u'b',
-              request_field='',
-              request_type_name=u'StorageBucketsListRequest',
-              response_type_name=u'Buckets',
-              supports_download=False,
-          ),
-          'Patch': base_api.ApiMethodInfo(
-              http_method=u'PATCH',
-              method_id=u'storage.buckets.patch',
-              ordered_params=[u'bucket'],
-              path_params=[u'bucket'],
-              query_params=[u'ifMetagenerationMatch', u'ifMetagenerationNotMatch', u'predefinedAcl', u'predefinedDefaultObjectAcl', u'projection'],
-              relative_path=u'b/{bucket}',
-              request_field=u'bucketResource',
-              request_type_name=u'StorageBucketsPatchRequest',
-              response_type_name=u'Bucket',
-              supports_download=False,
-          ),
-          'SetIamPolicy': base_api.ApiMethodInfo(
-              http_method=u'PUT',
-              method_id=u'storage.buckets.setIamPolicy',
-              ordered_params=[u'bucket'],
-              path_params=[u'bucket'],
-              query_params=[],
-              relative_path=u'b/{bucket}/iam',
-              request_field=u'policy',
-              request_type_name=u'StorageBucketsSetIamPolicyRequest',
-              response_type_name=u'Policy',
-              supports_download=False,
-          ),
-          'TestIamPermissions': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'storage.buckets.testIamPermissions',
-              ordered_params=[u'bucket', u'permissions'],
-              path_params=[u'bucket'],
-              query_params=[u'permissions'],
-              relative_path=u'b/{bucket}/iam/testPermissions',
-              request_field='',
-              request_type_name=u'StorageBucketsTestIamPermissionsRequest',
-              response_type_name=u'TestIamPermissionsResponse',
-              supports_download=False,
-          ),
-          'Update': base_api.ApiMethodInfo(
-              http_method=u'PUT',
-              method_id=u'storage.buckets.update',
-              ordered_params=[u'bucket'],
-              path_params=[u'bucket'],
-              query_params=[u'ifMetagenerationMatch', u'ifMetagenerationNotMatch', u'predefinedAcl', u'predefinedDefaultObjectAcl', u'projection'],
-              relative_path=u'b/{bucket}',
-              request_field=u'bucketResource',
-              request_type_name=u'StorageBucketsUpdateRequest',
-              response_type_name=u'Bucket',
-              supports_download=False,
-          ),
-          }
-
       self._upload_configs = {
           }
 
@@ -339,6 +231,19 @@ class StorageV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Delete.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'DELETE',
+        method_id=u'storage.buckets.delete',
+        ordered_params=[u'bucket'],
+        path_params=[u'bucket'],
+        query_params=[u'ifMetagenerationMatch', u'ifMetagenerationNotMatch'],
+        relative_path=u'b/{bucket}',
+        request_field='',
+        request_type_name=u'StorageBucketsDeleteRequest',
+        response_type_name=u'StorageBucketsDeleteResponse',
+        supports_download=False,
+    )
+
     def Get(self, request, global_params=None):
       """Returns metadata for the specified bucket.
 
@@ -351,6 +256,19 @@ class StorageV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('Get')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    Get.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'storage.buckets.get',
+        ordered_params=[u'bucket'],
+        path_params=[u'bucket'],
+        query_params=[u'ifMetagenerationMatch', u'ifMetagenerationNotMatch', u'projection'],
+        relative_path=u'b/{bucket}',
+        request_field='',
+        request_type_name=u'StorageBucketsGetRequest',
+        response_type_name=u'Bucket',
+        supports_download=False,
+    )
 
     def GetIamPolicy(self, request, global_params=None):
       """Returns an IAM policy for the specified bucket.
@@ -365,6 +283,19 @@ class StorageV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    GetIamPolicy.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'storage.buckets.getIamPolicy',
+        ordered_params=[u'bucket'],
+        path_params=[u'bucket'],
+        query_params=[],
+        relative_path=u'b/{bucket}/iam',
+        request_field='',
+        request_type_name=u'StorageBucketsGetIamPolicyRequest',
+        response_type_name=u'Policy',
+        supports_download=False,
+    )
+
     def Insert(self, request, global_params=None):
       """Creates a new bucket.
 
@@ -377,6 +308,19 @@ class StorageV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('Insert')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    Insert.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'POST',
+        method_id=u'storage.buckets.insert',
+        ordered_params=[u'project'],
+        path_params=[],
+        query_params=[u'predefinedAcl', u'predefinedDefaultObjectAcl', u'project', u'projection'],
+        relative_path=u'b',
+        request_field=u'bucket',
+        request_type_name=u'StorageBucketsInsertRequest',
+        response_type_name=u'Bucket',
+        supports_download=False,
+    )
 
     def List(self, request, global_params=None):
       """Retrieves a list of buckets for a given project.
@@ -391,6 +335,19 @@ class StorageV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    List.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'storage.buckets.list',
+        ordered_params=[u'project'],
+        path_params=[],
+        query_params=[u'maxResults', u'pageToken', u'prefix', u'project', u'projection'],
+        relative_path=u'b',
+        request_field='',
+        request_type_name=u'StorageBucketsListRequest',
+        response_type_name=u'Buckets',
+        supports_download=False,
+    )
+
     def Patch(self, request, global_params=None):
       """Updates a bucket. This method supports patch semantics.
 
@@ -403,6 +360,19 @@ class StorageV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('Patch')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    Patch.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'PATCH',
+        method_id=u'storage.buckets.patch',
+        ordered_params=[u'bucket'],
+        path_params=[u'bucket'],
+        query_params=[u'ifMetagenerationMatch', u'ifMetagenerationNotMatch', u'predefinedAcl', u'predefinedDefaultObjectAcl', u'projection'],
+        relative_path=u'b/{bucket}',
+        request_field=u'bucketResource',
+        request_type_name=u'StorageBucketsPatchRequest',
+        response_type_name=u'Bucket',
+        supports_download=False,
+    )
 
     def SetIamPolicy(self, request, global_params=None):
       """Updates an IAM policy for the specified bucket.
@@ -417,6 +387,19 @@ class StorageV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    SetIamPolicy.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'PUT',
+        method_id=u'storage.buckets.setIamPolicy',
+        ordered_params=[u'bucket'],
+        path_params=[u'bucket'],
+        query_params=[],
+        relative_path=u'b/{bucket}/iam',
+        request_field=u'policy',
+        request_type_name=u'StorageBucketsSetIamPolicyRequest',
+        response_type_name=u'Policy',
+        supports_download=False,
+    )
+
     def TestIamPermissions(self, request, global_params=None):
       """Tests a set of permissions on the given bucket to see which, if any, are held by the caller.
 
@@ -429,6 +412,19 @@ class StorageV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('TestIamPermissions')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    TestIamPermissions.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'storage.buckets.testIamPermissions',
+        ordered_params=[u'bucket', u'permissions'],
+        path_params=[u'bucket'],
+        query_params=[u'permissions'],
+        relative_path=u'b/{bucket}/iam/testPermissions',
+        request_field='',
+        request_type_name=u'StorageBucketsTestIamPermissionsRequest',
+        response_type_name=u'TestIamPermissionsResponse',
+        supports_download=False,
+    )
 
     def Update(self, request, global_params=None):
       """Updates a bucket.
@@ -443,6 +439,19 @@ class StorageV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Update.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'PUT',
+        method_id=u'storage.buckets.update',
+        ordered_params=[u'bucket'],
+        path_params=[u'bucket'],
+        query_params=[u'ifMetagenerationMatch', u'ifMetagenerationNotMatch', u'predefinedAcl', u'predefinedDefaultObjectAcl', u'projection'],
+        relative_path=u'b/{bucket}',
+        request_field=u'bucketResource',
+        request_type_name=u'StorageBucketsUpdateRequest',
+        response_type_name=u'Bucket',
+        supports_download=False,
+    )
+
   class ChannelsService(base_api.BaseApiService):
     """Service class for the channels resource."""
 
@@ -450,21 +459,6 @@ class StorageV1(base_api.BaseApiClient):
 
     def __init__(self, client):
       super(StorageV1.ChannelsService, self).__init__(client)
-      self._method_configs = {
-          'Stop': base_api.ApiMethodInfo(
-              http_method=u'POST',
-              method_id=u'storage.channels.stop',
-              ordered_params=[],
-              path_params=[],
-              query_params=[],
-              relative_path=u'channels/stop',
-              request_field='<request>',
-              request_type_name=u'Channel',
-              response_type_name=u'StorageChannelsStopResponse',
-              supports_download=False,
-          ),
-          }
-
       self._upload_configs = {
           }
 
@@ -481,6 +475,19 @@ class StorageV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Stop.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'POST',
+        method_id=u'storage.channels.stop',
+        ordered_params=[],
+        path_params=[],
+        query_params=[],
+        relative_path=u'channels/stop',
+        request_field='<request>',
+        request_type_name=u'Channel',
+        response_type_name=u'StorageChannelsStopResponse',
+        supports_download=False,
+    )
+
   class DefaultObjectAccessControlsService(base_api.BaseApiService):
     """Service class for the defaultObjectAccessControls resource."""
 
@@ -488,81 +495,6 @@ class StorageV1(base_api.BaseApiClient):
 
     def __init__(self, client):
       super(StorageV1.DefaultObjectAccessControlsService, self).__init__(client)
-      self._method_configs = {
-          'Delete': base_api.ApiMethodInfo(
-              http_method=u'DELETE',
-              method_id=u'storage.defaultObjectAccessControls.delete',
-              ordered_params=[u'bucket', u'entity'],
-              path_params=[u'bucket', u'entity'],
-              query_params=[],
-              relative_path=u'b/{bucket}/defaultObjectAcl/{entity}',
-              request_field='',
-              request_type_name=u'StorageDefaultObjectAccessControlsDeleteRequest',
-              response_type_name=u'StorageDefaultObjectAccessControlsDeleteResponse',
-              supports_download=False,
-          ),
-          'Get': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'storage.defaultObjectAccessControls.get',
-              ordered_params=[u'bucket', u'entity'],
-              path_params=[u'bucket', u'entity'],
-              query_params=[],
-              relative_path=u'b/{bucket}/defaultObjectAcl/{entity}',
-              request_field='',
-              request_type_name=u'StorageDefaultObjectAccessControlsGetRequest',
-              response_type_name=u'ObjectAccessControl',
-              supports_download=False,
-          ),
-          'Insert': base_api.ApiMethodInfo(
-              http_method=u'POST',
-              method_id=u'storage.defaultObjectAccessControls.insert',
-              ordered_params=[u'bucket'],
-              path_params=[u'bucket'],
-              query_params=[],
-              relative_path=u'b/{bucket}/defaultObjectAcl',
-              request_field='<request>',
-              request_type_name=u'ObjectAccessControl',
-              response_type_name=u'ObjectAccessControl',
-              supports_download=False,
-          ),
-          'List': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'storage.defaultObjectAccessControls.list',
-              ordered_params=[u'bucket'],
-              path_params=[u'bucket'],
-              query_params=[u'ifMetagenerationMatch', u'ifMetagenerationNotMatch'],
-              relative_path=u'b/{bucket}/defaultObjectAcl',
-              request_field='',
-              request_type_name=u'StorageDefaultObjectAccessControlsListRequest',
-              response_type_name=u'ObjectAccessControls',
-              supports_download=False,
-          ),
-          'Patch': base_api.ApiMethodInfo(
-              http_method=u'PATCH',
-              method_id=u'storage.defaultObjectAccessControls.patch',
-              ordered_params=[u'bucket', u'entity'],
-              path_params=[u'bucket', u'entity'],
-              query_params=[],
-              relative_path=u'b/{bucket}/defaultObjectAcl/{entity}',
-              request_field='<request>',
-              request_type_name=u'ObjectAccessControl',
-              response_type_name=u'ObjectAccessControl',
-              supports_download=False,
-          ),
-          'Update': base_api.ApiMethodInfo(
-              http_method=u'PUT',
-              method_id=u'storage.defaultObjectAccessControls.update',
-              ordered_params=[u'bucket', u'entity'],
-              path_params=[u'bucket', u'entity'],
-              query_params=[],
-              relative_path=u'b/{bucket}/defaultObjectAcl/{entity}',
-              request_field='<request>',
-              request_type_name=u'ObjectAccessControl',
-              response_type_name=u'ObjectAccessControl',
-              supports_download=False,
-          ),
-          }
-
       self._upload_configs = {
           }
 
@@ -579,6 +511,19 @@ class StorageV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Delete.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'DELETE',
+        method_id=u'storage.defaultObjectAccessControls.delete',
+        ordered_params=[u'bucket', u'entity'],
+        path_params=[u'bucket', u'entity'],
+        query_params=[],
+        relative_path=u'b/{bucket}/defaultObjectAcl/{entity}',
+        request_field='',
+        request_type_name=u'StorageDefaultObjectAccessControlsDeleteRequest',
+        response_type_name=u'StorageDefaultObjectAccessControlsDeleteResponse',
+        supports_download=False,
+    )
+
     def Get(self, request, global_params=None):
       """Returns the default object ACL entry for the specified entity on the specified bucket.
 
@@ -591,6 +536,19 @@ class StorageV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('Get')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    Get.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'storage.defaultObjectAccessControls.get',
+        ordered_params=[u'bucket', u'entity'],
+        path_params=[u'bucket', u'entity'],
+        query_params=[],
+        relative_path=u'b/{bucket}/defaultObjectAcl/{entity}',
+        request_field='',
+        request_type_name=u'StorageDefaultObjectAccessControlsGetRequest',
+        response_type_name=u'ObjectAccessControl',
+        supports_download=False,
+    )
 
     def Insert(self, request, global_params=None):
       """Creates a new default object ACL entry on the specified bucket.
@@ -605,6 +563,19 @@ class StorageV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Insert.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'POST',
+        method_id=u'storage.defaultObjectAccessControls.insert',
+        ordered_params=[u'bucket'],
+        path_params=[u'bucket'],
+        query_params=[],
+        relative_path=u'b/{bucket}/defaultObjectAcl',
+        request_field='<request>',
+        request_type_name=u'ObjectAccessControl',
+        response_type_name=u'ObjectAccessControl',
+        supports_download=False,
+    )
+
     def List(self, request, global_params=None):
       """Retrieves default object ACL entries on the specified bucket.
 
@@ -617,6 +588,19 @@ class StorageV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('List')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    List.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'storage.defaultObjectAccessControls.list',
+        ordered_params=[u'bucket'],
+        path_params=[u'bucket'],
+        query_params=[u'ifMetagenerationMatch', u'ifMetagenerationNotMatch'],
+        relative_path=u'b/{bucket}/defaultObjectAcl',
+        request_field='',
+        request_type_name=u'StorageDefaultObjectAccessControlsListRequest',
+        response_type_name=u'ObjectAccessControls',
+        supports_download=False,
+    )
 
     def Patch(self, request, global_params=None):
       """Updates a default object ACL entry on the specified bucket. This method supports patch semantics.
@@ -631,6 +615,19 @@ class StorageV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Patch.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'PATCH',
+        method_id=u'storage.defaultObjectAccessControls.patch',
+        ordered_params=[u'bucket', u'entity'],
+        path_params=[u'bucket', u'entity'],
+        query_params=[],
+        relative_path=u'b/{bucket}/defaultObjectAcl/{entity}',
+        request_field='<request>',
+        request_type_name=u'ObjectAccessControl',
+        response_type_name=u'ObjectAccessControl',
+        supports_download=False,
+    )
+
     def Update(self, request, global_params=None):
       """Updates a default object ACL entry on the specified bucket.
 
@@ -644,6 +641,19 @@ class StorageV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Update.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'PUT',
+        method_id=u'storage.defaultObjectAccessControls.update',
+        ordered_params=[u'bucket', u'entity'],
+        path_params=[u'bucket', u'entity'],
+        query_params=[],
+        relative_path=u'b/{bucket}/defaultObjectAcl/{entity}',
+        request_field='<request>',
+        request_type_name=u'ObjectAccessControl',
+        response_type_name=u'ObjectAccessControl',
+        supports_download=False,
+    )
+
   class NotificationsService(base_api.BaseApiService):
     """Service class for the notifications resource."""
 
@@ -651,57 +661,6 @@ class StorageV1(base_api.BaseApiClient):
 
     def __init__(self, client):
       super(StorageV1.NotificationsService, self).__init__(client)
-      self._method_configs = {
-          'Delete': base_api.ApiMethodInfo(
-              http_method=u'DELETE',
-              method_id=u'storage.notifications.delete',
-              ordered_params=[u'notification'],
-              path_params=[u'notification'],
-              query_params=[],
-              relative_path=u'notifications/{notification}',
-              request_field='',
-              request_type_name=u'StorageNotificationsDeleteRequest',
-              response_type_name=u'StorageNotificationsDeleteResponse',
-              supports_download=False,
-          ),
-          'Get': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'storage.notifications.get',
-              ordered_params=[u'notification'],
-              path_params=[u'notification'],
-              query_params=[],
-              relative_path=u'notifications/{notification}',
-              request_field='',
-              request_type_name=u'StorageNotificationsGetRequest',
-              response_type_name=u'Notification',
-              supports_download=False,
-          ),
-          'Insert': base_api.ApiMethodInfo(
-              http_method=u'POST',
-              method_id=u'storage.notifications.insert',
-              ordered_params=[],
-              path_params=[],
-              query_params=[],
-              relative_path=u'notifications',
-              request_field='<request>',
-              request_type_name=u'Notification',
-              response_type_name=u'Notification',
-              supports_download=False,
-          ),
-          'List': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'storage.notifications.list',
-              ordered_params=[u'bucket'],
-              path_params=[],
-              query_params=[u'bucket'],
-              relative_path=u'notifications',
-              request_field='',
-              request_type_name=u'StorageNotificationsListRequest',
-              response_type_name=u'Notifications',
-              supports_download=False,
-          ),
-          }
-
       self._upload_configs = {
           }
 
@@ -718,6 +677,19 @@ class StorageV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Delete.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'DELETE',
+        method_id=u'storage.notifications.delete',
+        ordered_params=[u'notification'],
+        path_params=[u'notification'],
+        query_params=[],
+        relative_path=u'notifications/{notification}',
+        request_field='',
+        request_type_name=u'StorageNotificationsDeleteRequest',
+        response_type_name=u'StorageNotificationsDeleteResponse',
+        supports_download=False,
+    )
+
     def Get(self, request, global_params=None):
       """View a notification configuration.
 
@@ -730,6 +702,19 @@ class StorageV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('Get')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    Get.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'storage.notifications.get',
+        ordered_params=[u'notification'],
+        path_params=[u'notification'],
+        query_params=[],
+        relative_path=u'notifications/{notification}',
+        request_field='',
+        request_type_name=u'StorageNotificationsGetRequest',
+        response_type_name=u'Notification',
+        supports_download=False,
+    )
 
     def Insert(self, request, global_params=None):
       """Creates a notification subscription for a given bucket.
@@ -744,6 +729,19 @@ class StorageV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Insert.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'POST',
+        method_id=u'storage.notifications.insert',
+        ordered_params=[],
+        path_params=[],
+        query_params=[],
+        relative_path=u'notifications',
+        request_field='<request>',
+        request_type_name=u'Notification',
+        response_type_name=u'Notification',
+        supports_download=False,
+    )
+
     def List(self, request, global_params=None):
       """Retrieves a list of notification subscriptions for a given bucket.
 
@@ -757,6 +755,19 @@ class StorageV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    List.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'storage.notifications.list',
+        ordered_params=[u'bucket'],
+        path_params=[],
+        query_params=[u'bucket'],
+        relative_path=u'notifications',
+        request_field='',
+        request_type_name=u'StorageNotificationsListRequest',
+        response_type_name=u'Notifications',
+        supports_download=False,
+    )
+
   class ObjectAccessControlsService(base_api.BaseApiService):
     """Service class for the objectAccessControls resource."""
 
@@ -764,81 +775,6 @@ class StorageV1(base_api.BaseApiClient):
 
     def __init__(self, client):
       super(StorageV1.ObjectAccessControlsService, self).__init__(client)
-      self._method_configs = {
-          'Delete': base_api.ApiMethodInfo(
-              http_method=u'DELETE',
-              method_id=u'storage.objectAccessControls.delete',
-              ordered_params=[u'bucket', u'object', u'entity'],
-              path_params=[u'bucket', u'entity', u'object'],
-              query_params=[u'generation'],
-              relative_path=u'b/{bucket}/o/{object}/acl/{entity}',
-              request_field='',
-              request_type_name=u'StorageObjectAccessControlsDeleteRequest',
-              response_type_name=u'StorageObjectAccessControlsDeleteResponse',
-              supports_download=False,
-          ),
-          'Get': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'storage.objectAccessControls.get',
-              ordered_params=[u'bucket', u'object', u'entity'],
-              path_params=[u'bucket', u'entity', u'object'],
-              query_params=[u'generation'],
-              relative_path=u'b/{bucket}/o/{object}/acl/{entity}',
-              request_field='',
-              request_type_name=u'StorageObjectAccessControlsGetRequest',
-              response_type_name=u'ObjectAccessControl',
-              supports_download=False,
-          ),
-          'Insert': base_api.ApiMethodInfo(
-              http_method=u'POST',
-              method_id=u'storage.objectAccessControls.insert',
-              ordered_params=[u'bucket', u'object'],
-              path_params=[u'bucket', u'object'],
-              query_params=[u'generation'],
-              relative_path=u'b/{bucket}/o/{object}/acl',
-              request_field=u'objectAccessControl',
-              request_type_name=u'StorageObjectAccessControlsInsertRequest',
-              response_type_name=u'ObjectAccessControl',
-              supports_download=False,
-          ),
-          'List': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'storage.objectAccessControls.list',
-              ordered_params=[u'bucket', u'object'],
-              path_params=[u'bucket', u'object'],
-              query_params=[u'generation'],
-              relative_path=u'b/{bucket}/o/{object}/acl',
-              request_field='',
-              request_type_name=u'StorageObjectAccessControlsListRequest',
-              response_type_name=u'ObjectAccessControls',
-              supports_download=False,
-          ),
-          'Patch': base_api.ApiMethodInfo(
-              http_method=u'PATCH',
-              method_id=u'storage.objectAccessControls.patch',
-              ordered_params=[u'bucket', u'object', u'entity'],
-              path_params=[u'bucket', u'entity', u'object'],
-              query_params=[u'generation'],
-              relative_path=u'b/{bucket}/o/{object}/acl/{entity}',
-              request_field=u'objectAccessControl',
-              request_type_name=u'StorageObjectAccessControlsPatchRequest',
-              response_type_name=u'ObjectAccessControl',
-              supports_download=False,
-          ),
-          'Update': base_api.ApiMethodInfo(
-              http_method=u'PUT',
-              method_id=u'storage.objectAccessControls.update',
-              ordered_params=[u'bucket', u'object', u'entity'],
-              path_params=[u'bucket', u'entity', u'object'],
-              query_params=[u'generation'],
-              relative_path=u'b/{bucket}/o/{object}/acl/{entity}',
-              request_field=u'objectAccessControl',
-              request_type_name=u'StorageObjectAccessControlsUpdateRequest',
-              response_type_name=u'ObjectAccessControl',
-              supports_download=False,
-          ),
-          }
-
       self._upload_configs = {
           }
 
@@ -855,6 +791,19 @@ class StorageV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Delete.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'DELETE',
+        method_id=u'storage.objectAccessControls.delete',
+        ordered_params=[u'bucket', u'object', u'entity'],
+        path_params=[u'bucket', u'entity', u'object'],
+        query_params=[u'generation'],
+        relative_path=u'b/{bucket}/o/{object}/acl/{entity}',
+        request_field='',
+        request_type_name=u'StorageObjectAccessControlsDeleteRequest',
+        response_type_name=u'StorageObjectAccessControlsDeleteResponse',
+        supports_download=False,
+    )
+
     def Get(self, request, global_params=None):
       """Returns the ACL entry for the specified entity on the specified object.
 
@@ -867,6 +816,19 @@ class StorageV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('Get')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    Get.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'storage.objectAccessControls.get',
+        ordered_params=[u'bucket', u'object', u'entity'],
+        path_params=[u'bucket', u'entity', u'object'],
+        query_params=[u'generation'],
+        relative_path=u'b/{bucket}/o/{object}/acl/{entity}',
+        request_field='',
+        request_type_name=u'StorageObjectAccessControlsGetRequest',
+        response_type_name=u'ObjectAccessControl',
+        supports_download=False,
+    )
 
     def Insert(self, request, global_params=None):
       """Creates a new ACL entry on the specified object.
@@ -881,6 +843,19 @@ class StorageV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Insert.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'POST',
+        method_id=u'storage.objectAccessControls.insert',
+        ordered_params=[u'bucket', u'object'],
+        path_params=[u'bucket', u'object'],
+        query_params=[u'generation'],
+        relative_path=u'b/{bucket}/o/{object}/acl',
+        request_field=u'objectAccessControl',
+        request_type_name=u'StorageObjectAccessControlsInsertRequest',
+        response_type_name=u'ObjectAccessControl',
+        supports_download=False,
+    )
+
     def List(self, request, global_params=None):
       """Retrieves ACL entries on the specified object.
 
@@ -893,6 +868,19 @@ class StorageV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('List')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    List.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'storage.objectAccessControls.list',
+        ordered_params=[u'bucket', u'object'],
+        path_params=[u'bucket', u'object'],
+        query_params=[u'generation'],
+        relative_path=u'b/{bucket}/o/{object}/acl',
+        request_field='',
+        request_type_name=u'StorageObjectAccessControlsListRequest',
+        response_type_name=u'ObjectAccessControls',
+        supports_download=False,
+    )
 
     def Patch(self, request, global_params=None):
       """Updates an ACL entry on the specified object. This method supports patch semantics.
@@ -907,6 +895,19 @@ class StorageV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Patch.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'PATCH',
+        method_id=u'storage.objectAccessControls.patch',
+        ordered_params=[u'bucket', u'object', u'entity'],
+        path_params=[u'bucket', u'entity', u'object'],
+        query_params=[u'generation'],
+        relative_path=u'b/{bucket}/o/{object}/acl/{entity}',
+        request_field=u'objectAccessControl',
+        request_type_name=u'StorageObjectAccessControlsPatchRequest',
+        response_type_name=u'ObjectAccessControl',
+        supports_download=False,
+    )
+
     def Update(self, request, global_params=None):
       """Updates an ACL entry on the specified object.
 
@@ -920,6 +921,19 @@ class StorageV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Update.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'PUT',
+        method_id=u'storage.objectAccessControls.update',
+        ordered_params=[u'bucket', u'object', u'entity'],
+        path_params=[u'bucket', u'entity', u'object'],
+        query_params=[u'generation'],
+        relative_path=u'b/{bucket}/o/{object}/acl/{entity}',
+        request_field=u'objectAccessControl',
+        request_type_name=u'StorageObjectAccessControlsUpdateRequest',
+        response_type_name=u'ObjectAccessControl',
+        supports_download=False,
+    )
+
   class ObjectsService(base_api.BaseApiService):
     """Service class for the objects resource."""
 
@@ -927,165 +941,6 @@ class StorageV1(base_api.BaseApiClient):
 
     def __init__(self, client):
       super(StorageV1.ObjectsService, self).__init__(client)
-      self._method_configs = {
-          'Compose': base_api.ApiMethodInfo(
-              http_method=u'POST',
-              method_id=u'storage.objects.compose',
-              ordered_params=[u'destinationBucket', u'destinationObject'],
-              path_params=[u'destinationBucket', u'destinationObject'],
-              query_params=[u'destinationPredefinedAcl', u'ifGenerationMatch', u'ifMetagenerationMatch'],
-              relative_path=u'b/{destinationBucket}/o/{destinationObject}/compose',
-              request_field=u'composeRequest',
-              request_type_name=u'StorageObjectsComposeRequest',
-              response_type_name=u'Object',
-              supports_download=True,
-          ),
-          'Copy': base_api.ApiMethodInfo(
-              http_method=u'POST',
-              method_id=u'storage.objects.copy',
-              ordered_params=[u'sourceBucket', u'sourceObject', u'destinationBucket', u'destinationObject'],
-              path_params=[u'destinationBucket', u'destinationObject', u'sourceBucket', u'sourceObject'],
-              query_params=[u'destinationPredefinedAcl', u'ifGenerationMatch', u'ifGenerationNotMatch', u'ifMetagenerationMatch', u'ifMetagenerationNotMatch', u'ifSourceGenerationMatch', u'ifSourceGenerationNotMatch', u'ifSourceMetagenerationMatch', u'ifSourceMetagenerationNotMatch', u'projection', u'sourceGeneration'],
-              relative_path=u'b/{sourceBucket}/o/{sourceObject}/copyTo/b/{destinationBucket}/o/{destinationObject}',
-              request_field=u'object',
-              request_type_name=u'StorageObjectsCopyRequest',
-              response_type_name=u'Object',
-              supports_download=True,
-          ),
-          'Delete': base_api.ApiMethodInfo(
-              http_method=u'DELETE',
-              method_id=u'storage.objects.delete',
-              ordered_params=[u'bucket', u'object'],
-              path_params=[u'bucket', u'object'],
-              query_params=[u'generation', u'ifGenerationMatch', u'ifGenerationNotMatch', u'ifMetagenerationMatch', u'ifMetagenerationNotMatch'],
-              relative_path=u'b/{bucket}/o/{object}',
-              request_field='',
-              request_type_name=u'StorageObjectsDeleteRequest',
-              response_type_name=u'StorageObjectsDeleteResponse',
-              supports_download=False,
-          ),
-          'Get': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'storage.objects.get',
-              ordered_params=[u'bucket', u'object'],
-              path_params=[u'bucket', u'object'],
-              query_params=[u'generation', u'ifGenerationMatch', u'ifGenerationNotMatch', u'ifMetagenerationMatch', u'ifMetagenerationNotMatch', u'projection'],
-              relative_path=u'b/{bucket}/o/{object}',
-              request_field='',
-              request_type_name=u'StorageObjectsGetRequest',
-              response_type_name=u'Object',
-              supports_download=True,
-          ),
-          'GetIamPolicy': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'storage.objects.getIamPolicy',
-              ordered_params=[u'bucket', u'object'],
-              path_params=[u'bucket', u'object'],
-              query_params=[u'generation'],
-              relative_path=u'b/{bucket}/o/{object}/iam',
-              request_field='',
-              request_type_name=u'StorageObjectsGetIamPolicyRequest',
-              response_type_name=u'Policy',
-              supports_download=False,
-          ),
-          'Insert': base_api.ApiMethodInfo(
-              http_method=u'POST',
-              method_id=u'storage.objects.insert',
-              ordered_params=[u'bucket'],
-              path_params=[u'bucket'],
-              query_params=[u'contentEncoding', u'ifGenerationMatch', u'ifGenerationNotMatch', u'ifMetagenerationMatch', u'ifMetagenerationNotMatch', u'name', u'predefinedAcl', u'projection'],
-              relative_path=u'b/{bucket}/o',
-              request_field=u'object',
-              request_type_name=u'StorageObjectsInsertRequest',
-              response_type_name=u'Object',
-              supports_download=True,
-          ),
-          'List': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'storage.objects.list',
-              ordered_params=[u'bucket'],
-              path_params=[u'bucket'],
-              query_params=[u'delimiter', u'maxResults', u'pageToken', u'prefix', u'projection', u'versions'],
-              relative_path=u'b/{bucket}/o',
-              request_field='',
-              request_type_name=u'StorageObjectsListRequest',
-              response_type_name=u'Objects',
-              supports_download=False,
-          ),
-          'Patch': base_api.ApiMethodInfo(
-              http_method=u'PATCH',
-              method_id=u'storage.objects.patch',
-              ordered_params=[u'bucket', u'object'],
-              path_params=[u'bucket', u'object'],
-              query_params=[u'generation', u'ifGenerationMatch', u'ifGenerationNotMatch', u'ifMetagenerationMatch', u'ifMetagenerationNotMatch', u'predefinedAcl', u'projection'],
-              relative_path=u'b/{bucket}/o/{object}',
-              request_field=u'objectResource',
-              request_type_name=u'StorageObjectsPatchRequest',
-              response_type_name=u'Object',
-              supports_download=False,
-          ),
-          'Rewrite': base_api.ApiMethodInfo(
-              http_method=u'POST',
-              method_id=u'storage.objects.rewrite',
-              ordered_params=[u'sourceBucket', u'sourceObject', u'destinationBucket', u'destinationObject'],
-              path_params=[u'destinationBucket', u'destinationObject', u'sourceBucket', u'sourceObject'],
-              query_params=[u'destinationPredefinedAcl', u'ifGenerationMatch', u'ifGenerationNotMatch', u'ifMetagenerationMatch', u'ifMetagenerationNotMatch', u'ifSourceGenerationMatch', u'ifSourceGenerationNotMatch', u'ifSourceMetagenerationMatch', u'ifSourceMetagenerationNotMatch', u'maxBytesRewrittenPerCall', u'projection', u'rewriteToken', u'sourceGeneration'],
-              relative_path=u'b/{sourceBucket}/o/{sourceObject}/rewriteTo/b/{destinationBucket}/o/{destinationObject}',
-              request_field=u'object',
-              request_type_name=u'StorageObjectsRewriteRequest',
-              response_type_name=u'RewriteResponse',
-              supports_download=False,
-          ),
-          'SetIamPolicy': base_api.ApiMethodInfo(
-              http_method=u'PUT',
-              method_id=u'storage.objects.setIamPolicy',
-              ordered_params=[u'bucket', u'object'],
-              path_params=[u'bucket', u'object'],
-              query_params=[u'generation'],
-              relative_path=u'b/{bucket}/o/{object}/iam',
-              request_field=u'policy',
-              request_type_name=u'StorageObjectsSetIamPolicyRequest',
-              response_type_name=u'Policy',
-              supports_download=False,
-          ),
-          'TestIamPermissions': base_api.ApiMethodInfo(
-              http_method=u'GET',
-              method_id=u'storage.objects.testIamPermissions',
-              ordered_params=[u'bucket', u'object', u'permissions'],
-              path_params=[u'bucket', u'object'],
-              query_params=[u'generation', u'permissions'],
-              relative_path=u'b/{bucket}/o/{object}/iam/testPermissions',
-              request_field='',
-              request_type_name=u'StorageObjectsTestIamPermissionsRequest',
-              response_type_name=u'TestIamPermissionsResponse',
-              supports_download=False,
-          ),
-          'Update': base_api.ApiMethodInfo(
-              http_method=u'PUT',
-              method_id=u'storage.objects.update',
-              ordered_params=[u'bucket', u'object'],
-              path_params=[u'bucket', u'object'],
-              query_params=[u'generation', u'ifGenerationMatch', u'ifGenerationNotMatch', u'ifMetagenerationMatch', u'ifMetagenerationNotMatch', u'predefinedAcl', u'projection'],
-              relative_path=u'b/{bucket}/o/{object}',
-              request_field=u'objectResource',
-              request_type_name=u'StorageObjectsUpdateRequest',
-              response_type_name=u'Object',
-              supports_download=True,
-          ),
-          'WatchAll': base_api.ApiMethodInfo(
-              http_method=u'POST',
-              method_id=u'storage.objects.watchAll',
-              ordered_params=[u'bucket'],
-              path_params=[u'bucket'],
-              query_params=[u'delimiter', u'maxResults', u'pageToken', u'prefix', u'projection', u'versions'],
-              relative_path=u'b/{bucket}/o/watch',
-              request_field=u'channel',
-              request_type_name=u'StorageObjectsWatchAllRequest',
-              response_type_name=u'Channel',
-              supports_download=False,
-          ),
-          }
-
       self._upload_configs = {
           'Insert': base_api.ApiUploadInfo(
               accept=['*/*'],
@@ -1113,6 +968,19 @@ class StorageV1(base_api.BaseApiClient):
           config, request, global_params=global_params,
           download=download)
 
+    Compose.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'POST',
+        method_id=u'storage.objects.compose',
+        ordered_params=[u'destinationBucket', u'destinationObject'],
+        path_params=[u'destinationBucket', u'destinationObject'],
+        query_params=[u'destinationPredefinedAcl', u'ifGenerationMatch', u'ifMetagenerationMatch'],
+        relative_path=u'b/{destinationBucket}/o/{destinationObject}/compose',
+        request_field=u'composeRequest',
+        request_type_name=u'StorageObjectsComposeRequest',
+        response_type_name=u'Object',
+        supports_download=True,
+    )
+
     def Copy(self, request, global_params=None, download=None):
       """Copies a source object to a destination object. Optionally overrides metadata.
 
@@ -1129,6 +997,19 @@ class StorageV1(base_api.BaseApiClient):
           config, request, global_params=global_params,
           download=download)
 
+    Copy.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'POST',
+        method_id=u'storage.objects.copy',
+        ordered_params=[u'sourceBucket', u'sourceObject', u'destinationBucket', u'destinationObject'],
+        path_params=[u'destinationBucket', u'destinationObject', u'sourceBucket', u'sourceObject'],
+        query_params=[u'destinationPredefinedAcl', u'ifGenerationMatch', u'ifGenerationNotMatch', u'ifMetagenerationMatch', u'ifMetagenerationNotMatch', u'ifSourceGenerationMatch', u'ifSourceGenerationNotMatch', u'ifSourceMetagenerationMatch', u'ifSourceMetagenerationNotMatch', u'projection', u'sourceGeneration'],
+        relative_path=u'b/{sourceBucket}/o/{sourceObject}/copyTo/b/{destinationBucket}/o/{destinationObject}',
+        request_field=u'object',
+        request_type_name=u'StorageObjectsCopyRequest',
+        response_type_name=u'Object',
+        supports_download=True,
+    )
+
     def Delete(self, request, global_params=None):
       """Deletes an object and its metadata. Deletions are permanent if versioning is not enabled for the bucket, or if the generation parameter is used.
 
@@ -1141,6 +1022,19 @@ class StorageV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('Delete')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    Delete.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'DELETE',
+        method_id=u'storage.objects.delete',
+        ordered_params=[u'bucket', u'object'],
+        path_params=[u'bucket', u'object'],
+        query_params=[u'generation', u'ifGenerationMatch', u'ifGenerationNotMatch', u'ifMetagenerationMatch', u'ifMetagenerationNotMatch'],
+        relative_path=u'b/{bucket}/o/{object}',
+        request_field='',
+        request_type_name=u'StorageObjectsDeleteRequest',
+        response_type_name=u'StorageObjectsDeleteResponse',
+        supports_download=False,
+    )
 
     def Get(self, request, global_params=None, download=None):
       """Retrieves an object or its metadata.
@@ -1158,6 +1052,19 @@ class StorageV1(base_api.BaseApiClient):
           config, request, global_params=global_params,
           download=download)
 
+    Get.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'storage.objects.get',
+        ordered_params=[u'bucket', u'object'],
+        path_params=[u'bucket', u'object'],
+        query_params=[u'generation', u'ifGenerationMatch', u'ifGenerationNotMatch', u'ifMetagenerationMatch', u'ifMetagenerationNotMatch', u'projection'],
+        relative_path=u'b/{bucket}/o/{object}',
+        request_field='',
+        request_type_name=u'StorageObjectsGetRequest',
+        response_type_name=u'Object',
+        supports_download=True,
+    )
+
     def GetIamPolicy(self, request, global_params=None):
       """Returns an IAM policy for the specified object.
 
@@ -1170,6 +1077,19 @@ class StorageV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('GetIamPolicy')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    GetIamPolicy.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'storage.objects.getIamPolicy',
+        ordered_params=[u'bucket', u'object'],
+        path_params=[u'bucket', u'object'],
+        query_params=[u'generation'],
+        relative_path=u'b/{bucket}/o/{object}/iam',
+        request_field='',
+        request_type_name=u'StorageObjectsGetIamPolicyRequest',
+        response_type_name=u'Policy',
+        supports_download=False,
+    )
 
     def Insert(self, request, global_params=None, upload=None, download=None):
       """Stores a new object and metadata.
@@ -1191,6 +1111,19 @@ class StorageV1(base_api.BaseApiClient):
           upload=upload, upload_config=upload_config,
           download=download)
 
+    Insert.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'POST',
+        method_id=u'storage.objects.insert',
+        ordered_params=[u'bucket'],
+        path_params=[u'bucket'],
+        query_params=[u'contentEncoding', u'ifGenerationMatch', u'ifGenerationNotMatch', u'ifMetagenerationMatch', u'ifMetagenerationNotMatch', u'name', u'predefinedAcl', u'projection'],
+        relative_path=u'b/{bucket}/o',
+        request_field=u'object',
+        request_type_name=u'StorageObjectsInsertRequest',
+        response_type_name=u'Object',
+        supports_download=True,
+    )
+
     def List(self, request, global_params=None):
       """Retrieves a list of objects matching the criteria.
 
@@ -1203,6 +1136,19 @@ class StorageV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('List')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    List.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'storage.objects.list',
+        ordered_params=[u'bucket'],
+        path_params=[u'bucket'],
+        query_params=[u'delimiter', u'maxResults', u'pageToken', u'prefix', u'projection', u'versions'],
+        relative_path=u'b/{bucket}/o',
+        request_field='',
+        request_type_name=u'StorageObjectsListRequest',
+        response_type_name=u'Objects',
+        supports_download=False,
+    )
 
     def Patch(self, request, global_params=None):
       """Updates an object's metadata. This method supports patch semantics.
@@ -1217,6 +1163,19 @@ class StorageV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    Patch.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'PATCH',
+        method_id=u'storage.objects.patch',
+        ordered_params=[u'bucket', u'object'],
+        path_params=[u'bucket', u'object'],
+        query_params=[u'generation', u'ifGenerationMatch', u'ifGenerationNotMatch', u'ifMetagenerationMatch', u'ifMetagenerationNotMatch', u'predefinedAcl', u'projection'],
+        relative_path=u'b/{bucket}/o/{object}',
+        request_field=u'objectResource',
+        request_type_name=u'StorageObjectsPatchRequest',
+        response_type_name=u'Object',
+        supports_download=False,
+    )
+
     def Rewrite(self, request, global_params=None):
       """Rewrites a source object to a destination object. Optionally overrides metadata.
 
@@ -1229,6 +1188,19 @@ class StorageV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('Rewrite')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    Rewrite.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'POST',
+        method_id=u'storage.objects.rewrite',
+        ordered_params=[u'sourceBucket', u'sourceObject', u'destinationBucket', u'destinationObject'],
+        path_params=[u'destinationBucket', u'destinationObject', u'sourceBucket', u'sourceObject'],
+        query_params=[u'destinationPredefinedAcl', u'ifGenerationMatch', u'ifGenerationNotMatch', u'ifMetagenerationMatch', u'ifMetagenerationNotMatch', u'ifSourceGenerationMatch', u'ifSourceGenerationNotMatch', u'ifSourceMetagenerationMatch', u'ifSourceMetagenerationNotMatch', u'maxBytesRewrittenPerCall', u'projection', u'rewriteToken', u'sourceGeneration'],
+        relative_path=u'b/{sourceBucket}/o/{sourceObject}/rewriteTo/b/{destinationBucket}/o/{destinationObject}',
+        request_field=u'object',
+        request_type_name=u'StorageObjectsRewriteRequest',
+        response_type_name=u'RewriteResponse',
+        supports_download=False,
+    )
 
     def SetIamPolicy(self, request, global_params=None):
       """Updates an IAM policy for the specified object.
@@ -1243,6 +1215,19 @@ class StorageV1(base_api.BaseApiClient):
       return self._RunMethod(
           config, request, global_params=global_params)
 
+    SetIamPolicy.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'PUT',
+        method_id=u'storage.objects.setIamPolicy',
+        ordered_params=[u'bucket', u'object'],
+        path_params=[u'bucket', u'object'],
+        query_params=[u'generation'],
+        relative_path=u'b/{bucket}/o/{object}/iam',
+        request_field=u'policy',
+        request_type_name=u'StorageObjectsSetIamPolicyRequest',
+        response_type_name=u'Policy',
+        supports_download=False,
+    )
+
     def TestIamPermissions(self, request, global_params=None):
       """Tests a set of permissions on the given object to see which, if any, are held by the caller.
 
@@ -1255,6 +1240,19 @@ class StorageV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('TestIamPermissions')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    TestIamPermissions.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'GET',
+        method_id=u'storage.objects.testIamPermissions',
+        ordered_params=[u'bucket', u'object', u'permissions'],
+        path_params=[u'bucket', u'object'],
+        query_params=[u'generation', u'permissions'],
+        relative_path=u'b/{bucket}/o/{object}/iam/testPermissions',
+        request_field='',
+        request_type_name=u'StorageObjectsTestIamPermissionsRequest',
+        response_type_name=u'TestIamPermissionsResponse',
+        supports_download=False,
+    )
 
     def Update(self, request, global_params=None, download=None):
       """Updates an object's metadata.
@@ -1272,6 +1270,19 @@ class StorageV1(base_api.BaseApiClient):
           config, request, global_params=global_params,
           download=download)
 
+    Update.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'PUT',
+        method_id=u'storage.objects.update',
+        ordered_params=[u'bucket', u'object'],
+        path_params=[u'bucket', u'object'],
+        query_params=[u'generation', u'ifGenerationMatch', u'ifGenerationNotMatch', u'ifMetagenerationMatch', u'ifMetagenerationNotMatch', u'predefinedAcl', u'projection'],
+        relative_path=u'b/{bucket}/o/{object}',
+        request_field=u'objectResource',
+        request_type_name=u'StorageObjectsUpdateRequest',
+        response_type_name=u'Object',
+        supports_download=True,
+    )
+
     def WatchAll(self, request, global_params=None):
       """Watch for changes on all objects in a bucket.
 
@@ -1284,3 +1295,16 @@ class StorageV1(base_api.BaseApiClient):
       config = self.GetMethodConfig('WatchAll')
       return self._RunMethod(
           config, request, global_params=global_params)
+
+    WatchAll.method_config = lambda: base_api.ApiMethodInfo(
+        http_method=u'POST',
+        method_id=u'storage.objects.watchAll',
+        ordered_params=[u'bucket'],
+        path_params=[u'bucket'],
+        query_params=[u'delimiter', u'maxResults', u'pageToken', u'prefix', u'projection', u'versions'],
+        relative_path=u'b/{bucket}/o/watch',
+        request_field=u'channel',
+        request_type_name=u'StorageObjectsWatchAllRequest',
+        response_type_name=u'Channel',
+        supports_download=False,
+    )


### PR DESCRIPTION
This PR tries to address a few goals simultaneously:
  1. Make method configs accessible statically, not requiring client initialization.
  1. Do not create all method configs upon import
  1. Do not create all method configs during client instantiation.

While method configs are relatively lightweight in grand schema of things, there can be quite a few of them. Some generated clients have 300-400 and sometimes applications need to use multiple such clients.
Since they are based on proto messages they are more expensive (measured upwards 20x) to instantiate as opposed to plain class or namedtuple.

For applications where startup time is important instantiating all these method_config instances during import time becomes prohibitive, running in over 100ms. At the same time there cases where structure of certain requests (like Get) needs to be introspected (for example when trying to parse a uri), without ever creating a client.

Longer term this extra functionality for managing resource ids can be (should be?) part of apitools.

This PR does not change existing public interface, and has been tested against heavy users of this library.
