### PR TITLE
Make JSON mappings use the class as a dictionary key

### DIFF
--- a/apitools/base/py/encoding.py
+++ b/apitools/base/py/encoding.py
@@ -659,7 +659,8 @@ def _CheckForExistingMappings(mapping_type, message_type,
 
 
 def _EncodeCustomFieldNames(message, encoded_value):
-    field_remappings = list(_JSON_FIELD_MAPPINGS.get(type(message), {}).items())
+    field_remappings = list(_JSON_FIELD_MAPPINGS.get(type(message), {})
+                            .items())
     if field_remappings:
         decoded_value = json.loads(encoded_value)
         for python_name, json_name in field_remappings:

--- a/apitools/base/py/encoding.py
+++ b/apitools/base/py/encoding.py
@@ -20,8 +20,6 @@ import base64
 import collections
 import datetime
 import json
-import os
-import sys
 
 import six
 
@@ -553,30 +551,8 @@ _JSON_ENUM_MAPPINGS = {}
 _JSON_FIELD_MAPPINGS = {}
 
 
-def _GetTypeKey(message_type, package):
-    """Get the prefix for this message type in mapping dicts."""
-    key = message_type.definition_name()
-    if package and key.startswith(package + '.'):
-        module_name = message_type.__module__
-        # We normalize '__main__' to something unique, if possible.
-        if module_name == '__main__':
-            try:
-                file_name = sys.modules[module_name].__file__
-            except (AttributeError, KeyError):
-                pass
-            else:
-                base_name = os.path.basename(file_name)
-                split_name = os.path.splitext(base_name)
-                if len(split_name) == 1:
-                    module_name = unicode(base_name)
-                else:
-                    module_name = u'.'.join(split_name[:-1])
-        key = module_name + '.' + key.partition('.')[2]
-    return key
-
-
 def AddCustomJsonEnumMapping(enum_type, python_name, json_name,
-                             package=''):
+                             package=None):  # pylint: disable=unused-argument
     """Add a custom wire encoding for a given enum value.
 
     This is primarily used in generated code, to handle enum values
@@ -586,24 +562,21 @@ def AddCustomJsonEnumMapping(enum_type, python_name, json_name,
       enum_type: (messages.Enum) An enum type
       python_name: (basestring) Python name for this value.
       json_name: (basestring) JSON name to be used on the wire.
-      package: (basestring, optional) Package prefix for this enum, if
-          present. We strip this off the enum name in order to generate
-          unique keys.
+      package: (NoneType, optional) No effect, exists for legacy compatibility.
     """
     if not issubclass(enum_type, messages.Enum):
         raise exceptions.TypecheckError(
             'Cannot set JSON enum mapping for non-enum "%s"' % enum_type)
-    enum_name = _GetTypeKey(enum_type, package)
     if python_name not in enum_type.names():
         raise exceptions.InvalidDataError(
             'Enum value %s not a value for type %s' % (python_name, enum_type))
-    field_mappings = _JSON_ENUM_MAPPINGS.setdefault(enum_name, {})
+    field_mappings = _JSON_ENUM_MAPPINGS.setdefault(enum_type, {})
     _CheckForExistingMappings('enum', enum_type, python_name, json_name)
     field_mappings[python_name] = json_name
 
 
 def AddCustomJsonFieldMapping(message_type, python_name, json_name,
-                              package=''):
+                              package=None):  # pylint: disable=unused-argument
     """Add a custom wire encoding for a given message field.
 
     This is primarily used in generated code, to handle enum values
@@ -613,36 +586,33 @@ def AddCustomJsonFieldMapping(message_type, python_name, json_name,
       message_type: (messages.Message) A message type
       python_name: (basestring) Python name for this value.
       json_name: (basestring) JSON name to be used on the wire.
-      package: (basestring, optional) Package prefix for this message, if
-          present. We strip this off the message name in order to generate
-          unique keys.
+      package: (NoneType, optional) No effect, exists for legacy compatibility.
     """
     if not issubclass(message_type, messages.Message):
         raise exceptions.TypecheckError(
             'Cannot set JSON field mapping for '
             'non-message "%s"' % message_type)
-    message_name = _GetTypeKey(message_type, package)
     try:
         _ = message_type.field_by_name(python_name)
     except KeyError:
         raise exceptions.InvalidDataError(
             'Field %s not recognized for type %s' % (
                 python_name, message_type))
-    field_mappings = _JSON_FIELD_MAPPINGS.setdefault(message_name, {})
+    field_mappings = _JSON_FIELD_MAPPINGS.setdefault(message_type, {})
     _CheckForExistingMappings('field', message_type, python_name, json_name)
     field_mappings[python_name] = json_name
 
 
 def GetCustomJsonEnumMapping(enum_type, python_name=None, json_name=None):
     """Return the appropriate remapping for the given enum, or None."""
-    return _FetchRemapping(enum_type.definition_name(), 'enum',
+    return _FetchRemapping(enum_type, 'enum',
                            python_name=python_name, json_name=json_name,
                            mappings=_JSON_ENUM_MAPPINGS)
 
 
 def GetCustomJsonFieldMapping(message_type, python_name=None, json_name=None):
     """Return the appropriate remapping for the given field, or None."""
-    return _FetchRemapping(message_type.definition_name(), 'field',
+    return _FetchRemapping(message_type, 'field',
                            python_name=python_name, json_name=json_name,
                            mappings=_JSON_FIELD_MAPPINGS)
 
@@ -689,8 +659,7 @@ def _CheckForExistingMappings(mapping_type, message_type,
 
 
 def _EncodeCustomFieldNames(message, encoded_value):
-    message_name = type(message).definition_name()
-    field_remappings = list(_JSON_FIELD_MAPPINGS.get(message_name, {}).items())
+    field_remappings = list(_JSON_FIELD_MAPPINGS.get(type(message), {}).items())
     if field_remappings:
         decoded_value = json.loads(encoded_value)
         for python_name, json_name in field_remappings:
@@ -701,8 +670,7 @@ def _EncodeCustomFieldNames(message, encoded_value):
 
 
 def _DecodeCustomFieldNames(message_type, encoded_message):
-    message_name = message_type.definition_name()
-    field_remappings = _JSON_FIELD_MAPPINGS.get(message_name, {})
+    field_remappings = _JSON_FIELD_MAPPINGS.get(message_type, {})
     if field_remappings:
         decoded_message = json.loads(encoded_message)
         for python_name, json_name in list(field_remappings.items()):

--- a/apitools/base/py/encoding_test.py
+++ b/apitools/base/py/encoding_test.py
@@ -138,7 +138,7 @@ class MessageWithRemappings(messages.Message):
     repeated_field = messages.StringField(5, repeated=True)
 
 
-class MessageWithAPackageAndRemappings(messages.Message):
+class MessageWithPackageAndRemappings(messages.Message):
 
     class SomeEnum(messages.Enum):
         enum_value = 1
@@ -401,19 +401,19 @@ class EncodingTest(unittest2.TestCase):
         this_module = sys.modules[__name__]
         package_name = 'my_package'
         try:
-          setattr(this_module, 'package', package_name)
+            setattr(this_module, 'package', package_name)
 
-          encoding.AddCustomJsonFieldMapping(
-              MessageWithAPackageAndRemappings,
-              'another_field', 'wire_field_name', package=package_name)
+            encoding.AddCustomJsonFieldMapping(
+                MessageWithPackageAndRemappings,
+                'another_field', 'wire_field_name', package=package_name)
 
-          msg = MessageWithAPackageAndRemappings(another_field='my value')
-          json_message = encoding.MessageToJson(msg)
-          self.assertEqual('{"wire_field_name": "my value"}', json_message)
-          self.assertEqual(
-              msg,
-              encoding.JsonToMessage(MessageWithAPackageAndRemappings,
-                                     json_message))
+            msg = MessageWithPackageAndRemappings(another_field='my value')
+            json_message = encoding.MessageToJson(msg)
+            self.assertEqual('{"wire_field_name": "my value"}', json_message)
+            self.assertEqual(
+                msg,
+                encoding.JsonToMessage(MessageWithPackageAndRemappings,
+                                       json_message))
         finally:
             delattr(this_module, 'package')
 
@@ -421,20 +421,20 @@ class EncodingTest(unittest2.TestCase):
         this_module = sys.modules[__name__]
         package_name = 'my_package'
         try:
-          setattr(this_module, 'package', package_name)
+            setattr(this_module, 'package', package_name)
 
-          encoding.AddCustomJsonEnumMapping(
-              MessageWithAPackageAndRemappings.SomeEnum,
-              'enum_value', 'other_wire_name', package=package_name)
+            encoding.AddCustomJsonEnumMapping(
+                MessageWithPackageAndRemappings.SomeEnum,
+                'enum_value', 'other_wire_name', package=package_name)
 
-          msg = MessageWithAPackageAndRemappings(
-              enum_field=MessageWithAPackageAndRemappings.SomeEnum.enum_value)
-          json_message = encoding.MessageToJson(msg)
-          self.assertEqual('{"enum_field": "other_wire_name"}', json_message)
-          self.assertEqual(
-              msg,
-              encoding.JsonToMessage(MessageWithAPackageAndRemappings,
-                                     json_message))
+            msg = MessageWithPackageAndRemappings(
+                enum_field=MessageWithPackageAndRemappings.SomeEnum.enum_value)
+            json_message = encoding.MessageToJson(msg)
+            self.assertEqual('{"enum_field": "other_wire_name"}', json_message)
+            self.assertEqual(
+                msg,
+                encoding.JsonToMessage(MessageWithPackageAndRemappings,
+                                       json_message))
 
         finally:
             delattr(this_module, 'package')


### PR DESCRIPTION
This had been using a string identifier which fails when a package is
specified.