### PR TITLE
Fix a nasty encoding corner case with JsonValue.

### DIFF
--- a/apitools/base/protorpclite/protojson.py
+++ b/apitools/base/protorpclite/protojson.py
@@ -277,22 +277,20 @@ class ProtoJson(object):
                         'No variant found for unrecognized field: %s', key)
                 continue
 
-            # Normalize values in to a list.
-            if isinstance(value, list):
-                if not value:
-                    continue
-            else:
-                value = [value]
-
-            valid_value = []
-            for item in value:
-                valid_value.append(self.decode_field(field, item))
+            # This is just for consistency with the old behavior.
+            if value == []:
+                continue
 
             if field.repeated:
-                _ = getattr(message, field.name)
+                # This should be unnecessary? Or in fact become an error.
+                if not isinstance(value, list):
+                    value = [value]
+                valid_value = [self.decode_field(field, item)
+                               for item in value]
                 setattr(message, field.name, valid_value)
             else:
-                setattr(message, field.name, valid_value[-1])
+                setattr(message, field.name, self.decode_field(field, value))
+
         return message
 
     def decode_field(self, field, value):

--- a/apitools/base/py/extra_types_test.py
+++ b/apitools/base/py/extra_types_test.py
@@ -129,6 +129,18 @@ class ExtraTypesTest(unittest2.TestCase):
         self.assertEqual(json_value, encoding.MessageToJson(value))
         self.assertEqual(json_obj, encoding.MessageToJson(obj))
 
+    def testJsonValueAsFieldTranslation(self):
+        class HasJsonValueMsg(messages.Message):
+            some_value = messages.MessageField(extra_types.JsonValue, 1)
+
+        msg_json = '{"some_value": [1, 2, 3]}'
+        msg = HasJsonValueMsg(
+            some_value=encoding.PyValueToMessage(
+                extra_types.JsonValue, [1, 2, 3]))
+        self.assertEqual(msg,
+                         encoding.JsonToMessage(HasJsonValueMsg, msg_json))
+        self.assertEqual(msg_json, encoding.MessageToJson(msg))
+
     def testDateField(self):
 
         class DateMsg(messages.Message):


### PR DESCRIPTION
The json encoding code in protorpc had a bit of custom logic to handle the
case of repeated vs. non-repeated fields with the same line of code. However,
in the case of a JsonValue (aka `any` type in a discovery doc), it's possible
for a non-repeated value to itself be a list. In this case, we'd always
deserialize the whole list, and then ... only use the last value.

The fix here is to actually simplify the code a bit, and split the logic based
on whether the field is repeated, *not* whether the value is itself a list.

This PR is partly for demonstration -- we need a test.

/cc @sb2nov