### PR TITLE
exclude samples & tests from install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setuptools.setup(
     author='Craig Citro',
     author_email='craigcitro@google.com',
     # Contained modules and scripts.
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(include=['apitools']),
     entry_points={'console_scripts': CONSOLE_SCRIPTS},
     install_requires=REQUIRED_PACKAGES,
     tests_require=REQUIRED_PACKAGES + CLI_PACKAGES + TESTING_PACKAGES,
@@ -80,6 +80,15 @@ setuptools.setup(
     include_package_data=True,
     package_data={
         'apitools.data': ['*'],
+    },
+    exclude_package_data={
+        '': [
+            '*_test.py',
+            '*/testing/*',
+            '*/testdata/*',
+            'base/protorpclite/test_util.py',
+            'gen/test_utils.py',
+        ],
     },
     # PyPI package information.
     classifiers=[


### PR DESCRIPTION
There's no value in installing the sample modules (plus they pollute
the global samples.* namespace), nor in installing the unittests.

For the samples, we set the include option with find_packages so the
code only searches the top level apitools dir.

For the tests, because they live alongside modules vs a completely
sep tree (which is fine), we have to add a series of globs to the
exclude_package_data to filter them out.