### PR TITLE
Do not raise exception in client mock if one already active.

### DIFF
--- a/apitools/base/py/list_pager_test.py
+++ b/apitools/base/py/list_pager_test.py
@@ -218,7 +218,7 @@ class ListPagerAttributeTest(unittest2.TestCase):
         for i, instance in enumerate(results):
             self.assertEquals('c{0}'.format(i), instance.fullResourcePath)
         self.assertEquals(2, i)
-    
+
     def testYieldFromListWithNoBatchSizeAttribute(self):
         self.mocked_client.iamPolicies.GetPolicyDetails.Expect(
             iam_messages.GetPolicyDetailsRequest(
@@ -231,7 +231,7 @@ class ListPagerAttributeTest(unittest2.TestCase):
                     iam_messages.PolicyDetail(fullResourcePath='c1'),
                 ],
             ))
-        
+
         client = iam_client.IamV1(get_credentials=False)
         request = iam_messages.GetPolicyDetailsRequest(
             fullResourcePath='myresource')

--- a/apitools/base/py/testing/mock_test.py
+++ b/apitools/base/py/testing/mock_test.py
@@ -37,6 +37,10 @@ def _GetApiServices(api_client_class):
             issubclass(potential_service, apitools_base.BaseApiService)))
 
 
+class CustomException(Exception):
+    pass
+
+
 class MockTest(unittest2.TestCase):
 
     def testMockFusionBasic(self):
@@ -55,6 +59,12 @@ class MockTest(unittest2.TestCase):
             client = fusiontables.FusiontablesV1(get_credentials=False)
             with self.assertRaises(apitools_base.HttpError):
                 client.column.List(1)
+
+    def testMockIfAnotherException(self):
+        with self.assertRaises(CustomException):
+            with mock.Client(fusiontables.FusiontablesV1) as client_class:
+                client_class.column.List.Expect(request=1, response=2)
+                raise CustomException('Something when wrong')
 
     def testMockFusionOrder(self):
         with mock.Client(fusiontables.FusiontablesV1) as client_class:


### PR DESCRIPTION
Developers get confused by this. While some test runners would show the stacktrace for both errors, only latter exception is scraped by some UIs masking the original uncaught exception.

This change makes sure to let original exception to propagate even if mock has failed.  