### PR TITLE
Add simple upload compression support.

### DIFF
--- a/apitools/base/py/compression.py
+++ b/apitools/base/py/compression.py
@@ -26,7 +26,8 @@ __all__ = [
 
 
 # pylint: disable=invalid-name
-def CompressStream(in_stream, length, compresslevel=2, chunksize=16777216):
+def CompressStream(in_stream, length=None, compresslevel=2,
+                   chunksize=16777216):
 
     """Compresses an input stream into a file-like buffer.
 
@@ -43,7 +44,9 @@ def CompressStream(in_stream, length, compresslevel=2, chunksize=16777216):
             smaller than expected. Because data is written to the output
             buffer in increments of the chunksize, the output buffer may be
             larger than length by chunksize. Very uncompressible data can
-            exceed this further if gzip inflates the underlying data.
+            exceed this further if gzip inflates the underlying data. If
+            length is none, the input stream will be compressed until
+            it's exhausted.
         compresslevel: Optional, defaults to 2. The desired compression level.
         chunksize: Optional, defaults to 16MiB. The chunk size used when
             reading data from the input stream to write into the output
@@ -61,7 +64,7 @@ def CompressStream(in_stream, length, compresslevel=2, chunksize=16777216):
                        fileobj=out_stream,
                        compresslevel=compresslevel) as compress_stream:
         # Read until we've written at least length bytes to the output stream.
-        while out_stream.length < length:
+        while not length or out_stream.length < length:
             data = in_stream.read(chunksize)
             data_length = len(data)
             compress_stream.write(data)

--- a/apitools/base/py/compression_test.py
+++ b/apitools/base/py/compression_test.py
@@ -50,6 +50,22 @@ class CompressionTest(unittest2.TestCase):
         # Ensure the input stream was exhausted.
         self.assertTrue(exhausted)
 
+    def testCompressionUnbounded(self):
+        """Test unbounded compression.
+
+        Test that the input stream is exhausted when length is none.
+        """
+        output, read, exhausted = compression.CompressStream(
+            self.stream,
+            None,
+            9)
+        # Ensure the compressed buffer is smaller than the input buffer.
+        self.assertLess(output.length, self.length)
+        # Ensure we read the entire input stream.
+        self.assertEqual(read, self.length)
+        # Ensure the input stream was exhausted.
+        self.assertTrue(exhausted)
+
     def testCompressionPartial(self):
         """Test partial compression.
 

--- a/apitools/base/py/gzip.py
+++ b/apitools/base/py/gzip.py
@@ -47,7 +47,7 @@ def write32u(output, value):
     output.write(struct.pack("<L", value))
 
 
-class _PaddedFile:
+class _PaddedFile(object):
     """Minimal read-only file object that prepends a string to the contents
     of an actual file. Shouldn't be used outside of gzip.py, as it lacks
     essential functionality."""

--- a/apitools/base/py/transfer_test.py
+++ b/apitools/base/py/transfer_test.py
@@ -343,12 +343,10 @@ class CompressedUploadTest(unittest2.TestCase):
         # Set the chunk size so the entire stream is uploaded.
         upload.chunksize = len(self.sample_data)
         # Mock the upload to return the sample response.
-        with mock.patch.object(
-                transfer.Upload,
-                '_Upload__SendMediaRequest') as mock_result, \
-                mock.patch.object(
-                    http_wrapper,
-                    'MakeRequest') as make_request:
+        with mock.patch.object(transfer.Upload,
+                               '_Upload__SendMediaRequest') as mock_result, \
+                mock.patch.object(http_wrapper,
+                                  'MakeRequest') as make_request:
             mock_result.return_value = self.response
             make_request.return_value = self.response
 
@@ -382,9 +380,8 @@ class CompressedUploadTest(unittest2.TestCase):
             gzip_encoded=True)
         upload.strategy = transfer.RESUMABLE_UPLOAD
         # Mock the upload to return the sample response.
-        with mock.patch.object(
-                http_wrapper,
-                'MakeRequest') as make_request:
+        with mock.patch.object(http_wrapper,
+                               'MakeRequest') as make_request:
             make_request.return_value = self.response
 
             # Initialization.
@@ -410,12 +407,10 @@ class CompressedUploadTest(unittest2.TestCase):
             gzip_encoded=True)
         upload.strategy = transfer.RESUMABLE_UPLOAD
         # Mock the upload to return the sample response.
-        with mock.patch.object(
-                transfer.Upload,
-                'StreamInChunks') as mock_result, \
-                mock.patch.object(
-                    http_wrapper,
-                    'MakeRequest') as make_request:
+        with mock.patch.object(transfer.Upload,
+                               'StreamInChunks') as mock_result, \
+                mock.patch.object(http_wrapper,
+                                  'MakeRequest') as make_request:
             mock_result.return_value = self.response
             make_request.return_value = self.response
 


### PR DESCRIPTION
This pull request adds additional support for compressing "simple" uploads. This includes multipart and media uploads. Additionally, compressing uploads when auto_transfer is set is added.