### PR TITLE
Treat exceptions accessing GCE credential cache file as a cache miss

### DIFF
--- a/apitools/base/py/credentials_lib.py
+++ b/apitools/base/py/credentials_lib.py
@@ -302,6 +302,8 @@ class GceAssertionCredentials(gce.AppAssertionCredentials):
                             if (creds['scopes'] in
                                     (None, cached_creds['scopes'])):
                                 scopes = cached_creds['scopes']
+                except KeyboardInterrupt:
+                    raise
                 except:  # pylint: disable=bare-except
                     # Treat exceptions as a cache miss.
                     pass
@@ -334,6 +336,8 @@ class GceAssertionCredentials(gce.AppAssertionCredentials):
                         # If it's not locked, the locking process will
                         # write the same data to the file, so just
                         # continue.
+                except KeyboardInterrupt:
+                    raise
                 except:  # pylint: disable=bare-except
                     # Treat exceptions as a cache miss.
                     pass

--- a/apitools/base/py/credentials_lib.py
+++ b/apitools/base/py/credentials_lib.py
@@ -302,6 +302,9 @@ class GceAssertionCredentials(gce.AppAssertionCredentials):
                             if (creds['scopes'] in
                                     (None, cached_creds['scopes'])):
                                 scopes = cached_creds['scopes']
+                except:  # pylint: disable=bare-except
+                    # Treat exceptions as a cache miss.
+                    pass
                 finally:
                     cache_file.unlock_and_close()
         return scopes
@@ -331,6 +334,9 @@ class GceAssertionCredentials(gce.AppAssertionCredentials):
                         # If it's not locked, the locking process will
                         # write the same data to the file, so just
                         # continue.
+                except:  # pylint: disable=bare-except
+                    # Treat exceptions as a cache miss.
+                    pass
                 finally:
                     cache_file.unlock_and_close()
 


### PR DESCRIPTION
This fixes an issue where problems accessing the cache file on
the filesystem (for example, in a container with no mounted
filesystem) would cause apitools to abort entirely, as opposed to
simply not caching the credentials.

Fixes https://github.com/google/apitools/issues/139