### PR TITLE
Fix issue with encoding unrecognized Enum values.

### DIFF
--- a/apitools/base/protorpclite/protojson.py
+++ b/apitools/base/protorpclite/protojson.py
@@ -283,11 +283,19 @@ class ProtoJson(object):
                 valid_value = [self.decode_field(field, item)
                                for item in value]
                 setattr(message, field.name, valid_value)
-            else:
-                # This is just for consistency with the old behavior.
-                if value == []:
-                    continue
+                continue
+            # This is just for consistency with the old behavior.
+            if value == []:
+                continue
+            try:
                 setattr(message, field.name, self.decode_field(field, value))
+            except messages.DecodeError:
+                # Save unknown enum values.
+                if not isinstance(field, messages.EnumField):
+                    raise
+                variant = self.__find_variant(value)
+                if variant:
+                    message.set_unrecognized_field(key, value, variant)
 
         return message
 

--- a/apitools/base/protorpclite/protojson_test.py
+++ b/apitools/base/protorpclite/protojson_test.py
@@ -198,12 +198,18 @@ class ProtojsonTest(test_util.TestCase,
 
     def testNumericEnumerationNegativeTest(self):
         """Test with an invalid number for the enum value."""
-        self.assertRaisesRegexp(
-            messages.DecodeError,
-            'Invalid enum value "89"',
-            protojson.decode_message,
-            MyMessage,
-            '{"an_enum": 89}')
+        # The message should successfully decode.
+        message = protojson.decode_message(MyMessage,
+                                           '{"an_enum": 89}')
+
+        expected_message = MyMessage()
+
+        self.assertEquals(expected_message, message)
+        # The roundtrip should result in equivalent encoded
+        # message.
+        self.assertEquals(
+            '{"an_enum": 89}',
+            protojson.encode_message(message))
 
     def testAlphaEnumeration(self):
         """Test that alpha enum values work."""
@@ -214,23 +220,36 @@ class ProtojsonTest(test_util.TestCase,
 
         self.assertEquals(expected_message, message)
 
+
     def testAlphaEnumerationNegativeTest(self):
         """The alpha enum value is invalid."""
-        self.assertRaisesRegexp(
-            messages.DecodeError,
-            'Invalid enum value "IAMINVALID"',
-            protojson.decode_message,
-            MyMessage,
-            '{"an_enum": "IAMINVALID"}')
+        # The message should successfully decode.
+        message = protojson.decode_message(MyMessage,
+                                           '{"an_enum": "IAMINVALID"}')
+
+        expected_message = MyMessage()
+
+        self.assertEquals(expected_message, message)
+        # The roundtrip should result in equivalent encoded
+        # message.
+        self.assertEquals(
+            '{"an_enum": "IAMINVALID"}',
+            protojson.encode_message(message))
 
     def testEnumerationNegativeTestWithEmptyString(self):
         """The enum value is an empty string."""
-        self.assertRaisesRegexp(
-            messages.DecodeError,
-            'Invalid enum value ""',
-            protojson.decode_message,
-            MyMessage,
-            '{"an_enum": ""}')
+        # The message should successfully decode.
+        message = protojson.decode_message(MyMessage,
+                                           '{"an_enum": ""}')
+
+        expected_message = MyMessage()
+
+        self.assertEquals(expected_message, message)
+        # The roundtrip should result in equivalent encoded
+        # message.
+        self.assertEquals(
+            '{"an_enum": ""}',
+            protojson.encode_message(message))
 
     def testNullValues(self):
         """Test that null values overwrite existing values."""

--- a/apitools/base/protorpclite/protojson_test.py
+++ b/apitools/base/protorpclite/protojson_test.py
@@ -51,6 +51,10 @@ class MyMessage(messages.Message):
 
         nested_value = messages.StringField(1)
 
+    class NestedDatetime(messages.Message):
+
+        nested_dt_value = message_types.DateTimeField(1)
+
     a_string = messages.StringField(2)
     an_integer = messages.IntegerField(3)
     a_float = messages.FloatField(4)
@@ -63,6 +67,7 @@ class MyMessage(messages.Message):
     a_repeated_datetime = message_types.DateTimeField(11, repeated=True)
     a_custom = CustomField(12)
     a_repeated_custom = CustomField(13, repeated=True)
+    a_nested_datetime = messages.MessageField(NestedDatetime, 14)
 
 
 class ModuleInterfaceTest(test_util.ModuleInterfaceTest,
@@ -367,6 +372,16 @@ class ProtojsonTest(test_util.TestCase,
     def testDecodeInvalidDateTime(self):
         self.assertRaises(messages.DecodeError, protojson.decode_message,
                           MyMessage, '{"a_datetime": "invalid"}')
+
+    def testDecodeInvalidMessage(self):
+        encoded = """{
+        "a_nested_datetime": {
+          "nested_dt_value": "invalid"
+          }
+        }
+        """
+        self.assertRaises(messages.DecodeError, protojson.decode_message,
+                          MyMessage, encoded)
 
     def testEncodeDateTime(self):
         for datetime_string, datetime_vals in (

--- a/apitools/base/protorpclite/protojson_test.py
+++ b/apitools/base/protorpclite/protojson_test.py
@@ -220,7 +220,6 @@ class ProtojsonTest(test_util.TestCase,
 
         self.assertEquals(expected_message, message)
 
-
     def testAlphaEnumerationNegativeTest(self):
         """The alpha enum value is invalid."""
         # The message should successfully decode.

--- a/apitools/base/protorpclite/protojson_test.py
+++ b/apitools/base/protorpclite/protojson_test.py
@@ -207,9 +207,7 @@ class ProtojsonTest(test_util.TestCase,
         self.assertEquals(expected_message, message)
         # The roundtrip should result in equivalent encoded
         # message.
-        self.assertEquals(
-            '{"an_enum": 89}',
-            protojson.encode_message(message))
+        self.assertEquals('{"an_enum": 89}', protojson.encode_message(message))
 
     def testAlphaEnumeration(self):
         """Test that alpha enum values work."""
@@ -229,26 +227,20 @@ class ProtojsonTest(test_util.TestCase,
         expected_message = MyMessage()
 
         self.assertEquals(expected_message, message)
-        # The roundtrip should result in equivalent encoded
-        # message.
-        self.assertEquals(
-            '{"an_enum": "IAMINVALID"}',
-            protojson.encode_message(message))
+        # The roundtrip should result in equivalent encoded message.
+        self.assertEquals('{"an_enum": "IAMINVALID"}',
+                          protojson.encode_message(message))
 
     def testEnumerationNegativeTestWithEmptyString(self):
         """The enum value is an empty string."""
         # The message should successfully decode.
-        message = protojson.decode_message(MyMessage,
-                                           '{"an_enum": ""}')
+        message = protojson.decode_message(MyMessage, '{"an_enum": ""}')
 
         expected_message = MyMessage()
 
         self.assertEquals(expected_message, message)
-        # The roundtrip should result in equivalent encoded
-        # message.
-        self.assertEquals(
-            '{"an_enum": ""}',
-            protojson.encode_message(message))
+        # The roundtrip should result in equivalent encoded message.
+        self.assertEquals('{"an_enum": ""}', protojson.encode_message(message))
 
     def testNullValues(self):
         """Test that null values overwrite existing values."""

--- a/apitools/base/protorpclite/test_util.py
+++ b/apitools/base/protorpclite/test_util.py
@@ -583,12 +583,11 @@ class ProtoConformanceTestBase(object):
         # successfully decoded even if the enum value is invalid. Encoding the
         # decoded message should result in equivalence with the original
         # encoded message containing an invalid enum.
-        decoded = self.PROTOLIB.decode_message(
-            OptionalMessage, self.encoded_invalid_enum)
+        decoded = self.PROTOLIB.decode_message(OptionalMessage,
+                                               self.encoded_invalid_enum)
         message = OptionalMessage()
         self.assertEqual(message, decoded)
-        encoded = self.PROTOLIB.encode_message(
-            decoded)
+        encoded = self.PROTOLIB.encode_message(decoded)
         self.assertEqual(self.encoded_invalid_enum, encoded)
 
     def testDateTimeNoTimeZone(self):

--- a/apitools/base/protorpclite/test_util.py
+++ b/apitools/base/protorpclite/test_util.py
@@ -579,11 +579,17 @@ class ProtoConformanceTestBase(object):
         self.assertTrue(isinstance(self.PROTOLIB.CONTENT_TYPE, str))
 
     def testDecodeInvalidEnumType(self):
-        self.assertRaisesWithRegexpMatch(messages.DecodeError,
-                                         'Invalid enum value ',
-                                         self.PROTOLIB.decode_message,
-                                         OptionalMessage,
-                                         self.encoded_invalid_enum)
+        # Since protos need to be able to add new enums, a message should be
+        # successfully decoded even if the enum value is invalid. Encoding the
+        # decoded message should result in equivalence with the original encoded
+        # message containing an invalid enum.
+        decoded = self.PROTOLIB.decode_message(
+            OptionalMessage, self.encoded_invalid_enum)
+        message = OptionalMessage()
+        self.assertEqual(message, decoded)
+        encoded = self.PROTOLIB.encode_message(
+            decoded)
+        self.assertEqual(self.encoded_invalid_enum, encoded)
 
     def testDateTimeNoTimeZone(self):
         """Test that DateTimeFields are encoded/decoded correctly."""

--- a/apitools/base/protorpclite/test_util.py
+++ b/apitools/base/protorpclite/test_util.py
@@ -581,8 +581,8 @@ class ProtoConformanceTestBase(object):
     def testDecodeInvalidEnumType(self):
         # Since protos need to be able to add new enums, a message should be
         # successfully decoded even if the enum value is invalid. Encoding the
-        # decoded message should result in equivalence with the original encoded
-        # message containing an invalid enum.
+        # decoded message should result in equivalence with the original
+        # encoded message containing an invalid enum.
         decoded = self.PROTOLIB.decode_message(
             OptionalMessage, self.encoded_invalid_enum)
         message = OptionalMessage()

--- a/apitools/base/py/encoding_test.py
+++ b/apitools/base/py/encoding_test.py
@@ -477,8 +477,8 @@ class EncodingTest(unittest2.TestCase):
                          json.loads(encoding.MessageToJson(message)))
 
     def testUnknownEnumNestedRoundtrip(self):
-        json_with_typo = ('{"outer_key": {"key_one": {"field_one": "VALUE_OEN",'
-                          ' "field_two": "VALUE_OEN"}}}')
+        json_with_typo = ('{"outer_key": {"key_one": {"field_one": '
+                          '"VALUE_OEN", "field_two": "VALUE_OEN"}}}')
         msg = encoding.JsonToMessage(NestedAdditionalPropertiesWithEnumMessage,
                                      json_with_typo)
         self.assertEqual(json.loads(json_with_typo),

--- a/apitools/base/py/encoding_test.py
+++ b/apitools/base/py/encoding_test.py
@@ -233,9 +233,7 @@ class EncodingTest(unittest2.TestCase):
 
     def testCopyProtoMessageMappingInvalidEnum(self):
         json_msg = '{"key_one": {"field_one": "BAD_VALUE"}}'
-        orig_msg = encoding.JsonToMessage(
-            MapToMessageWithEnum,
-            json_msg)
+        orig_msg = encoding.JsonToMessage(MapToMessageWithEnum, json_msg)
         new_msg = encoding.CopyProtoMessage(orig_msg)
         for msg in (orig_msg, new_msg):
             self.assertEqual(
@@ -326,12 +324,9 @@ class EncodingTest(unittest2.TestCase):
 
     def testInvalidEnumEncodingInAMap(self):
         json_msg = '{"key_one": {"field_one": "BAD_VALUE"}}'
-        msg = encoding.JsonToMessage(
-            MapToMessageWithEnum,
-            json_msg)
+        msg = encoding.JsonToMessage(MapToMessageWithEnum, json_msg)
         new_msg = encoding.MessageToJson(msg)
-        self.assertEqual('{"key_one": {"field_one": "BAD_VALUE"}}',
-                         new_msg)
+        self.assertEqual('{"key_one": {"field_one": "BAD_VALUE"}}', new_msg)
 
     def testIncludeFields(self):
         msg = SimpleMessage()
@@ -482,11 +477,10 @@ class EncodingTest(unittest2.TestCase):
                          json.loads(encoding.MessageToJson(message)))
 
     def testUnknownEnumNestedRoundtrip(self):
-        json_with_typo = (
-            '{"outer_key": {"key_one": {"field_one": "VALUE_OEN",'
-            ' "field_two": "VALUE_OEN"}}}')
-        msg = encoding.JsonToMessage(
-            NestedAdditionalPropertiesWithEnumMessage, json_with_typo)
+        json_with_typo = ('{"outer_key": {"key_one": {"field_one": "VALUE_OEN",'
+                          ' "field_two": "VALUE_OEN"}}}')
+        msg = encoding.JsonToMessage(NestedAdditionalPropertiesWithEnumMessage,
+                                     json_with_typo)
         self.assertEqual(json.loads(json_with_typo),
                          json.loads(encoding.MessageToJson(msg)))
 

--- a/apitools/base/py/encoding_test.py
+++ b/apitools/base/py/encoding_test.py
@@ -331,7 +331,7 @@ class EncodingTest(unittest2.TestCase):
             json_msg)
         new_msg = encoding.MessageToJson(msg)
         self.assertEqual('{"key_one": {"field_one": "BAD_VALUE"}}',
-                         encoding.MessageToJson(msg))
+                         new_msg)
 
     def testIncludeFields(self):
         msg = SimpleMessage()


### PR DESCRIPTION
Previously this caused an error when the Enum values were inside
an unknown field because the base protojson codec used to copy the message
during the mapping of unknown fields fails on unknown Enums. This changes
the base protojson to handle unknown values for EnumFields as
unrecognized fields.