### PR TITLE
Force gflags dependent library version to 3.0.6.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ REQUIRED_PACKAGES = [
 
 CLI_PACKAGES = [
     'google-apputils>=0.4.0',
-    'python-gflags>=2.0',
+    'python-gflags==3.0.6',  # Starting version 3.0.7 py26 is not supported.
 ]
 
 TESTING_PACKAGES = [

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,9 @@
 envlist = py26,py27,pypy,py34,py35,lint,cover,py27oldoauth2client
 
 [testenv]
-deps = nose
+deps =
+    nose
+    python-gflags==3.0.6
 commands =
     pip install google-apitools[testing]
     nosetests []
@@ -53,7 +55,7 @@ commands =
     nosetests --with-xunit --with-xcoverage --cover-package=apitools --nocapture --cover-erase --cover-tests --cover-branches []
 deps =
     google-apputils
-    python-gflags
+    python-gflags==3.0.6
     mock
     nose
     unittest2


### PR DESCRIPTION
Python 2.6 is no longer supported by gflags.