### PR TITLE
Pin oauth2client to avoid using version 4.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ py_version = platform.python_version()
 if py_version < '2.7':
     REQUIRED_PACKAGES.append('argparse>=1.2.1')
 
-_APITOOLS_VERSION = '0.5.4'
+_APITOOLS_VERSION = '0.5.5'
 
 with open('README.rst') as fileobj:
     README = fileobj.read()

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ except ImportError:
 # Python version and OS.
 REQUIRED_PACKAGES = [
     'httplib2>=0.8',
-    'oauth2client>=1.5.2',
+    'oauth2client>=1.5.2,<4.0.0dev',
     'setuptools>=18.5',
     'six>=1.9.0',
     ]


### PR DESCRIPTION
The 4.0.0 version of oauth2client removes locked_file.