### PR TITLE
Add limit support for limiting size of batch request.

### DIFF
--- a/apitools/base/py/__init__.py
+++ b/apitools/base/py/__init__.py
@@ -17,6 +17,7 @@
 """Top-level imports for apitools base files."""
 
 # pylint:disable=wildcard-import
+# pylint:disable=redefined-builtin
 from apitools.base.py.base_api import *
 from apitools.base.py.batch import *
 from apitools.base.py.credentials_lib import *


### PR DESCRIPTION
Some apis impose limit on batch requests.
See for example:
  https://cloud.google.com/compute/docs/api/how-tos/batch