### PR TITLE
Fix a bug with ADC being None.

### DIFF
--- a/apitools/base/py/credentials_lib.py
+++ b/apitools/base/py/credentials_lib.py
@@ -656,6 +656,8 @@ def _GetApplicationDefaultCredentials(
     # cloud-platform, our scopes are a subset of cloud scopes, and the
     # ADC will work.
     cp = 'https://www.googleapis.com/auth/cloud-platform'
+    if credentials is None:
+        return None
     if not isinstance(credentials, gc) or cp in scopes:
         return credentials.create_scoped(scopes)
     return None

--- a/apitools/base/py/credentials_lib_test.py
+++ b/apitools/base/py/credentials_lib_test.py
@@ -80,6 +80,13 @@ class CredentialsLibTest(unittest2.TestCase):
             # The urllib module does weird things with header case.
             self.assertEqual('Google', req.get_header('Metadata-flavor'))
 
+    def testGetAdcNone(self):
+        # Tests that we correctly return None when ADC aren't present in
+        # the well-known file.
+        creds = credentials_lib._GetApplicationDefaultCredentials(
+            client_info={'scope': ''})
+        self.assertIsNone(creds)
+
 
 class TestGetRunFlowFlags(unittest2.TestCase):
 


### PR DESCRIPTION
Unsurprisingly, None doesn't have a `create_scoped` method. :)