### PR TITLE
Fixes #123

### DIFF
--- a/apitools/base/protorpclite/messages.py
+++ b/apitools/base/protorpclite/messages.py
@@ -300,7 +300,8 @@ class _EnumClass(_DefinitionClass):
 
     def __init__(cls, name, bases, dct):
         # Can only define one level of sub-classes below Enum.
-        if not (bases == (object,) or tuple(base.__name__ in bases) == ('Enum',)):
+        if not (bases == (object,) or
+                tuple(base.__name__ for base in bases) == ('Enum',)):
             raise EnumDefinitionError(
                 'Enum type %s may only inherit from Enum' % name)
 

--- a/apitools/base/protorpclite/messages.py
+++ b/apitools/base/protorpclite/messages.py
@@ -300,7 +300,7 @@ class _EnumClass(_DefinitionClass):
 
     def __init__(cls, name, bases, dct):
         # Can only define one level of sub-classes below Enum.
-        if not (bases == (object,) or bases == (Enum,)):
+        if not (bases == (object,) or tuple(base.__name__ in bases) == ('Enum',)):
             raise EnumDefinitionError(
                 'Enum type %s may only inherit from Enum' % name)
 


### PR DESCRIPTION
Class Enum is not define in this reference. 
Getting the class name is a workaround to a circular dependency, since ```Enum``` inherits form ```_EnumClass``` itself.