### PR TITLE
Added response_encoding parameter to api client classes.

### DIFF
--- a/apitools/base/py/base_api.py
+++ b/apitools/base/py/base_api.py
@@ -239,7 +239,7 @@ class BaseApiClient(object):
                  model=None, log_request=False, log_response=False,
                  num_retries=5, max_retry_wait=60, credentials_args=None,
                  default_global_params=None, additional_http_headers=None,
-                 check_response_func=None, retry_func=None):
+                 check_response_func=None, retry_func=None, response_encoding=None):
         _RequireClassAttrs(self, ('_package', '_scopes', 'messages_module'))
         if default_global_params is not None:
             util.Typecheck(default_global_params, self.params_type)
@@ -267,6 +267,7 @@ class BaseApiClient(object):
         self.additional_http_headers = additional_http_headers or {}
         self.check_response_func = check_response_func
         self.retry_func = retry_func
+        self.response_encoding = response_encoding
 
         # TODO(craigcitro): Finish deprecating these fields.
         _ = model
@@ -603,12 +604,16 @@ class BaseApiService(object):
             http_response = http_wrapper.Response(
                 info=http_response.info, content='{}',
                 request_url=http_response.request_url)
+
+        content = http_response.content
+        if self._client.response_encoding:
+            content = content.decode(self._client.response_encoding)
+
         if self.__client.response_type_model == 'json':
-            return http_response.content
+            return content
         response_type = _LoadClass(method_config.response_type_name,
                                    self.__client.MESSAGES_MODULE)
-        return self.__client.DeserializeMessage(
-            response_type, http_response.content)
+        return self.__client.DeserializeMessage(response_type, content)
 
     def __SetBaseHeaders(self, http_request, client):
         """Fill in the basic headers on http_request."""

--- a/apitools/base/py/base_api_test.py
+++ b/apitools/base/py/base_api_test.py
@@ -132,6 +132,25 @@ class BaseApiTest(unittest2.TestCase):
                 http_response.content,
                 service.ProcessHttpResponse(method_config, http_response))
 
+    def testJsonResponseEncoding(self):
+        # On Python 3, httplib2 always returns bytes, so we need to check that
+        # we can correctly decode the message content using the given encoding.
+        method_config = base_api.ApiMethodInfo(
+            response_type_name='SimpleMessage')
+        service = FakeService(FakeClient(
+            'http://www.example.com/', credentials=FakeCredentials(),
+            response_encoding='utf8'))
+        http_response = http_wrapper.Response(
+            info={'status': '200'}, content=b'{"field": "abc"}',
+            request_url='http://www.google.com')
+        response_message = SimpleMessage(field=u'abc')
+        self.assertEqual(response_message, service.ProcessHttpResponse(
+            method_config, http_response))
+        with service.client.JsonResponseModel():
+            self.assertEqual(
+                http_response.content.decode('utf8'),
+                service.ProcessHttpResponse(method_config, http_response))
+
     def testAdditionalHeaders(self):
         additional_headers = {'Request-Is-Awesome': '1'}
         client = self.__GetFakeClient()

--- a/apitools/gen/service_registry.py
+++ b/apitools/gen/service_registry.py
@@ -238,7 +238,7 @@ class ServiceRegistry(object):
                 printer('get_credentials=True, http=None, model=None,')
                 printer('log_request=False, log_response=False,')
                 printer('credentials_args=None, default_global_params=None,')
-                printer('additional_http_headers=None):')
+                printer('additional_http_headers=None, response_encoding=None):')
             with printer.Indent():
                 printer('"""Create a new %s handle."""', client_info.package)
                 printer('url = url or self.BASE_URL')
@@ -251,7 +251,8 @@ class ServiceRegistry(object):
                         'log_response=log_response,')
                 printer('    credentials_args=credentials_args,')
                 printer('    default_global_params=default_global_params,')
-                printer('    additional_http_headers=additional_http_headers)')
+                printer('    additional_http_headers=additional_http_headers,')
+                printer('    response_encoding=response_encoding)')
                 for name in self.__service_method_info_map.keys():
                     printer('self.%s = self.%s(self)',
                             name, self.__GetServiceClassName(name))

--- a/samples/bigquery_sample/bigquery_v2/bigquery_v2_client.py
+++ b/samples/bigquery_sample/bigquery_v2/bigquery_v2_client.py
@@ -24,7 +24,7 @@ class BigqueryV2(base_api.BaseApiClient):
                get_credentials=True, http=None, model=None,
                log_request=False, log_response=False,
                credentials_args=None, default_global_params=None,
-               additional_http_headers=None):
+               additional_http_headers=None, response_encoding=None):
     """Create a new bigquery handle."""
     url = url or self.BASE_URL
     super(BigqueryV2, self).__init__(
@@ -33,7 +33,8 @@ class BigqueryV2(base_api.BaseApiClient):
         log_request=log_request, log_response=log_response,
         credentials_args=credentials_args,
         default_global_params=default_global_params,
-        additional_http_headers=additional_http_headers)
+        additional_http_headers=additional_http_headers,
+        response_encoding=response_encoding)
     self.datasets = self.DatasetsService(self)
     self.jobs = self.JobsService(self)
     self.projects = self.ProjectsService(self)

--- a/samples/dns_sample/dns_v1/dns_v1_client.py
+++ b/samples/dns_sample/dns_v1/dns_v1_client.py
@@ -24,7 +24,7 @@ class DnsV1(base_api.BaseApiClient):
                get_credentials=True, http=None, model=None,
                log_request=False, log_response=False,
                credentials_args=None, default_global_params=None,
-               additional_http_headers=None):
+               additional_http_headers=None, response_encoding=None):
     """Create a new dns handle."""
     url = url or self.BASE_URL
     super(DnsV1, self).__init__(
@@ -33,7 +33,8 @@ class DnsV1(base_api.BaseApiClient):
         log_request=log_request, log_response=log_response,
         credentials_args=credentials_args,
         default_global_params=default_global_params,
-        additional_http_headers=additional_http_headers)
+        additional_http_headers=additional_http_headers,
+        response_encoding=response_encoding)
     self.changes = self.ChangesService(self)
     self.managedZones = self.ManagedZonesService(self)
     self.projects = self.ProjectsService(self)

--- a/samples/fusiontables_sample/fusiontables_v1/fusiontables_v1_client.py
+++ b/samples/fusiontables_sample/fusiontables_v1/fusiontables_v1_client.py
@@ -24,7 +24,7 @@ class FusiontablesV1(base_api.BaseApiClient):
                get_credentials=True, http=None, model=None,
                log_request=False, log_response=False,
                credentials_args=None, default_global_params=None,
-               additional_http_headers=None):
+               additional_http_headers=None, response_encoding=None):
     """Create a new fusiontables handle."""
     url = url or self.BASE_URL
     super(FusiontablesV1, self).__init__(
@@ -33,7 +33,8 @@ class FusiontablesV1(base_api.BaseApiClient):
         log_request=log_request, log_response=log_response,
         credentials_args=credentials_args,
         default_global_params=default_global_params,
-        additional_http_headers=additional_http_headers)
+        additional_http_headers=additional_http_headers,
+        response_encoding=response_encoding)
     self.column = self.ColumnService(self)
     self.query = self.QueryService(self)
     self.style = self.StyleService(self)

--- a/samples/iam_sample/iam_v1/iam_v1_client.py
+++ b/samples/iam_sample/iam_v1/iam_v1_client.py
@@ -24,7 +24,7 @@ class IamV1(base_api.BaseApiClient):
                get_credentials=True, http=None, model=None,
                log_request=False, log_response=False,
                credentials_args=None, default_global_params=None,
-               additional_http_headers=None):
+               additional_http_headers=None, response_encoding=None):
     """Create a new iam handle."""
     url = url or self.BASE_URL
     super(IamV1, self).__init__(
@@ -33,7 +33,8 @@ class IamV1(base_api.BaseApiClient):
         log_request=log_request, log_response=log_response,
         credentials_args=credentials_args,
         default_global_params=default_global_params,
-        additional_http_headers=additional_http_headers)
+        additional_http_headers=additional_http_headers,
+        response_encoding=response_encoding)
     self.iamPolicies = self.IamPoliciesService(self)
     self.projects_serviceAccounts_keys = self.ProjectsServiceAccountsKeysService(self)
     self.projects_serviceAccounts = self.ProjectsServiceAccountsService(self)

--- a/samples/servicemanagement_sample/servicemanagement_v1/servicemanagement_v1_client.py
+++ b/samples/servicemanagement_sample/servicemanagement_v1/servicemanagement_v1_client.py
@@ -24,7 +24,7 @@ class ServicemanagementV1(base_api.BaseApiClient):
                get_credentials=True, http=None, model=None,
                log_request=False, log_response=False,
                credentials_args=None, default_global_params=None,
-               additional_http_headers=None):
+               additional_http_headers=None, response_encoding=None):
     """Create a new servicemanagement handle."""
     url = url or self.BASE_URL
     super(ServicemanagementV1, self).__init__(
@@ -33,7 +33,8 @@ class ServicemanagementV1(base_api.BaseApiClient):
         log_request=log_request, log_response=log_response,
         credentials_args=credentials_args,
         default_global_params=default_global_params,
-        additional_http_headers=additional_http_headers)
+        additional_http_headers=additional_http_headers,
+        response_encoding=response_encoding)
     self.operations = self.OperationsService(self)
     self.services_accessPolicy = self.ServicesAccessPolicyService(self)
     self.services_configs = self.ServicesConfigsService(self)

--- a/samples/storage_sample/storage_v1/storage_v1_client.py
+++ b/samples/storage_sample/storage_v1/storage_v1_client.py
@@ -24,7 +24,7 @@ class StorageV1(base_api.BaseApiClient):
                get_credentials=True, http=None, model=None,
                log_request=False, log_response=False,
                credentials_args=None, default_global_params=None,
-               additional_http_headers=None):
+               additional_http_headers=None, response_encoding=None):
     """Create a new storage handle."""
     url = url or self.BASE_URL
     super(StorageV1, self).__init__(
@@ -33,7 +33,8 @@ class StorageV1(base_api.BaseApiClient):
         log_request=log_request, log_response=log_response,
         credentials_args=credentials_args,
         default_global_params=default_global_params,
-        additional_http_headers=additional_http_headers)
+        additional_http_headers=additional_http_headers,
+        response_encoding=response_encoding)
     self.bucketAccessControls = self.BucketAccessControlsService(self)
     self.buckets = self.BucketsService(self)
     self.channels = self.ChannelsService(self)


### PR DESCRIPTION
On Python 3, httplib2 returns message contents as bytes, which cannot be
read by json.loads(). It must first be decoded to text. Specifying this
parameter tells the client to first decode the body before trying to
parse it.