### PR TITLE
Allow key of AdditionalProperty to contain unicode

### DIFF
--- a/apitools/base/py/encoding.py
+++ b/apitools/base/py/encoding.py
@@ -428,7 +428,12 @@ def _DecodeUnrecognizedFields(message, pair_type):
         else:
             decoded_value = protojson.ProtoJson().decode_field(
                 pair_type.value, value)
-        new_pair = pair_type(key=str(unknown_field), value=decoded_value)
+        try:
+            new_pair_key = str(unknown_field)
+        except UnicodeEncodeError:
+            new_pair_key = protojson.ProtoJson().decode_field(
+                pair_type.key, unknown_field)
+        new_pair = pair_type(key=new_pair_key, value=decoded_value)
         new_values.append(new_pair)
     return new_values
 

--- a/apitools/base/py/encoding_test.py
+++ b/apitools/base/py/encoding_test.py
@@ -1,4 +1,4 @@
-#
+# -*- coding: utf-8 -*-
 # Copyright 2015 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -219,17 +219,17 @@ class EncodingTest(unittest2.TestCase):
             AdditionalPropertiesMessage.AdditionalProperty(
                 key='key_one', value='value_one'),
             AdditionalPropertiesMessage.AdditionalProperty(
-                key='key_two', value='value_two'),
+                key=u'key_twð', value='value_two'),
         ]
 
         encoded_msg = encoding.MessageToJson(msg)
         self.assertEqual(
-            {'key_one': 'value_one', 'key_two': 'value_two'},
+            {'key_one': 'value_one', u'key_twð': 'value_two'},
             json.loads(encoded_msg))
 
         new_msg = encoding.JsonToMessage(type(msg), encoded_msg)
         self.assertEqual(
-            set(('key_one', 'key_two')),
+            set(('key_one', u'key_twð')),
             set([x.key for x in new_msg.additional_properties]))
         self.assertIsNot(msg, new_msg)
 


### PR DESCRIPTION
Use case: for custom object metadata, gsutil uses an AdditionalProperty
message. Custom object metadata can contain unicode characters in either
the key or value fields. Previously, the key field was being implicitly
encoded as ASCII via a call to str(). When this call fails, we should
attempt to properly decode the field. See GoogleCloudPlatform/gsutil#431
for additional context.