### PR TITLE
Fix GCE creds serialization w/ oauth2client >= 4.0

### DIFF
--- a/apitools/base/py/credentials_lib_test.py
+++ b/apitools/base/py/credentials_lib_test.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os.path
 import shutil
 import tempfile
@@ -80,6 +81,18 @@ class CredentialsLibTest(unittest2.TestCase):
         self._GetServiceCreds(
             service_account_name='my_service_account',
             scopes=scopes)
+
+    def testGceAssertionCredentialsToJson(self):
+        scopes = ['scope1']
+        service_account_name = 'my_service_account'
+        # Ensure that we can obtain a JSON representation of
+        # GceAssertionCredentials to put in a credential Storage object, and
+        # that the JSON representation is valid.
+        original_creds = self._GetServiceCreds(
+            service_account_name=service_account_name,
+            scopes=scopes)
+        original_creds_json_str = original_creds.to_json()
+        json.loads(original_creds_json_str)
 
     @mock.patch.object(util, 'DetectGce', autospec=True)
     def testGceServiceAccountsCached(self, mock_detect):


### PR DESCRIPTION
When updating gsutil to use oauth2client 4.1.2 and apitools 0.5.19,
testing on GCE instances showed that GceAssertionCredentials were not
being written to our credential storage file. Debugging showed that this
was because of a KeyError when looking for the 'scope' attribute in a
serialized credential (no longer included as of oauth2client 3.0). The
'scope' value was also mistakenly being passed in as an argument for
'email'. This change maintains backward compatibility for oauth2client
versions that used the 'scope' attribute while also working for current
versions that don't include 'scope' when constructing a
GceAssertionCredentials object.