### PR TITLE
Add batch request callback hook

### DIFF
--- a/apitools/base/py/batch.py
+++ b/apitools/base/py/batch.py
@@ -182,7 +182,7 @@ class BatchApiRequest(object):
         self.api_requests.append(api_request)
 
     def Execute(self, http, sleep_between_polls=5, max_retries=5,
-                max_batch_size=None):
+                max_batch_size=None, batch_request_callback=None):
         """Execute all of the requests in the batch.
 
         Args:
@@ -209,7 +209,10 @@ class BatchApiRequest(object):
             for i in range(0, len(requests), batch_size):
                 # Create a batch_http_request object and populate it with
                 # incomplete requests.
-                batch_http_request = BatchHttpRequest(batch_url=self.batch_url)
+                batch_http_request = BatchHttpRequest(
+                    batch_url=self.batch_url,
+                    callback=batch_request_callback
+                )
                 for request in itertools.islice(requests,
                                                 i, i + batch_size):
                     batch_http_request.Add(

--- a/apitools/base/py/batch.py
+++ b/apitools/base/py/batch.py
@@ -194,6 +194,8 @@ class BatchApiRequest(object):
               exception, whatever it happened to be.
           max_batch_size: int, if specified requests will be split in batches
               of given size.
+          batch_request_callback: function of (http_response, exception) passed
+              to BatchHttpRequest which will be run on any given results.
 
         Returns:
           List of ApiCalls.

--- a/apitools/base/py/batch_test.py
+++ b/apitools/base/py/batch_test.py
@@ -152,12 +152,13 @@ class BatchTest(unittest2.TestCase):
     def testSingleRequestInBatch(self):
         desired_url = 'https://www.example.com'
 
-        callback_result = None
+        callback_was_called = []
         def _Callback(response, exception):
             self.assertEqual({'status': '200'}, response.info)
             self.assertEqual('content', response.content)
             self.assertEqual(desired_url, response.request_url)
             self.assertIsNone(exception)
+            callback_was_called.append(1)
 
         mock_service = FakeService()
 
@@ -205,6 +206,7 @@ class BatchTest(unittest2.TestCase):
             self.assertEqual({'status': '200'}, response.info)
             self.assertEqual('content', response.content)
             self.assertEqual(desired_url, response.request_url)
+        self.assertEquals(1, len(callback_was_called))
 
     def _MakeResponse(self, number_of_parts):
         return http_wrapper.Response(

--- a/apitools/base/py/batch_test.py
+++ b/apitools/base/py/batch_test.py
@@ -150,9 +150,17 @@ class BatchTest(unittest2.TestCase):
                                   exceptions.HttpError)
 
     def testSingleRequestInBatch(self):
+        desired_url = 'https://www.example.com'
+
+        callback_result = None
+        def _Callback(response, exception):
+            self.assertEqual({'status': '200'}, response.info)
+            self.assertEqual('content', response.content)
+            self.assertEqual(desired_url, response.request_url)
+            self.assertIsNone(exception)
+
         mock_service = FakeService()
 
-        desired_url = 'https://www.example.com'
         batch_api_request = batch.BatchApiRequest(batch_url=desired_url)
         # The request to be added. The actual request sent will be somewhat
         # larger, as this is added to a batch.
@@ -185,7 +193,8 @@ class BatchTest(unittest2.TestCase):
                 'desired_request': desired_request,
             })
 
-            api_request_responses = batch_api_request.Execute(FakeHttp())
+            api_request_responses = batch_api_request.Execute(
+                FakeHttp(), batch_request_callback=_Callback)
 
             self.assertEqual(1, len(api_request_responses))
             self.assertEqual(1, mock_request.call_count)


### PR DESCRIPTION
This allows custom error handling etc in the case of batch requests, similar to what is possible in single request mode.