### PR TITLE
Update YieldFromList to support APIs without a batch_size_attribute

### DIFF
--- a/apitools/base/py/list_pager.py
+++ b/apitools/base/py/list_pager.py
@@ -52,14 +52,15 @@ def YieldFromList(
           response message holding the page token for the next page.
       batch_size_attribute: str, The name of the attribute in a
           response message holding the maximum number of results to be
-          returned.
+          returned. None if caller-specified batch size is unsupported.
 
     Yields:
       protorpc.message.Message, The resources listed by the service.
 
     """
     request = encoding.CopyProtoMessage(request)
-    setattr(request, batch_size_attribute, batch_size)
+    if batch_size_attribute:
+        setattr(request, batch_size_attribute, batch_size)
     setattr(request, current_token_attribute, None)
     while limit is None or limit:
         response = getattr(service, method)(request,

--- a/apitools/base/py/list_pager_test.py
+++ b/apitools/base/py/list_pager_test.py
@@ -218,3 +218,29 @@ class ListPagerAttributeTest(unittest2.TestCase):
         for i, instance in enumerate(results):
             self.assertEquals('c{0}'.format(i), instance.fullResourcePath)
         self.assertEquals(2, i)
+    
+    def testYieldFromListWithNoBatchSizeAttribute(self):
+        self.mocked_client.iamPolicies.GetPolicyDetails.Expect(
+            iam_messages.GetPolicyDetailsRequest(
+                pageToken=None,
+                fullResourcePath='myresource',
+            ),
+            iam_messages.GetPolicyDetailsResponse(
+                policies=[
+                    iam_messages.PolicyDetail(fullResourcePath='c0'),
+                    iam_messages.PolicyDetail(fullResourcePath='c1'),
+                ],
+            ))
+        
+        client = iam_client.IamV1(get_credentials=False)
+        request = iam_messages.GetPolicyDetailsRequest(
+            fullResourcePath='myresource')
+        results = list_pager.YieldFromList(
+            client.iamPolicies, request,
+            batch_size_attribute=None,
+            method='GetPolicyDetails', field='policies')
+
+        i = 0
+        for i, instance in enumerate(results):
+            self.assertEquals('c{0}'.format(i), instance.fullResourcePath)
+        self.assertEquals(1, i)


### PR DESCRIPTION
Cloud Bigtable services generally don't support a user-specified batch size in their List request objects. With this edit, YieldFromList can work with them.