### PR TITLE
Process schemas in predictable order in codegen.

### DIFF
--- a/apitools/gen/gen_client_lib.py
+++ b/apitools/gen/gen_client_lib.py
@@ -90,7 +90,7 @@ class DescriptorGenerator(object):
             self.__root_package, self.__base_files_package,
             self.__protorpc_package)
         schemas = self.__discovery_doc.get('schemas', {})
-        for schema_name, schema in schemas.items():
+        for schema_name, schema in sorted(schemas.items()):
             self.__message_registry.AddDescriptorFromSchema(
                 schema_name, schema)
 


### PR DESCRIPTION
Without this the generation process can produce code which is lightly differently ordered.

Sample Diff:

```
 encoding.AddCustomJsonFieldMapping(
-    JsonSchema, '_ref', '$ref',
-    package=u'discovery')
-encoding.AddCustomJsonFieldMapping(
     RestMethod.RequestValue, '_ref', '$ref',
     package=u'discovery')
 encoding.AddCustomJsonFieldMapping(
     RestMethod.ResponseValue, '_ref', '$ref',
     package=u'discovery')
+encoding.AddCustomJsonFieldMapping(
+    JsonSchema, '_ref', '$ref',
+    package=u'discovery')
```