### PR TITLE
Expose client mock url and http properties.

### DIFF
--- a/apitools/base/py/testing/mock.py
+++ b/apitools/base/py/testing/mock.py
@@ -324,6 +324,10 @@ class Client(object):
         self.__real_include_fields = self.__client_class.IncludeFields
         self.__client_class.IncludeFields = self.IncludeFields
 
+        # pylint: disable=attribute-defined-outside-init
+        self._url = client._url
+        self._http = client._http
+
         return self
 
     def __exit__(self, exc_type, value, traceback):
@@ -338,6 +342,8 @@ class Client(object):
             setattr(self.__client_class, name, service_class)
             delattr(self, service_class._NAME)
         self.__real_service_classes = {}
+        del self._url
+        del self._http
 
         if self._request_responses:
             raise ExpectedRequestsException(

--- a/apitools/base/py/testing/mock_test.py
+++ b/apitools/base/py/testing/mock_test.py
@@ -15,6 +15,7 @@
 
 """Tests for apitools.base.py.testing.mock."""
 
+import httplib2
 import unittest2
 import six
 
@@ -111,6 +112,32 @@ class MockTest(unittest2.TestCase):
         with mock.Client(fusiontables.FusiontablesV1) as mock_client:
             self.assertEquals(fusiontables_messages,
                               mock_client.MESSAGES_MODULE)
+
+    def testMockHasUrlProperty(self):
+        with mock.Client(fusiontables.FusiontablesV1) as mock_client:
+            self.assertEquals(fusiontables.FusiontablesV1.BASE_URL,
+                              mock_client.url)
+        self.assertFalse(hasattr(mock_client, 'url'))
+
+    def testMockHasOverrideUrlProperty(self):
+        real_client = fusiontables.FusiontablesV1(url='http://localhost:8080',
+                                                  get_credentials=False)
+        with mock.Client(fusiontables.FusiontablesV1,
+                         real_client) as mock_client:
+            self.assertEquals('http://localhost:8080/', mock_client.url)
+
+    def testMockHasHttpProperty(self):
+        with mock.Client(fusiontables.FusiontablesV1) as mock_client:
+            self.assertIsInstance(mock_client.http, httplib2.Http)
+        self.assertFalse(hasattr(mock_client, 'http'))
+
+    def testMockHasOverrideHttpProperty(self):
+        real_client = fusiontables.FusiontablesV1(url='http://localhost:8080',
+                                                  http='SomeHttpObject',
+                                                  get_credentials=False)
+        with mock.Client(fusiontables.FusiontablesV1,
+                         real_client) as mock_client:
+            self.assertEquals('SomeHttpObject', mock_client.http)
 
     def testMockPreservesServiceMethods(self):
         services = _GetApiServices(fusiontables.FusiontablesV1)


### PR DESCRIPTION
Real apitools client has public url and http properties.
This ensures that these properties work in mocked client.
