### PR TITLE
Add the Metadata-Flavor header for GCE detection.

### DIFF
--- a/apitools/base/py/util.py
+++ b/apitools/base/py/util.py
@@ -63,7 +63,8 @@ def DetectGce():
     """
     try:
         o = urllib_request.build_opener(urllib_request.ProxyHandler({})).open(
-            urllib_request.Request('http://metadata.google.internal'))
+            urllib_request.Request('http://metadata.google.internal',
+                                   headers={'Metadata-Flavor': 'Google'}))
     except urllib_error.URLError:
         return False
     return (o.getcode() == http_client.OK and


### PR DESCRIPTION
This is required for GCE detection: newer versions of the metadata service
will reject requests without this header, meaning that GCE detection will
fail.

PTAL @vilasj @cherba 