### PR TITLE
Fix a bad bounds check for downloads.

### DIFF
--- a/apitools/base/py/transfer.py
+++ b/apitools/base/py/transfer.py
@@ -350,7 +350,7 @@ class Download(_Transfer):
     def __SetRangeHeader(self, request, start, end=None):
         if start < 0:
             request.headers['range'] = 'bytes=%d' % start
-        elif end is None:
+        elif end is None or end < start:
             request.headers['range'] = 'bytes=%d-' % start
         else:
             request.headers['range'] = 'bytes=%d-%d' % (start, end)


### PR DESCRIPTION
Previously, if we created a download with `auto_transfer=True` with the full
download smaller than the default `chunksize`, and then called
`StreamInChunks`, we'd end up downloading the full content twice. This was due
to a bad bounds check in setting a range header -- we'd end up with a header
like `Range: bytes=100-99`, and the server would ignore the start value,
giving us all the bytes again.

This adds a fix and a test.