### PR TITLE
Convert generated api client/message docstrings into raw strings.

### DIFF
--- a/apitools/gen/extended_descriptor.py
+++ b/apitools/gen/extended_descriptor.py
@@ -373,7 +373,7 @@ class _ProtoRpcPrinter(ProtoPrinter):
 
     def __PrintEnumDocstringLines(self, enum_type):
         description = enum_type.description or '%s enum type.' % enum_type.name
-        for line in textwrap.wrap('"""%s' % description,
+        for line in textwrap.wrap('r"""%s' % description,
                                   self.__printer.CalculateWidth()):
             self.__printer(line)
         PrintIndentedDescriptions(self.__printer, enum_type.values, 'Values')
@@ -433,9 +433,9 @@ class _ProtoRpcPrinter(ProtoPrinter):
             if short_description:
                 # Note that we use explicit string interpolation here since
                 # we're in comment context.
-                self.__printer('"""%s"""' % description)
+                self.__printer('r"""%s"""' % description)
                 return
-            for line in textwrap.wrap('"""%s' % description,
+            for line in textwrap.wrap('r"""%s' % description,
                                       self.__printer.CalculateWidth()):
                 self.__printer(line)
 

--- a/apitools/gen/service_registry.py
+++ b/apitools/gen/service_registry.py
@@ -70,7 +70,7 @@ class ServiceRegistry(object):
         else:
             description = '%s method for the %s service.' % (method_name, name)
         with printer.CommentContext():
-            printer('"""%s' % description)
+            printer('r"""%s' % description)
         printer()
         printer('Args:')
         printer('  request: (%s) input message', method_info.request_type_name)

--- a/samples/bigquery_sample/bigquery_v2/bigquery_v2_client.py
+++ b/samples/bigquery_sample/bigquery_v2/bigquery_v2_client.py
@@ -52,7 +52,7 @@ class BigqueryV2(base_api.BaseApiClient):
           }
 
     def Delete(self, request, global_params=None):
-      """Deletes the dataset specified by the datasetId value. Before you can delete a dataset, you must delete all its tables, either manually or by specifying deleteContents. Immediately after deletion, you can create another dataset with the same name.
+      r"""Deletes the dataset specified by the datasetId value. Before you can delete a dataset, you must delete all its tables, either manually or by specifying deleteContents. Immediately after deletion, you can create another dataset with the same name.
 
       Args:
         request: (BigqueryDatasetsDeleteRequest) input message
@@ -78,7 +78,7 @@ class BigqueryV2(base_api.BaseApiClient):
     )
 
     def Get(self, request, global_params=None):
-      """Returns the dataset specified by datasetID.
+      r"""Returns the dataset specified by datasetID.
 
       Args:
         request: (BigqueryDatasetsGetRequest) input message
@@ -104,7 +104,7 @@ class BigqueryV2(base_api.BaseApiClient):
     )
 
     def Insert(self, request, global_params=None):
-      """Creates a new empty dataset.
+      r"""Creates a new empty dataset.
 
       Args:
         request: (BigqueryDatasetsInsertRequest) input message
@@ -130,7 +130,7 @@ class BigqueryV2(base_api.BaseApiClient):
     )
 
     def List(self, request, global_params=None):
-      """Lists all datasets in the specified project to which you have been granted the READER dataset role.
+      r"""Lists all datasets in the specified project to which you have been granted the READER dataset role.
 
       Args:
         request: (BigqueryDatasetsListRequest) input message
@@ -156,7 +156,7 @@ class BigqueryV2(base_api.BaseApiClient):
     )
 
     def Patch(self, request, global_params=None):
-      """Updates information in an existing dataset. The update method replaces the entire dataset resource, whereas the patch method only replaces fields that are provided in the submitted dataset resource. This method supports patch semantics.
+      r"""Updates information in an existing dataset. The update method replaces the entire dataset resource, whereas the patch method only replaces fields that are provided in the submitted dataset resource. This method supports patch semantics.
 
       Args:
         request: (BigqueryDatasetsPatchRequest) input message
@@ -182,7 +182,7 @@ class BigqueryV2(base_api.BaseApiClient):
     )
 
     def Update(self, request, global_params=None):
-      """Updates information in an existing dataset. The update method replaces the entire dataset resource, whereas the patch method only replaces fields that are provided in the submitted dataset resource.
+      r"""Updates information in an existing dataset. The update method replaces the entire dataset resource, whereas the patch method only replaces fields that are provided in the submitted dataset resource.
 
       Args:
         request: (BigqueryDatasetsUpdateRequest) input message
@@ -226,7 +226,7 @@ class BigqueryV2(base_api.BaseApiClient):
           }
 
     def Cancel(self, request, global_params=None):
-      """Requests that a job be cancelled. This call will return immediately, and the client will need to poll for the job status to see if the cancel completed successfully. Cancelled jobs may still incur costs.
+      r"""Requests that a job be cancelled. This call will return immediately, and the client will need to poll for the job status to see if the cancel completed successfully. Cancelled jobs may still incur costs.
 
       Args:
         request: (BigqueryJobsCancelRequest) input message
@@ -252,7 +252,7 @@ class BigqueryV2(base_api.BaseApiClient):
     )
 
     def Get(self, request, global_params=None):
-      """Returns information about a specific job. Job information is available for a six month period after creation. Requires that you're the person who ran the job, or have the Is Owner project role.
+      r"""Returns information about a specific job. Job information is available for a six month period after creation. Requires that you're the person who ran the job, or have the Is Owner project role.
 
       Args:
         request: (BigqueryJobsGetRequest) input message
@@ -278,7 +278,7 @@ class BigqueryV2(base_api.BaseApiClient):
     )
 
     def GetQueryResults(self, request, global_params=None):
-      """Retrieves the results of a query job.
+      r"""Retrieves the results of a query job.
 
       Args:
         request: (BigqueryJobsGetQueryResultsRequest) input message
@@ -304,7 +304,7 @@ class BigqueryV2(base_api.BaseApiClient):
     )
 
     def Insert(self, request, global_params=None, upload=None):
-      """Starts a new asynchronous job. Requires the Can View project role.
+      r"""Starts a new asynchronous job. Requires the Can View project role.
 
       Args:
         request: (BigqueryJobsInsertRequest) input message
@@ -334,7 +334,7 @@ class BigqueryV2(base_api.BaseApiClient):
     )
 
     def List(self, request, global_params=None):
-      """Lists all jobs that you started in the specified project. Job information is available for a six month period after creation. The job list is sorted in reverse chronological order, by job creation time. Requires the Can View project role, or the Is Owner project role if you set the allUsers property.
+      r"""Lists all jobs that you started in the specified project. Job information is available for a six month period after creation. The job list is sorted in reverse chronological order, by job creation time. Requires the Can View project role, or the Is Owner project role if you set the allUsers property.
 
       Args:
         request: (BigqueryJobsListRequest) input message
@@ -360,7 +360,7 @@ class BigqueryV2(base_api.BaseApiClient):
     )
 
     def Query(self, request, global_params=None):
-      """Runs a BigQuery SQL query synchronously and returns query results if the query completes within a specified timeout.
+      r"""Runs a BigQuery SQL query synchronously and returns query results if the query completes within a specified timeout.
 
       Args:
         request: (BigqueryJobsQueryRequest) input message
@@ -396,7 +396,7 @@ class BigqueryV2(base_api.BaseApiClient):
           }
 
     def List(self, request, global_params=None):
-      """Lists all projects to which you have been granted any project role.
+      r"""Lists all projects to which you have been granted any project role.
 
       Args:
         request: (BigqueryProjectsListRequest) input message
@@ -432,7 +432,7 @@ class BigqueryV2(base_api.BaseApiClient):
           }
 
     def InsertAll(self, request, global_params=None):
-      """Streams data into BigQuery one record at a time without needing to run a load job. Requires the WRITER dataset role.
+      r"""Streams data into BigQuery one record at a time without needing to run a load job. Requires the WRITER dataset role.
 
       Args:
         request: (BigqueryTabledataInsertAllRequest) input message
@@ -458,7 +458,7 @@ class BigqueryV2(base_api.BaseApiClient):
     )
 
     def List(self, request, global_params=None):
-      """Retrieves table data from a specified set of rows. Requires the READER dataset role.
+      r"""Retrieves table data from a specified set of rows. Requires the READER dataset role.
 
       Args:
         request: (BigqueryTabledataListRequest) input message
@@ -494,7 +494,7 @@ class BigqueryV2(base_api.BaseApiClient):
           }
 
     def Delete(self, request, global_params=None):
-      """Deletes the table specified by tableId from the dataset. If the table contains data, all the data will be deleted.
+      r"""Deletes the table specified by tableId from the dataset. If the table contains data, all the data will be deleted.
 
       Args:
         request: (BigqueryTablesDeleteRequest) input message
@@ -520,7 +520,7 @@ class BigqueryV2(base_api.BaseApiClient):
     )
 
     def Get(self, request, global_params=None):
-      """Gets the specified table resource by table ID. This method does not return the data in the table, it only returns the table resource, which describes the structure of this table.
+      r"""Gets the specified table resource by table ID. This method does not return the data in the table, it only returns the table resource, which describes the structure of this table.
 
       Args:
         request: (BigqueryTablesGetRequest) input message
@@ -546,7 +546,7 @@ class BigqueryV2(base_api.BaseApiClient):
     )
 
     def Insert(self, request, global_params=None):
-      """Creates a new, empty table in the dataset.
+      r"""Creates a new, empty table in the dataset.
 
       Args:
         request: (BigqueryTablesInsertRequest) input message
@@ -572,7 +572,7 @@ class BigqueryV2(base_api.BaseApiClient):
     )
 
     def List(self, request, global_params=None):
-      """Lists all tables in the specified dataset. Requires the READER dataset role.
+      r"""Lists all tables in the specified dataset. Requires the READER dataset role.
 
       Args:
         request: (BigqueryTablesListRequest) input message
@@ -598,7 +598,7 @@ class BigqueryV2(base_api.BaseApiClient):
     )
 
     def Patch(self, request, global_params=None):
-      """Updates information in an existing table. The update method replaces the entire table resource, whereas the patch method only replaces fields that are provided in the submitted table resource. This method supports patch semantics.
+      r"""Updates information in an existing table. The update method replaces the entire table resource, whereas the patch method only replaces fields that are provided in the submitted table resource. This method supports patch semantics.
 
       Args:
         request: (BigqueryTablesPatchRequest) input message
@@ -624,7 +624,7 @@ class BigqueryV2(base_api.BaseApiClient):
     )
 
     def Update(self, request, global_params=None):
-      """Updates information in an existing table. The update method replaces the entire table resource, whereas the patch method only replaces fields that are provided in the submitted table resource.
+      r"""Updates information in an existing table. The update method replaces the entire table resource, whereas the patch method only replaces fields that are provided in the submitted table resource.
 
       Args:
         request: (BigqueryTablesUpdateRequest) input message

--- a/samples/bigquery_sample/bigquery_v2/bigquery_v2_messages.py
+++ b/samples/bigquery_sample/bigquery_v2/bigquery_v2_messages.py
@@ -13,7 +13,7 @@ package = 'bigquery'
 
 
 class BigqueryDatasetsDeleteRequest(_messages.Message):
-  """A BigqueryDatasetsDeleteRequest object.
+  r"""A BigqueryDatasetsDeleteRequest object.
 
   Fields:
     datasetId: Dataset ID of dataset being deleted
@@ -28,11 +28,11 @@ class BigqueryDatasetsDeleteRequest(_messages.Message):
 
 
 class BigqueryDatasetsDeleteResponse(_messages.Message):
-  """An empty BigqueryDatasetsDelete response."""
+  r"""An empty BigqueryDatasetsDelete response."""
 
 
 class BigqueryDatasetsGetRequest(_messages.Message):
-  """A BigqueryDatasetsGetRequest object.
+  r"""A BigqueryDatasetsGetRequest object.
 
   Fields:
     datasetId: Dataset ID of the requested dataset
@@ -44,7 +44,7 @@ class BigqueryDatasetsGetRequest(_messages.Message):
 
 
 class BigqueryDatasetsInsertRequest(_messages.Message):
-  """A BigqueryDatasetsInsertRequest object.
+  r"""A BigqueryDatasetsInsertRequest object.
 
   Fields:
     dataset: A Dataset resource to be passed as the request body.
@@ -56,7 +56,7 @@ class BigqueryDatasetsInsertRequest(_messages.Message):
 
 
 class BigqueryDatasetsListRequest(_messages.Message):
-  """A BigqueryDatasetsListRequest object.
+  r"""A BigqueryDatasetsListRequest object.
 
   Fields:
     all: Whether to list all datasets, including hidden ones
@@ -79,7 +79,7 @@ class BigqueryDatasetsListRequest(_messages.Message):
 
 
 class BigqueryDatasetsPatchRequest(_messages.Message):
-  """A BigqueryDatasetsPatchRequest object.
+  r"""A BigqueryDatasetsPatchRequest object.
 
   Fields:
     dataset: A Dataset resource to be passed as the request body.
@@ -93,7 +93,7 @@ class BigqueryDatasetsPatchRequest(_messages.Message):
 
 
 class BigqueryDatasetsUpdateRequest(_messages.Message):
-  """A BigqueryDatasetsUpdateRequest object.
+  r"""A BigqueryDatasetsUpdateRequest object.
 
   Fields:
     dataset: A Dataset resource to be passed as the request body.
@@ -107,7 +107,7 @@ class BigqueryDatasetsUpdateRequest(_messages.Message):
 
 
 class BigqueryJobsCancelRequest(_messages.Message):
-  """A BigqueryJobsCancelRequest object.
+  r"""A BigqueryJobsCancelRequest object.
 
   Fields:
     jobId: [Required] Job ID of the job to cancel
@@ -119,7 +119,7 @@ class BigqueryJobsCancelRequest(_messages.Message):
 
 
 class BigqueryJobsGetQueryResultsRequest(_messages.Message):
-  """A BigqueryJobsGetQueryResultsRequest object.
+  r"""A BigqueryJobsGetQueryResultsRequest object.
 
   Fields:
     jobId: [Required] Job ID of the query job
@@ -142,7 +142,7 @@ class BigqueryJobsGetQueryResultsRequest(_messages.Message):
 
 
 class BigqueryJobsGetRequest(_messages.Message):
-  """A BigqueryJobsGetRequest object.
+  r"""A BigqueryJobsGetRequest object.
 
   Fields:
     jobId: [Required] Job ID of the requested job
@@ -154,7 +154,7 @@ class BigqueryJobsGetRequest(_messages.Message):
 
 
 class BigqueryJobsInsertRequest(_messages.Message):
-  """A BigqueryJobsInsertRequest object.
+  r"""A BigqueryJobsInsertRequest object.
 
   Fields:
     job: A Job resource to be passed as the request body.
@@ -166,7 +166,7 @@ class BigqueryJobsInsertRequest(_messages.Message):
 
 
 class BigqueryJobsListRequest(_messages.Message):
-  """A BigqueryJobsListRequest object.
+  r"""A BigqueryJobsListRequest object.
 
   Enums:
     ProjectionValueValuesEnum: Restrict information returned to a set of
@@ -185,7 +185,7 @@ class BigqueryJobsListRequest(_messages.Message):
   """
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Restrict information returned to a set of selected fields
+    r"""Restrict information returned to a set of selected fields
 
     Values:
       full: Includes all job data
@@ -195,7 +195,7 @@ class BigqueryJobsListRequest(_messages.Message):
     minimal = 1
 
   class StateFilterValueValuesEnum(_messages.Enum):
-    """Filter for job state
+    r"""Filter for job state
 
     Values:
       done: Finished jobs
@@ -215,7 +215,7 @@ class BigqueryJobsListRequest(_messages.Message):
 
 
 class BigqueryJobsQueryRequest(_messages.Message):
-  """A BigqueryJobsQueryRequest object.
+  r"""A BigqueryJobsQueryRequest object.
 
   Fields:
     projectId: Project ID of the project billed for the query
@@ -227,7 +227,7 @@ class BigqueryJobsQueryRequest(_messages.Message):
 
 
 class BigqueryProjectsListRequest(_messages.Message):
-  """A BigqueryProjectsListRequest object.
+  r"""A BigqueryProjectsListRequest object.
 
   Fields:
     maxResults: Maximum number of results to return
@@ -240,7 +240,7 @@ class BigqueryProjectsListRequest(_messages.Message):
 
 
 class BigqueryTabledataInsertAllRequest(_messages.Message):
-  """A BigqueryTabledataInsertAllRequest object.
+  r"""A BigqueryTabledataInsertAllRequest object.
 
   Fields:
     datasetId: Dataset ID of the destination table.
@@ -257,7 +257,7 @@ class BigqueryTabledataInsertAllRequest(_messages.Message):
 
 
 class BigqueryTabledataListRequest(_messages.Message):
-  """A BigqueryTabledataListRequest object.
+  r"""A BigqueryTabledataListRequest object.
 
   Fields:
     datasetId: Dataset ID of the table to read
@@ -278,7 +278,7 @@ class BigqueryTabledataListRequest(_messages.Message):
 
 
 class BigqueryTablesDeleteRequest(_messages.Message):
-  """A BigqueryTablesDeleteRequest object.
+  r"""A BigqueryTablesDeleteRequest object.
 
   Fields:
     datasetId: Dataset ID of the table to delete
@@ -292,11 +292,11 @@ class BigqueryTablesDeleteRequest(_messages.Message):
 
 
 class BigqueryTablesDeleteResponse(_messages.Message):
-  """An empty BigqueryTablesDelete response."""
+  r"""An empty BigqueryTablesDelete response."""
 
 
 class BigqueryTablesGetRequest(_messages.Message):
-  """A BigqueryTablesGetRequest object.
+  r"""A BigqueryTablesGetRequest object.
 
   Fields:
     datasetId: Dataset ID of the requested table
@@ -310,7 +310,7 @@ class BigqueryTablesGetRequest(_messages.Message):
 
 
 class BigqueryTablesInsertRequest(_messages.Message):
-  """A BigqueryTablesInsertRequest object.
+  r"""A BigqueryTablesInsertRequest object.
 
   Fields:
     datasetId: Dataset ID of the new table
@@ -324,7 +324,7 @@ class BigqueryTablesInsertRequest(_messages.Message):
 
 
 class BigqueryTablesListRequest(_messages.Message):
-  """A BigqueryTablesListRequest object.
+  r"""A BigqueryTablesListRequest object.
 
   Fields:
     datasetId: Dataset ID of the tables to list
@@ -341,7 +341,7 @@ class BigqueryTablesListRequest(_messages.Message):
 
 
 class BigqueryTablesPatchRequest(_messages.Message):
-  """A BigqueryTablesPatchRequest object.
+  r"""A BigqueryTablesPatchRequest object.
 
   Fields:
     datasetId: Dataset ID of the table to update
@@ -357,7 +357,7 @@ class BigqueryTablesPatchRequest(_messages.Message):
 
 
 class BigqueryTablesUpdateRequest(_messages.Message):
-  """A BigqueryTablesUpdateRequest object.
+  r"""A BigqueryTablesUpdateRequest object.
 
   Fields:
     datasetId: Dataset ID of the table to update
@@ -373,7 +373,7 @@ class BigqueryTablesUpdateRequest(_messages.Message):
 
 
 class BigtableColumn(_messages.Message):
-  """A BigtableColumn object.
+  r"""A BigtableColumn object.
 
   Fields:
     encoding: [Optional] The encoding of the values when the type is not
@@ -417,7 +417,7 @@ class BigtableColumn(_messages.Message):
 
 
 class BigtableColumnFamily(_messages.Message):
-  """A BigtableColumnFamily object.
+  r"""A BigtableColumnFamily object.
 
   Fields:
     columns: [Optional] Lists of columns that should be exposed as individual
@@ -451,7 +451,7 @@ class BigtableColumnFamily(_messages.Message):
 
 
 class BigtableOptions(_messages.Message):
-  """A BigtableOptions object.
+  r"""A BigtableOptions object.
 
   Fields:
     columnFamilies: [Optional] List of column families to expose in the table
@@ -478,7 +478,7 @@ class BigtableOptions(_messages.Message):
 
 
 class CsvOptions(_messages.Message):
-  """A CsvOptions object.
+  r"""A CsvOptions object.
 
   Fields:
     allowJaggedRows: [Optional] Indicates if BigQuery should accept rows that
@@ -521,7 +521,7 @@ class CsvOptions(_messages.Message):
 
 
 class Dataset(_messages.Message):
-  """A Dataset object.
+  r"""A Dataset object.
 
   Messages:
     AccessValueListEntry: A AccessValueListEntry object.
@@ -582,7 +582,7 @@ class Dataset(_messages.Message):
   """
 
   class AccessValueListEntry(_messages.Message):
-    """A AccessValueListEntry object.
+    r"""A AccessValueListEntry object.
 
     Fields:
       domain: [Pick one] A domain to grant access to. Any users signed in with
@@ -616,7 +616,7 @@ class Dataset(_messages.Message):
 
   @encoding.MapUnrecognizedFields('additionalProperties')
   class LabelsValue(_messages.Message):
-    """[Experimental] The labels associated with this dataset. You can use
+    r"""[Experimental] The labels associated with this dataset. You can use
     these to organize and group your datasets. You can set this property when
     inserting or updating a dataset. Label keys and values can be no longer
     than 63 characters, can only contain letters, numeric characters,
@@ -633,7 +633,7 @@ class Dataset(_messages.Message):
     """
 
     class AdditionalProperty(_messages.Message):
-      """An additional property for a LabelsValue object.
+      r"""An additional property for a LabelsValue object.
 
       Fields:
         key: Name of the additional property.
@@ -661,7 +661,7 @@ class Dataset(_messages.Message):
 
 
 class DatasetList(_messages.Message):
-  """A DatasetList object.
+  r"""A DatasetList object.
 
   Messages:
     DatasetsValueListEntry: A DatasetsValueListEntry object.
@@ -680,7 +680,7 @@ class DatasetList(_messages.Message):
   """
 
   class DatasetsValueListEntry(_messages.Message):
-    """A DatasetsValueListEntry object.
+    r"""A DatasetsValueListEntry object.
 
     Messages:
       LabelsValue: [Experimental] The labels associated with this dataset. You
@@ -699,7 +699,7 @@ class DatasetList(_messages.Message):
 
     @encoding.MapUnrecognizedFields('additionalProperties')
     class LabelsValue(_messages.Message):
-      """[Experimental] The labels associated with this dataset. You can use
+      r"""[Experimental] The labels associated with this dataset. You can use
       these to organize and group your datasets.
 
       Messages:
@@ -710,7 +710,7 @@ class DatasetList(_messages.Message):
       """
 
       class AdditionalProperty(_messages.Message):
-        """An additional property for a LabelsValue object.
+        r"""An additional property for a LabelsValue object.
 
         Fields:
           key: Name of the additional property.
@@ -735,7 +735,7 @@ class DatasetList(_messages.Message):
 
 
 class DatasetReference(_messages.Message):
-  """A DatasetReference object.
+  r"""A DatasetReference object.
 
   Fields:
     datasetId: [Required] A unique ID for this dataset, without the project
@@ -749,7 +749,7 @@ class DatasetReference(_messages.Message):
 
 
 class ErrorProto(_messages.Message):
-  """A ErrorProto object.
+  r"""A ErrorProto object.
 
   Fields:
     debugInfo: Debugging information. This property is internal to Google and
@@ -766,7 +766,7 @@ class ErrorProto(_messages.Message):
 
 
 class ExplainQueryStage(_messages.Message):
-  """A ExplainQueryStage object.
+  r"""A ExplainQueryStage object.
 
   Fields:
     computeRatioAvg: Relative amount of time the average shard spent on CPU-
@@ -809,7 +809,7 @@ class ExplainQueryStage(_messages.Message):
 
 
 class ExplainQueryStep(_messages.Message):
-  """A ExplainQueryStep object.
+  r"""A ExplainQueryStep object.
 
   Fields:
     kind: Machine-readable operation type.
@@ -821,7 +821,7 @@ class ExplainQueryStep(_messages.Message):
 
 
 class ExternalDataConfiguration(_messages.Message):
-  """A ExternalDataConfiguration object.
+  r"""A ExternalDataConfiguration object.
 
   Fields:
     autodetect: [Experimental] Try to detect schema and format options
@@ -885,7 +885,7 @@ class ExternalDataConfiguration(_messages.Message):
 
 
 class GetQueryResultsResponse(_messages.Message):
-  """A GetQueryResultsResponse object.
+  r"""A GetQueryResultsResponse object.
 
   Fields:
     cacheHit: Whether the query result was fetched from the query cache.
@@ -934,7 +934,7 @@ class GetQueryResultsResponse(_messages.Message):
 
 
 class GoogleSheetsOptions(_messages.Message):
-  """A GoogleSheetsOptions object.
+  r"""A GoogleSheetsOptions object.
 
   Fields:
     skipLeadingRows: [Optional] The number of rows at the top of a sheet that
@@ -955,7 +955,7 @@ class GoogleSheetsOptions(_messages.Message):
 
 
 class Job(_messages.Message):
-  """A Job object.
+  r"""A Job object.
 
   Fields:
     configuration: [Required] Describes the job configuration.
@@ -985,7 +985,7 @@ class Job(_messages.Message):
 
 
 class JobCancelResponse(_messages.Message):
-  """A JobCancelResponse object.
+  r"""A JobCancelResponse object.
 
   Fields:
     job: The final state of the job.
@@ -997,7 +997,7 @@ class JobCancelResponse(_messages.Message):
 
 
 class JobConfiguration(_messages.Message):
-  """A JobConfiguration object.
+  r"""A JobConfiguration object.
 
   Fields:
     copy: [Pick one] Copies a table.
@@ -1018,7 +1018,7 @@ class JobConfiguration(_messages.Message):
 
 
 class JobConfigurationExtract(_messages.Message):
-  """A JobConfigurationExtract object.
+  r"""A JobConfigurationExtract object.
 
   Fields:
     compression: [Optional] The compression type to use for exported files.
@@ -1048,7 +1048,7 @@ class JobConfigurationExtract(_messages.Message):
 
 
 class JobConfigurationLoad(_messages.Message):
-  """A JobConfigurationLoad object.
+  r"""A JobConfigurationLoad object.
 
   Fields:
     allowJaggedRows: [Optional] Accept rows that are missing trailing optional
@@ -1167,7 +1167,7 @@ class JobConfigurationLoad(_messages.Message):
 
 
 class JobConfigurationQuery(_messages.Message):
-  """A JobConfigurationQuery object.
+  r"""A JobConfigurationQuery object.
 
   Messages:
     TableDefinitionsValue: [Optional] If querying an external data source
@@ -1247,7 +1247,7 @@ class JobConfigurationQuery(_messages.Message):
 
   @encoding.MapUnrecognizedFields('additionalProperties')
   class TableDefinitionsValue(_messages.Message):
-    """[Optional] If querying an external data source outside of BigQuery,
+    r"""[Optional] If querying an external data source outside of BigQuery,
     describes the data format, location and other properties of the data
     source. By defining these properties, the data source can then be queried
     as if it were a standard BigQuery table.
@@ -1262,7 +1262,7 @@ class JobConfigurationQuery(_messages.Message):
     """
 
     class AdditionalProperty(_messages.Message):
-      """An additional property for a TableDefinitionsValue object.
+      r"""An additional property for a TableDefinitionsValue object.
 
       Fields:
         key: Name of the additional property.
@@ -1293,7 +1293,7 @@ class JobConfigurationQuery(_messages.Message):
 
 
 class JobConfigurationTableCopy(_messages.Message):
-  """A JobConfigurationTableCopy object.
+  r"""A JobConfigurationTableCopy object.
 
   Fields:
     createDisposition: [Optional] Specifies whether the job is allowed to
@@ -1325,7 +1325,7 @@ class JobConfigurationTableCopy(_messages.Message):
 
 
 class JobList(_messages.Message):
-  """A JobList object.
+  r"""A JobList object.
 
   Messages:
     JobsValueListEntry: A JobsValueListEntry object.
@@ -1338,7 +1338,7 @@ class JobList(_messages.Message):
   """
 
   class JobsValueListEntry(_messages.Message):
-    """A JobsValueListEntry object.
+    r"""A JobsValueListEntry object.
 
     Fields:
       configuration: [Full-projection-only] Specifies the job configuration.
@@ -1373,7 +1373,7 @@ class JobList(_messages.Message):
 
 
 class JobReference(_messages.Message):
-  """A JobReference object.
+  r"""A JobReference object.
 
   Fields:
     jobId: [Required] The ID of the job. The ID must contain only letters
@@ -1387,7 +1387,7 @@ class JobReference(_messages.Message):
 
 
 class JobStatistics(_messages.Message):
-  """A JobStatistics object.
+  r"""A JobStatistics object.
 
   Fields:
     creationTime: [Output-only] Creation time of this job, in milliseconds
@@ -1414,7 +1414,7 @@ class JobStatistics(_messages.Message):
 
 
 class JobStatistics2(_messages.Message):
-  """A JobStatistics2 object.
+  r"""A JobStatistics2 object.
 
   Fields:
     billingTier: [Output-only] Billing tier for the job.
@@ -1445,7 +1445,7 @@ class JobStatistics2(_messages.Message):
 
 
 class JobStatistics3(_messages.Message):
-  """A JobStatistics3 object.
+  r"""A JobStatistics3 object.
 
   Fields:
     inputFileBytes: [Output-only] Number of bytes of source data in a load
@@ -1464,7 +1464,7 @@ class JobStatistics3(_messages.Message):
 
 
 class JobStatistics4(_messages.Message):
-  """A JobStatistics4 object.
+  r"""A JobStatistics4 object.
 
   Fields:
     destinationUriFileCounts: [Output-only] Number of files per destination
@@ -1477,7 +1477,7 @@ class JobStatistics4(_messages.Message):
 
 
 class JobStatus(_messages.Message):
-  """A JobStatus object.
+  r"""A JobStatus object.
 
   Fields:
     errorResult: [Output-only] Final error result of the job. If present,
@@ -1495,7 +1495,7 @@ class JobStatus(_messages.Message):
 
 @encoding.MapUnrecognizedFields('additionalProperties')
 class JsonObject(_messages.Message):
-  """Represents a single JSON object.
+  r"""Represents a single JSON object.
 
   Messages:
     AdditionalProperty: An additional property for a JsonObject object.
@@ -1505,7 +1505,7 @@ class JsonObject(_messages.Message):
   """
 
   class AdditionalProperty(_messages.Message):
-    """An additional property for a JsonObject object.
+    r"""An additional property for a JsonObject object.
 
     Fields:
       key: Name of the additional property.
@@ -1522,7 +1522,7 @@ JsonValue = extra_types.JsonValue
 
 
 class ProjectList(_messages.Message):
-  """A ProjectList object.
+  r"""A ProjectList object.
 
   Messages:
     ProjectsValueListEntry: A ProjectsValueListEntry object.
@@ -1536,7 +1536,7 @@ class ProjectList(_messages.Message):
   """
 
   class ProjectsValueListEntry(_messages.Message):
-    """A ProjectsValueListEntry object.
+    r"""A ProjectsValueListEntry object.
 
     Fields:
       friendlyName: A descriptive name for this project.
@@ -1560,7 +1560,7 @@ class ProjectList(_messages.Message):
 
 
 class ProjectReference(_messages.Message):
-  """A ProjectReference object.
+  r"""A ProjectReference object.
 
   Fields:
     projectId: [Required] ID of the project. Can be either the numeric ID or
@@ -1571,7 +1571,7 @@ class ProjectReference(_messages.Message):
 
 
 class QueryRequest(_messages.Message):
-  """A QueryRequest object.
+  r"""A QueryRequest object.
 
   Fields:
     defaultDataset: [Optional] Specifies the default datasetId and projectId
@@ -1624,7 +1624,7 @@ class QueryRequest(_messages.Message):
 
 
 class QueryResponse(_messages.Message):
-  """A QueryResponse object.
+  r"""A QueryResponse object.
 
   Fields:
     cacheHit: Whether the query result was fetched from the query cache.
@@ -1672,7 +1672,7 @@ class QueryResponse(_messages.Message):
 
 
 class StandardQueryParameters(_messages.Message):
-  """Query parameters accepted by all methods.
+  r"""Query parameters accepted by all methods.
 
   Enums:
     AltValueValuesEnum: Data format for the response.
@@ -1695,7 +1695,7 @@ class StandardQueryParameters(_messages.Message):
   """
 
   class AltValueValuesEnum(_messages.Enum):
-    """Data format for the response.
+    r"""Data format for the response.
 
     Values:
       json: Responses with Content-Type of application/json
@@ -1713,7 +1713,7 @@ class StandardQueryParameters(_messages.Message):
 
 
 class Streamingbuffer(_messages.Message):
-  """A Streamingbuffer object.
+  r"""A Streamingbuffer object.
 
   Fields:
     estimatedBytes: [Output-only] A lower-bound estimate of the number of
@@ -1731,7 +1731,7 @@ class Streamingbuffer(_messages.Message):
 
 
 class Table(_messages.Message):
-  """A Table object.
+  r"""A Table object.
 
   Fields:
     creationTime: [Output-only] The time when this table was created, in
@@ -1800,7 +1800,7 @@ class Table(_messages.Message):
 
 
 class TableCell(_messages.Message):
-  """A TableCell object.
+  r"""A TableCell object.
 
   Fields:
     v: A extra_types.JsonValue attribute.
@@ -1810,7 +1810,7 @@ class TableCell(_messages.Message):
 
 
 class TableDataInsertAllRequest(_messages.Message):
-  """A TableDataInsertAllRequest object.
+  r"""A TableDataInsertAllRequest object.
 
   Messages:
     RowsValueListEntry: A RowsValueListEntry object.
@@ -1833,7 +1833,7 @@ class TableDataInsertAllRequest(_messages.Message):
   """
 
   class RowsValueListEntry(_messages.Message):
-    """A RowsValueListEntry object.
+    r"""A RowsValueListEntry object.
 
     Fields:
       insertId: [Optional] A unique ID for each row. BigQuery uses this
@@ -1854,7 +1854,7 @@ class TableDataInsertAllRequest(_messages.Message):
 
 
 class TableDataInsertAllResponse(_messages.Message):
-  """A TableDataInsertAllResponse object.
+  r"""A TableDataInsertAllResponse object.
 
   Messages:
     InsertErrorsValueListEntry: A InsertErrorsValueListEntry object.
@@ -1865,7 +1865,7 @@ class TableDataInsertAllResponse(_messages.Message):
   """
 
   class InsertErrorsValueListEntry(_messages.Message):
-    """A InsertErrorsValueListEntry object.
+    r"""A InsertErrorsValueListEntry object.
 
     Fields:
       errors: Error information for the row indicated by the index property.
@@ -1880,7 +1880,7 @@ class TableDataInsertAllResponse(_messages.Message):
 
 
 class TableDataList(_messages.Message):
-  """A TableDataList object.
+  r"""A TableDataList object.
 
   Fields:
     etag: A hash of this page of results.
@@ -1900,7 +1900,7 @@ class TableDataList(_messages.Message):
 
 
 class TableFieldSchema(_messages.Message):
-  """A TableFieldSchema object.
+  r"""A TableFieldSchema object.
 
   Fields:
     description: [Optional] The field description. The maximum length is 16K
@@ -1925,7 +1925,7 @@ class TableFieldSchema(_messages.Message):
 
 
 class TableList(_messages.Message):
-  """A TableList object.
+  r"""A TableList object.
 
   Messages:
     TablesValueListEntry: A TablesValueListEntry object.
@@ -1939,7 +1939,7 @@ class TableList(_messages.Message):
   """
 
   class TablesValueListEntry(_messages.Message):
-    """A TablesValueListEntry object.
+    r"""A TablesValueListEntry object.
 
     Fields:
       friendlyName: The user-friendly name for this table.
@@ -1963,7 +1963,7 @@ class TableList(_messages.Message):
 
 
 class TableReference(_messages.Message):
-  """A TableReference object.
+  r"""A TableReference object.
 
   Fields:
     datasetId: [Required] The ID of the dataset containing this table.
@@ -1979,7 +1979,7 @@ class TableReference(_messages.Message):
 
 
 class TableRow(_messages.Message):
-  """A TableRow object.
+  r"""A TableRow object.
 
   Fields:
     f: Represents a single row in the result set, consisting of one or more
@@ -1990,7 +1990,7 @@ class TableRow(_messages.Message):
 
 
 class TableSchema(_messages.Message):
-  """A TableSchema object.
+  r"""A TableSchema object.
 
   Fields:
     fields: Describes the fields in a table.
@@ -2000,7 +2000,7 @@ class TableSchema(_messages.Message):
 
 
 class TimePartitioning(_messages.Message):
-  """A TimePartitioning object.
+  r"""A TimePartitioning object.
 
   Fields:
     expirationMs: [Optional] Number of milliseconds for which to keep the
@@ -2014,7 +2014,7 @@ class TimePartitioning(_messages.Message):
 
 
 class UserDefinedFunctionResource(_messages.Message):
-  """A UserDefinedFunctionResource object.
+  r"""A UserDefinedFunctionResource object.
 
   Fields:
     inlineCode: [Pick one] An inline resource that contains code for a user-
@@ -2029,7 +2029,7 @@ class UserDefinedFunctionResource(_messages.Message):
 
 
 class ViewDefinition(_messages.Message):
-  """A ViewDefinition object.
+  r"""A ViewDefinition object.
 
   Fields:
     query: [Required] A query that BigQuery executes when the view is

--- a/samples/dns_sample/dns_v1/dns_v1_client.py
+++ b/samples/dns_sample/dns_v1/dns_v1_client.py
@@ -51,7 +51,7 @@ class DnsV1(base_api.BaseApiClient):
           }
 
     def Create(self, request, global_params=None):
-      """Atomically update the ResourceRecordSet collection.
+      r"""Atomically update the ResourceRecordSet collection.
 
       Args:
         request: (DnsChangesCreateRequest) input message
@@ -77,7 +77,7 @@ class DnsV1(base_api.BaseApiClient):
     )
 
     def Get(self, request, global_params=None):
-      """Fetch the representation of an existing Change.
+      r"""Fetch the representation of an existing Change.
 
       Args:
         request: (DnsChangesGetRequest) input message
@@ -103,7 +103,7 @@ class DnsV1(base_api.BaseApiClient):
     )
 
     def List(self, request, global_params=None):
-      """Enumerate Changes to a ResourceRecordSet collection.
+      r"""Enumerate Changes to a ResourceRecordSet collection.
 
       Args:
         request: (DnsChangesListRequest) input message
@@ -139,7 +139,7 @@ class DnsV1(base_api.BaseApiClient):
           }
 
     def Create(self, request, global_params=None):
-      """Create a new ManagedZone.
+      r"""Create a new ManagedZone.
 
       Args:
         request: (DnsManagedZonesCreateRequest) input message
@@ -165,7 +165,7 @@ class DnsV1(base_api.BaseApiClient):
     )
 
     def Delete(self, request, global_params=None):
-      """Delete a previously created ManagedZone.
+      r"""Delete a previously created ManagedZone.
 
       Args:
         request: (DnsManagedZonesDeleteRequest) input message
@@ -191,7 +191,7 @@ class DnsV1(base_api.BaseApiClient):
     )
 
     def Get(self, request, global_params=None):
-      """Fetch the representation of an existing ManagedZone.
+      r"""Fetch the representation of an existing ManagedZone.
 
       Args:
         request: (DnsManagedZonesGetRequest) input message
@@ -217,7 +217,7 @@ class DnsV1(base_api.BaseApiClient):
     )
 
     def List(self, request, global_params=None):
-      """Enumerate ManagedZones that have been created but not yet deleted.
+      r"""Enumerate ManagedZones that have been created but not yet deleted.
 
       Args:
         request: (DnsManagedZonesListRequest) input message
@@ -253,7 +253,7 @@ class DnsV1(base_api.BaseApiClient):
           }
 
     def Get(self, request, global_params=None):
-      """Fetch the representation of an existing Project.
+      r"""Fetch the representation of an existing Project.
 
       Args:
         request: (DnsProjectsGetRequest) input message
@@ -289,7 +289,7 @@ class DnsV1(base_api.BaseApiClient):
           }
 
     def List(self, request, global_params=None):
-      """Enumerate ResourceRecordSets that have been created but not yet deleted.
+      r"""Enumerate ResourceRecordSets that have been created but not yet deleted.
 
       Args:
         request: (DnsResourceRecordSetsListRequest) input message

--- a/samples/dns_sample/dns_v1/dns_v1_messages.py
+++ b/samples/dns_sample/dns_v1/dns_v1_messages.py
@@ -12,7 +12,7 @@ package = 'dns'
 
 
 class Change(_messages.Message):
-  """An atomic update to a collection of ResourceRecordSets.
+  r"""An atomic update to a collection of ResourceRecordSets.
 
   Enums:
     StatusValueValuesEnum: Status of the operation (output only).
@@ -31,7 +31,7 @@ class Change(_messages.Message):
   """
 
   class StatusValueValuesEnum(_messages.Enum):
-    """Status of the operation (output only).
+    r"""Status of the operation (output only).
 
     Values:
       done: <no description>
@@ -49,7 +49,7 @@ class Change(_messages.Message):
 
 
 class ChangesListResponse(_messages.Message):
-  """The response to a request to enumerate Changes to a ResourceRecordSets
+  r"""The response to a request to enumerate Changes to a ResourceRecordSets
   collection.
 
   Fields:
@@ -72,7 +72,7 @@ class ChangesListResponse(_messages.Message):
 
 
 class DnsChangesCreateRequest(_messages.Message):
-  """A DnsChangesCreateRequest object.
+  r"""A DnsChangesCreateRequest object.
 
   Fields:
     change: A Change resource to be passed as the request body.
@@ -87,7 +87,7 @@ class DnsChangesCreateRequest(_messages.Message):
 
 
 class DnsChangesGetRequest(_messages.Message):
-  """A DnsChangesGetRequest object.
+  r"""A DnsChangesGetRequest object.
 
   Fields:
     changeId: The identifier of the requested change, from a previous
@@ -103,7 +103,7 @@ class DnsChangesGetRequest(_messages.Message):
 
 
 class DnsChangesListRequest(_messages.Message):
-  """A DnsChangesListRequest object.
+  r"""A DnsChangesListRequest object.
 
   Enums:
     SortByValueValuesEnum: Sorting criterion. The only supported value is
@@ -122,7 +122,7 @@ class DnsChangesListRequest(_messages.Message):
   """
 
   class SortByValueValuesEnum(_messages.Enum):
-    """Sorting criterion. The only supported value is change sequence.
+    r"""Sorting criterion. The only supported value is change sequence.
 
     Values:
       changeSequence: <no description>
@@ -138,7 +138,7 @@ class DnsChangesListRequest(_messages.Message):
 
 
 class DnsManagedZonesCreateRequest(_messages.Message):
-  """A DnsManagedZonesCreateRequest object.
+  r"""A DnsManagedZonesCreateRequest object.
 
   Fields:
     managedZone: A ManagedZone resource to be passed as the request body.
@@ -150,7 +150,7 @@ class DnsManagedZonesCreateRequest(_messages.Message):
 
 
 class DnsManagedZonesDeleteRequest(_messages.Message):
-  """A DnsManagedZonesDeleteRequest object.
+  r"""A DnsManagedZonesDeleteRequest object.
 
   Fields:
     managedZone: Identifies the managed zone addressed by this request. Can be
@@ -163,11 +163,11 @@ class DnsManagedZonesDeleteRequest(_messages.Message):
 
 
 class DnsManagedZonesDeleteResponse(_messages.Message):
-  """An empty DnsManagedZonesDelete response."""
+  r"""An empty DnsManagedZonesDelete response."""
 
 
 class DnsManagedZonesGetRequest(_messages.Message):
-  """A DnsManagedZonesGetRequest object.
+  r"""A DnsManagedZonesGetRequest object.
 
   Fields:
     managedZone: Identifies the managed zone addressed by this request. Can be
@@ -180,7 +180,7 @@ class DnsManagedZonesGetRequest(_messages.Message):
 
 
 class DnsManagedZonesListRequest(_messages.Message):
-  """A DnsManagedZonesListRequest object.
+  r"""A DnsManagedZonesListRequest object.
 
   Fields:
     dnsName: Restricts the list to return only zones with this domain name.
@@ -198,7 +198,7 @@ class DnsManagedZonesListRequest(_messages.Message):
 
 
 class DnsProjectsGetRequest(_messages.Message):
-  """A DnsProjectsGetRequest object.
+  r"""A DnsProjectsGetRequest object.
 
   Fields:
     project: Identifies the project addressed by this request.
@@ -208,7 +208,7 @@ class DnsProjectsGetRequest(_messages.Message):
 
 
 class DnsResourceRecordSetsListRequest(_messages.Message):
-  """A DnsResourceRecordSetsListRequest object.
+  r"""A DnsResourceRecordSetsListRequest object.
 
   Fields:
     managedZone: Identifies the managed zone addressed by this request. Can be
@@ -233,7 +233,7 @@ class DnsResourceRecordSetsListRequest(_messages.Message):
 
 
 class ManagedZone(_messages.Message):
-  """A zone is a subtree of the DNS namespace under one administrative
+  r"""A zone is a subtree of the DNS namespace under one administrative
   responsibility. A ManagedZone is a resource that represents a DNS zone
   hosted by the Cloud DNS service.
 
@@ -270,7 +270,7 @@ class ManagedZone(_messages.Message):
 
 
 class ManagedZonesListResponse(_messages.Message):
-  """A ManagedZonesListResponse object.
+  r"""A ManagedZonesListResponse object.
 
   Fields:
     kind: Type of resource.
@@ -292,7 +292,7 @@ class ManagedZonesListResponse(_messages.Message):
 
 
 class Project(_messages.Message):
-  """A project resource. The project is a top level container for resources
+  r"""A project resource. The project is a top level container for resources
   including Cloud DNS ManagedZones. Projects can be created only in the APIs
   console.
 
@@ -312,7 +312,7 @@ class Project(_messages.Message):
 
 
 class Quota(_messages.Message):
-  """Limits associated with a Project.
+  r"""Limits associated with a Project.
 
   Fields:
     kind: Identifies what kind of resource this is. Value: the fixed string
@@ -340,7 +340,7 @@ class Quota(_messages.Message):
 
 
 class ResourceRecordSet(_messages.Message):
-  """A unit of data that will be returned by the DNS servers.
+  r"""A unit of data that will be returned by the DNS servers.
 
   Fields:
     kind: Identifies what kind of resource this is. Value: the fixed string
@@ -361,7 +361,7 @@ class ResourceRecordSet(_messages.Message):
 
 
 class ResourceRecordSetsListResponse(_messages.Message):
-  """A ResourceRecordSetsListResponse object.
+  r"""A ResourceRecordSetsListResponse object.
 
   Fields:
     kind: Type of resource.
@@ -383,7 +383,7 @@ class ResourceRecordSetsListResponse(_messages.Message):
 
 
 class StandardQueryParameters(_messages.Message):
-  """Query parameters accepted by all methods.
+  r"""Query parameters accepted by all methods.
 
   Enums:
     AltValueValuesEnum: Data format for the response.
@@ -406,7 +406,7 @@ class StandardQueryParameters(_messages.Message):
   """
 
   class AltValueValuesEnum(_messages.Enum):
-    """Data format for the response.
+    r"""Data format for the response.
 
     Values:
       json: Responses with Content-Type of application/json

--- a/samples/fusiontables_sample/fusiontables_v1/fusiontables_v1_client.py
+++ b/samples/fusiontables_sample/fusiontables_v1/fusiontables_v1_client.py
@@ -53,7 +53,7 @@ class FusiontablesV1(base_api.BaseApiClient):
           }
 
     def Delete(self, request, global_params=None):
-      """Deletes the column.
+      r"""Deletes the column.
 
       Args:
         request: (FusiontablesColumnDeleteRequest) input message
@@ -79,7 +79,7 @@ class FusiontablesV1(base_api.BaseApiClient):
     )
 
     def Get(self, request, global_params=None):
-      """Retrieves a specific column by its id.
+      r"""Retrieves a specific column by its id.
 
       Args:
         request: (FusiontablesColumnGetRequest) input message
@@ -105,7 +105,7 @@ class FusiontablesV1(base_api.BaseApiClient):
     )
 
     def Insert(self, request, global_params=None):
-      """Adds a new column to the table.
+      r"""Adds a new column to the table.
 
       Args:
         request: (FusiontablesColumnInsertRequest) input message
@@ -131,7 +131,7 @@ class FusiontablesV1(base_api.BaseApiClient):
     )
 
     def List(self, request, global_params=None):
-      """Retrieves a list of columns.
+      r"""Retrieves a list of columns.
 
       Args:
         request: (FusiontablesColumnListRequest) input message
@@ -157,7 +157,7 @@ class FusiontablesV1(base_api.BaseApiClient):
     )
 
     def Patch(self, request, global_params=None):
-      """Updates the name or type of an existing column. This method supports patch semantics.
+      r"""Updates the name or type of an existing column. This method supports patch semantics.
 
       Args:
         request: (FusiontablesColumnPatchRequest) input message
@@ -183,7 +183,7 @@ class FusiontablesV1(base_api.BaseApiClient):
     )
 
     def Update(self, request, global_params=None):
-      """Updates the name or type of an existing column.
+      r"""Updates the name or type of an existing column.
 
       Args:
         request: (FusiontablesColumnUpdateRequest) input message
@@ -219,7 +219,7 @@ class FusiontablesV1(base_api.BaseApiClient):
           }
 
     def Sql(self, request, global_params=None, download=None):
-      """Executes an SQL SELECT/INSERT/UPDATE/DELETE/SHOW/DESCRIBE/CREATE statement.
+      r"""Executes an SQL SELECT/INSERT/UPDATE/DELETE/SHOW/DESCRIBE/CREATE statement.
 
       Args:
         request: (FusiontablesQuerySqlRequest) input message
@@ -248,7 +248,7 @@ class FusiontablesV1(base_api.BaseApiClient):
     )
 
     def SqlGet(self, request, global_params=None, download=None):
-      """Executes an SQL SELECT/SHOW/DESCRIBE statement.
+      r"""Executes an SQL SELECT/SHOW/DESCRIBE statement.
 
       Args:
         request: (FusiontablesQuerySqlGetRequest) input message
@@ -287,7 +287,7 @@ class FusiontablesV1(base_api.BaseApiClient):
           }
 
     def Delete(self, request, global_params=None):
-      """Deletes a style.
+      r"""Deletes a style.
 
       Args:
         request: (FusiontablesStyleDeleteRequest) input message
@@ -313,7 +313,7 @@ class FusiontablesV1(base_api.BaseApiClient):
     )
 
     def Get(self, request, global_params=None):
-      """Gets a specific style.
+      r"""Gets a specific style.
 
       Args:
         request: (FusiontablesStyleGetRequest) input message
@@ -339,7 +339,7 @@ class FusiontablesV1(base_api.BaseApiClient):
     )
 
     def Insert(self, request, global_params=None):
-      """Adds a new style for the table.
+      r"""Adds a new style for the table.
 
       Args:
         request: (StyleSetting) input message
@@ -365,7 +365,7 @@ class FusiontablesV1(base_api.BaseApiClient):
     )
 
     def List(self, request, global_params=None):
-      """Retrieves a list of styles.
+      r"""Retrieves a list of styles.
 
       Args:
         request: (FusiontablesStyleListRequest) input message
@@ -391,7 +391,7 @@ class FusiontablesV1(base_api.BaseApiClient):
     )
 
     def Patch(self, request, global_params=None):
-      """Updates an existing style. This method supports patch semantics.
+      r"""Updates an existing style. This method supports patch semantics.
 
       Args:
         request: (StyleSetting) input message
@@ -417,7 +417,7 @@ class FusiontablesV1(base_api.BaseApiClient):
     )
 
     def Update(self, request, global_params=None):
-      """Updates an existing style.
+      r"""Updates an existing style.
 
       Args:
         request: (StyleSetting) input message
@@ -469,7 +469,7 @@ class FusiontablesV1(base_api.BaseApiClient):
           }
 
     def Copy(self, request, global_params=None):
-      """Copies a table.
+      r"""Copies a table.
 
       Args:
         request: (FusiontablesTableCopyRequest) input message
@@ -495,7 +495,7 @@ class FusiontablesV1(base_api.BaseApiClient):
     )
 
     def Delete(self, request, global_params=None):
-      """Deletes a table.
+      r"""Deletes a table.
 
       Args:
         request: (FusiontablesTableDeleteRequest) input message
@@ -521,7 +521,7 @@ class FusiontablesV1(base_api.BaseApiClient):
     )
 
     def Get(self, request, global_params=None):
-      """Retrieves a specific table by its id.
+      r"""Retrieves a specific table by its id.
 
       Args:
         request: (FusiontablesTableGetRequest) input message
@@ -547,7 +547,7 @@ class FusiontablesV1(base_api.BaseApiClient):
     )
 
     def ImportRows(self, request, global_params=None, upload=None):
-      """Import more rows into a table.
+      r"""Import more rows into a table.
 
       Args:
         request: (FusiontablesTableImportRowsRequest) input message
@@ -577,7 +577,7 @@ class FusiontablesV1(base_api.BaseApiClient):
     )
 
     def ImportTable(self, request, global_params=None, upload=None):
-      """Import a new table.
+      r"""Import a new table.
 
       Args:
         request: (FusiontablesTableImportTableRequest) input message
@@ -607,7 +607,7 @@ class FusiontablesV1(base_api.BaseApiClient):
     )
 
     def Insert(self, request, global_params=None):
-      """Creates a new table.
+      r"""Creates a new table.
 
       Args:
         request: (Table) input message
@@ -633,7 +633,7 @@ class FusiontablesV1(base_api.BaseApiClient):
     )
 
     def List(self, request, global_params=None):
-      """Retrieves a list of tables a user owns.
+      r"""Retrieves a list of tables a user owns.
 
       Args:
         request: (FusiontablesTableListRequest) input message
@@ -659,7 +659,7 @@ class FusiontablesV1(base_api.BaseApiClient):
     )
 
     def Patch(self, request, global_params=None):
-      """Updates an existing table. Unless explicitly requested, only the name, description, and attribution will be updated. This method supports patch semantics.
+      r"""Updates an existing table. Unless explicitly requested, only the name, description, and attribution will be updated. This method supports patch semantics.
 
       Args:
         request: (FusiontablesTablePatchRequest) input message
@@ -685,7 +685,7 @@ class FusiontablesV1(base_api.BaseApiClient):
     )
 
     def Update(self, request, global_params=None):
-      """Updates an existing table. Unless explicitly requested, only the name, description, and attribution will be updated.
+      r"""Updates an existing table. Unless explicitly requested, only the name, description, and attribution will be updated.
 
       Args:
         request: (FusiontablesTableUpdateRequest) input message
@@ -721,7 +721,7 @@ class FusiontablesV1(base_api.BaseApiClient):
           }
 
     def Delete(self, request, global_params=None):
-      """Deletes the task, unless already started.
+      r"""Deletes the task, unless already started.
 
       Args:
         request: (FusiontablesTaskDeleteRequest) input message
@@ -747,7 +747,7 @@ class FusiontablesV1(base_api.BaseApiClient):
     )
 
     def Get(self, request, global_params=None):
-      """Retrieves a specific task by its id.
+      r"""Retrieves a specific task by its id.
 
       Args:
         request: (FusiontablesTaskGetRequest) input message
@@ -773,7 +773,7 @@ class FusiontablesV1(base_api.BaseApiClient):
     )
 
     def List(self, request, global_params=None):
-      """Retrieves a list of tasks.
+      r"""Retrieves a list of tasks.
 
       Args:
         request: (FusiontablesTaskListRequest) input message
@@ -809,7 +809,7 @@ class FusiontablesV1(base_api.BaseApiClient):
           }
 
     def Delete(self, request, global_params=None):
-      """Deletes a template.
+      r"""Deletes a template.
 
       Args:
         request: (FusiontablesTemplateDeleteRequest) input message
@@ -835,7 +835,7 @@ class FusiontablesV1(base_api.BaseApiClient):
     )
 
     def Get(self, request, global_params=None):
-      """Retrieves a specific template by its id.
+      r"""Retrieves a specific template by its id.
 
       Args:
         request: (FusiontablesTemplateGetRequest) input message
@@ -861,7 +861,7 @@ class FusiontablesV1(base_api.BaseApiClient):
     )
 
     def Insert(self, request, global_params=None):
-      """Creates a new template for the table.
+      r"""Creates a new template for the table.
 
       Args:
         request: (Template) input message
@@ -887,7 +887,7 @@ class FusiontablesV1(base_api.BaseApiClient):
     )
 
     def List(self, request, global_params=None):
-      """Retrieves a list of templates.
+      r"""Retrieves a list of templates.
 
       Args:
         request: (FusiontablesTemplateListRequest) input message
@@ -913,7 +913,7 @@ class FusiontablesV1(base_api.BaseApiClient):
     )
 
     def Patch(self, request, global_params=None):
-      """Updates an existing template. This method supports patch semantics.
+      r"""Updates an existing template. This method supports patch semantics.
 
       Args:
         request: (Template) input message
@@ -939,7 +939,7 @@ class FusiontablesV1(base_api.BaseApiClient):
     )
 
     def Update(self, request, global_params=None):
-      """Updates an existing template.
+      r"""Updates an existing template.
 
       Args:
         request: (Template) input message

--- a/samples/fusiontables_sample/fusiontables_v1/fusiontables_v1_messages.py
+++ b/samples/fusiontables_sample/fusiontables_v1/fusiontables_v1_messages.py
@@ -12,7 +12,7 @@ package = 'fusiontables'
 
 
 class Bucket(_messages.Message):
-  """Specifies the minimum and maximum values, the color, opacity, icon and
+  r"""Specifies the minimum and maximum values, the color, opacity, icon and
   weight of a bucket within a StyleSetting.
 
   Fields:
@@ -35,7 +35,7 @@ class Bucket(_messages.Message):
 
 
 class Column(_messages.Message):
-  """Specifies the id, name and type of a column in a table.
+  r"""Specifies the id, name and type of a column in a table.
 
   Messages:
     BaseColumnValue: Optional identifier of the base column. If present, this
@@ -55,7 +55,7 @@ class Column(_messages.Message):
   """
 
   class BaseColumnValue(_messages.Message):
-    """Optional identifier of the base column. If present, this column is
+    r"""Optional identifier of the base column. If present, this column is
     derived from the specified base column.
 
     Fields:
@@ -78,7 +78,7 @@ class Column(_messages.Message):
 
 
 class ColumnList(_messages.Message):
-  """Represents a list of columns in a table.
+  r"""Represents a list of columns in a table.
 
   Fields:
     items: List of all requested columns.
@@ -95,7 +95,7 @@ class ColumnList(_messages.Message):
 
 
 class FusiontablesColumnDeleteRequest(_messages.Message):
-  """A FusiontablesColumnDeleteRequest object.
+  r"""A FusiontablesColumnDeleteRequest object.
 
   Fields:
     columnId: Name or identifier for the column being deleted.
@@ -107,11 +107,11 @@ class FusiontablesColumnDeleteRequest(_messages.Message):
 
 
 class FusiontablesColumnDeleteResponse(_messages.Message):
-  """An empty FusiontablesColumnDelete response."""
+  r"""An empty FusiontablesColumnDelete response."""
 
 
 class FusiontablesColumnGetRequest(_messages.Message):
-  """A FusiontablesColumnGetRequest object.
+  r"""A FusiontablesColumnGetRequest object.
 
   Fields:
     columnId: Name or identifier for the column that is being requested.
@@ -123,7 +123,7 @@ class FusiontablesColumnGetRequest(_messages.Message):
 
 
 class FusiontablesColumnInsertRequest(_messages.Message):
-  """A FusiontablesColumnInsertRequest object.
+  r"""A FusiontablesColumnInsertRequest object.
 
   Fields:
     column: A Column resource to be passed as the request body.
@@ -135,7 +135,7 @@ class FusiontablesColumnInsertRequest(_messages.Message):
 
 
 class FusiontablesColumnListRequest(_messages.Message):
-  """A FusiontablesColumnListRequest object.
+  r"""A FusiontablesColumnListRequest object.
 
   Fields:
     maxResults: Maximum number of columns to return. Optional. Default is 5.
@@ -150,7 +150,7 @@ class FusiontablesColumnListRequest(_messages.Message):
 
 
 class FusiontablesColumnPatchRequest(_messages.Message):
-  """A FusiontablesColumnPatchRequest object.
+  r"""A FusiontablesColumnPatchRequest object.
 
   Fields:
     column: A Column resource to be passed as the request body.
@@ -164,7 +164,7 @@ class FusiontablesColumnPatchRequest(_messages.Message):
 
 
 class FusiontablesColumnUpdateRequest(_messages.Message):
-  """A FusiontablesColumnUpdateRequest object.
+  r"""A FusiontablesColumnUpdateRequest object.
 
   Fields:
     column: A Column resource to be passed as the request body.
@@ -178,7 +178,7 @@ class FusiontablesColumnUpdateRequest(_messages.Message):
 
 
 class FusiontablesQuerySqlGetRequest(_messages.Message):
-  """A FusiontablesQuerySqlGetRequest object.
+  r"""A FusiontablesQuerySqlGetRequest object.
 
   Fields:
     hdrs: Should column names be included (in the first row)?. Default is
@@ -195,7 +195,7 @@ class FusiontablesQuerySqlGetRequest(_messages.Message):
 
 
 class FusiontablesQuerySqlRequest(_messages.Message):
-  """A FusiontablesQuerySqlRequest object.
+  r"""A FusiontablesQuerySqlRequest object.
 
   Fields:
     hdrs: Should column names be included (in the first row)?. Default is
@@ -212,7 +212,7 @@ class FusiontablesQuerySqlRequest(_messages.Message):
 
 
 class FusiontablesStyleDeleteRequest(_messages.Message):
-  """A FusiontablesStyleDeleteRequest object.
+  r"""A FusiontablesStyleDeleteRequest object.
 
   Fields:
     styleId: Identifier (within a table) for the style being deleted
@@ -224,11 +224,11 @@ class FusiontablesStyleDeleteRequest(_messages.Message):
 
 
 class FusiontablesStyleDeleteResponse(_messages.Message):
-  """An empty FusiontablesStyleDelete response."""
+  r"""An empty FusiontablesStyleDelete response."""
 
 
 class FusiontablesStyleGetRequest(_messages.Message):
-  """A FusiontablesStyleGetRequest object.
+  r"""A FusiontablesStyleGetRequest object.
 
   Fields:
     styleId: Identifier (integer) for a specific style in a table
@@ -240,7 +240,7 @@ class FusiontablesStyleGetRequest(_messages.Message):
 
 
 class FusiontablesStyleListRequest(_messages.Message):
-  """A FusiontablesStyleListRequest object.
+  r"""A FusiontablesStyleListRequest object.
 
   Fields:
     maxResults: Maximum number of styles to return. Optional. Default is 5.
@@ -255,7 +255,7 @@ class FusiontablesStyleListRequest(_messages.Message):
 
 
 class FusiontablesTableCopyRequest(_messages.Message):
-  """A FusiontablesTableCopyRequest object.
+  r"""A FusiontablesTableCopyRequest object.
 
   Fields:
     copyPresentation: Whether to also copy tabs, styles, and templates.
@@ -268,7 +268,7 @@ class FusiontablesTableCopyRequest(_messages.Message):
 
 
 class FusiontablesTableDeleteRequest(_messages.Message):
-  """A FusiontablesTableDeleteRequest object.
+  r"""A FusiontablesTableDeleteRequest object.
 
   Fields:
     tableId: ID of the table that is being deleted.
@@ -278,11 +278,11 @@ class FusiontablesTableDeleteRequest(_messages.Message):
 
 
 class FusiontablesTableDeleteResponse(_messages.Message):
-  """An empty FusiontablesTableDelete response."""
+  r"""An empty FusiontablesTableDelete response."""
 
 
 class FusiontablesTableGetRequest(_messages.Message):
-  """A FusiontablesTableGetRequest object.
+  r"""A FusiontablesTableGetRequest object.
 
   Fields:
     tableId: Identifier(ID) for the table being requested.
@@ -292,7 +292,7 @@ class FusiontablesTableGetRequest(_messages.Message):
 
 
 class FusiontablesTableImportRowsRequest(_messages.Message):
-  """A FusiontablesTableImportRowsRequest object.
+  r"""A FusiontablesTableImportRowsRequest object.
 
   Fields:
     delimiter: The delimiter used to separate cell values. This can only
@@ -324,7 +324,7 @@ class FusiontablesTableImportRowsRequest(_messages.Message):
 
 
 class FusiontablesTableImportTableRequest(_messages.Message):
-  """A FusiontablesTableImportTableRequest object.
+  r"""A FusiontablesTableImportTableRequest object.
 
   Fields:
     delimiter: The delimiter used to separate cell values. This can only
@@ -340,7 +340,7 @@ class FusiontablesTableImportTableRequest(_messages.Message):
 
 
 class FusiontablesTableListRequest(_messages.Message):
-  """A FusiontablesTableListRequest object.
+  r"""A FusiontablesTableListRequest object.
 
   Fields:
     maxResults: Maximum number of styles to return. Optional. Default is 5.
@@ -353,7 +353,7 @@ class FusiontablesTableListRequest(_messages.Message):
 
 
 class FusiontablesTablePatchRequest(_messages.Message):
-  """A FusiontablesTablePatchRequest object.
+  r"""A FusiontablesTablePatchRequest object.
 
   Fields:
     replaceViewDefinition: Should the view definition also be updated? The
@@ -369,7 +369,7 @@ class FusiontablesTablePatchRequest(_messages.Message):
 
 
 class FusiontablesTableUpdateRequest(_messages.Message):
-  """A FusiontablesTableUpdateRequest object.
+  r"""A FusiontablesTableUpdateRequest object.
 
   Fields:
     replaceViewDefinition: Should the view definition also be updated? The
@@ -385,7 +385,7 @@ class FusiontablesTableUpdateRequest(_messages.Message):
 
 
 class FusiontablesTaskDeleteRequest(_messages.Message):
-  """A FusiontablesTaskDeleteRequest object.
+  r"""A FusiontablesTaskDeleteRequest object.
 
   Fields:
     tableId: Table from which the task is being deleted.
@@ -397,11 +397,11 @@ class FusiontablesTaskDeleteRequest(_messages.Message):
 
 
 class FusiontablesTaskDeleteResponse(_messages.Message):
-  """An empty FusiontablesTaskDelete response."""
+  r"""An empty FusiontablesTaskDelete response."""
 
 
 class FusiontablesTaskGetRequest(_messages.Message):
-  """A FusiontablesTaskGetRequest object.
+  r"""A FusiontablesTaskGetRequest object.
 
   Fields:
     tableId: Table to which the task belongs.
@@ -413,7 +413,7 @@ class FusiontablesTaskGetRequest(_messages.Message):
 
 
 class FusiontablesTaskListRequest(_messages.Message):
-  """A FusiontablesTaskListRequest object.
+  r"""A FusiontablesTaskListRequest object.
 
   Fields:
     maxResults: Maximum number of columns to return. Optional. Default is 5.
@@ -429,7 +429,7 @@ class FusiontablesTaskListRequest(_messages.Message):
 
 
 class FusiontablesTemplateDeleteRequest(_messages.Message):
-  """A FusiontablesTemplateDeleteRequest object.
+  r"""A FusiontablesTemplateDeleteRequest object.
 
   Fields:
     tableId: Table from which the template is being deleted
@@ -441,11 +441,11 @@ class FusiontablesTemplateDeleteRequest(_messages.Message):
 
 
 class FusiontablesTemplateDeleteResponse(_messages.Message):
-  """An empty FusiontablesTemplateDelete response."""
+  r"""An empty FusiontablesTemplateDelete response."""
 
 
 class FusiontablesTemplateGetRequest(_messages.Message):
-  """A FusiontablesTemplateGetRequest object.
+  r"""A FusiontablesTemplateGetRequest object.
 
   Fields:
     tableId: Table to which the template belongs
@@ -457,7 +457,7 @@ class FusiontablesTemplateGetRequest(_messages.Message):
 
 
 class FusiontablesTemplateListRequest(_messages.Message):
-  """A FusiontablesTemplateListRequest object.
+  r"""A FusiontablesTemplateListRequest object.
 
   Fields:
     maxResults: Maximum number of templates to return. Optional. Default is 5.
@@ -472,7 +472,7 @@ class FusiontablesTemplateListRequest(_messages.Message):
 
 
 class Geometry(_messages.Message):
-  """Represents a Geometry object.
+  r"""Represents a Geometry object.
 
   Fields:
     geometries: The list of geometries in this geometry collection.
@@ -486,7 +486,7 @@ class Geometry(_messages.Message):
 
 
 class Import(_messages.Message):
-  """Represents an import request.
+  r"""Represents an import request.
 
   Fields:
     kind: Type name: a template for an import request.
@@ -498,7 +498,7 @@ class Import(_messages.Message):
 
 
 class Line(_messages.Message):
-  """Represents a line geometry.
+  r"""Represents a line geometry.
 
   Messages:
     CoordinatesValueListEntry: Single entry in a CoordinatesValue.
@@ -509,7 +509,7 @@ class Line(_messages.Message):
   """
 
   class CoordinatesValueListEntry(_messages.Message):
-    """Single entry in a CoordinatesValue.
+    r"""Single entry in a CoordinatesValue.
 
     Fields:
       entry: A number attribute.
@@ -522,7 +522,7 @@ class Line(_messages.Message):
 
 
 class LineStyle(_messages.Message):
-  """Represents a LineStyle within a StyleSetting
+  r"""Represents a LineStyle within a StyleSetting
 
   Fields:
     strokeColor: Color of the line in #RRGGBB format.
@@ -542,7 +542,7 @@ class LineStyle(_messages.Message):
 
 
 class Point(_messages.Message):
-  """Represents a point object.
+  r"""Represents a point object.
 
   Fields:
     coordinates: The coordinates that define the point.
@@ -554,7 +554,7 @@ class Point(_messages.Message):
 
 
 class PointStyle(_messages.Message):
-  """Represents a PointStyle within a StyleSetting
+  r"""Represents a PointStyle within a StyleSetting
 
   Fields:
     iconName: Name of the icon. Use values defined in
@@ -568,7 +568,7 @@ class PointStyle(_messages.Message):
 
 
 class Polygon(_messages.Message):
-  """Represents a polygon object.
+  r"""Represents a polygon object.
 
   Messages:
     CoordinatesValueListEntry: Single entry in a CoordinatesValue.
@@ -579,7 +579,7 @@ class Polygon(_messages.Message):
   """
 
   class CoordinatesValueListEntry(_messages.Message):
-    """Single entry in a CoordinatesValue.
+    r"""Single entry in a CoordinatesValue.
 
     Messages:
       EntryValueListEntry: Single entry in a EntryValue.
@@ -589,7 +589,7 @@ class Polygon(_messages.Message):
     """
 
     class EntryValueListEntry(_messages.Message):
-      """Single entry in a EntryValue.
+      r"""Single entry in a EntryValue.
 
       Fields:
         entry: A number attribute.
@@ -604,7 +604,7 @@ class Polygon(_messages.Message):
 
 
 class PolygonStyle(_messages.Message):
-  """Represents a PolygonStyle within a StyleSetting
+  r"""Represents a PolygonStyle within a StyleSetting
 
   Fields:
     fillColor: Color of the interior of the polygon in #RRGGBB format.
@@ -633,7 +633,7 @@ class PolygonStyle(_messages.Message):
 
 
 class Sqlresponse(_messages.Message):
-  """Represents a response to an sql statement.
+  r"""Represents a response to an sql statement.
 
   Messages:
     RowsValueListEntry: Single entry in a RowsValue.
@@ -647,7 +647,7 @@ class Sqlresponse(_messages.Message):
   """
 
   class RowsValueListEntry(_messages.Message):
-    """Single entry in a RowsValue.
+    r"""Single entry in a RowsValue.
 
     Fields:
       entry: A extra_types.JsonValue attribute.
@@ -661,7 +661,7 @@ class Sqlresponse(_messages.Message):
 
 
 class StandardQueryParameters(_messages.Message):
-  """Query parameters accepted by all methods.
+  r"""Query parameters accepted by all methods.
 
   Enums:
     AltValueValuesEnum: Data format for the response.
@@ -684,7 +684,7 @@ class StandardQueryParameters(_messages.Message):
   """
 
   class AltValueValuesEnum(_messages.Enum):
-    """Data format for the response.
+    r"""Data format for the response.
 
     Values:
       csv: Responses with Content-Type of text/csv
@@ -704,7 +704,7 @@ class StandardQueryParameters(_messages.Message):
 
 
 class StyleFunction(_messages.Message):
-  """Represents a StyleFunction within a StyleSetting
+  r"""Represents a StyleFunction within a StyleSetting
 
   Messages:
     GradientValue: Gradient function that interpolates a range of colors based
@@ -726,7 +726,7 @@ class StyleFunction(_messages.Message):
   """
 
   class GradientValue(_messages.Message):
-    """Gradient function that interpolates a range of colors based on column
+    r"""Gradient function that interpolates a range of colors based on column
     value.
 
     Messages:
@@ -741,7 +741,7 @@ class StyleFunction(_messages.Message):
     """
 
     class ColorsValueListEntry(_messages.Message):
-      """A ColorsValueListEntry object.
+      r"""A ColorsValueListEntry object.
 
       Fields:
         color: Color in #RRGGBB format.
@@ -762,7 +762,7 @@ class StyleFunction(_messages.Message):
 
 
 class StyleSetting(_messages.Message):
-  """Represents a complete StyleSettings object. The primary key is a
+  r"""Represents a complete StyleSettings object. The primary key is a
   combination of the tableId and a styleId.
 
   Fields:
@@ -788,7 +788,7 @@ class StyleSetting(_messages.Message):
 
 
 class StyleSettingList(_messages.Message):
-  """Represents a list of styles for a given table.
+  r"""Represents a list of styles for a given table.
 
   Fields:
     items: All requested style settings.
@@ -805,7 +805,7 @@ class StyleSettingList(_messages.Message):
 
 
 class Table(_messages.Message):
-  """Represents a table. Specifies the name, whether it is exportable,
+  r"""Represents a table. Specifies the name, whether it is exportable,
   description, attribution, and attribution link.
 
   Fields:
@@ -835,7 +835,7 @@ class Table(_messages.Message):
 
 
 class TableList(_messages.Message):
-  """Represents a list of tables.
+  r"""Represents a list of tables.
 
   Fields:
     items: List of all requested tables.
@@ -850,7 +850,7 @@ class TableList(_messages.Message):
 
 
 class Task(_messages.Message):
-  """Specifies the identifier, name, and type of a task in a table.
+  r"""Specifies the identifier, name, and type of a task in a table.
 
   Fields:
     kind: Type of the resource. This is always "fusiontables#task".
@@ -873,7 +873,7 @@ class Task(_messages.Message):
 
 
 class TaskList(_messages.Message):
-  """Represents a list of tasks for a table.
+  r"""Represents a list of tasks for a table.
 
   Fields:
     items: List of all requested tasks.
@@ -890,7 +890,7 @@ class TaskList(_messages.Message):
 
 
 class Template(_messages.Message):
-  """Represents the contents of InfoWindow templates.
+  r"""Represents the contents of InfoWindow templates.
 
   Fields:
     automaticColumnNames: List of columns from which the template is to be
@@ -918,7 +918,7 @@ class Template(_messages.Message):
 
 
 class TemplateList(_messages.Message):
-  """Represents a list of templates for a given table.
+  r"""Represents a list of templates for a given table.
 
   Fields:
     items: List of all requested templates.

--- a/samples/iam_sample/iam_v1/iam_v1_client.py
+++ b/samples/iam_sample/iam_v1/iam_v1_client.py
@@ -52,7 +52,7 @@ class IamV1(base_api.BaseApiClient):
           }
 
     def GetPolicyDetails(self, request, global_params=None):
-      """Returns the current IAM policy and the policies on the inherited resources.
+      r"""Returns the current IAM policy and the policies on the inherited resources.
 that the user has access to.
 
       Args:
@@ -89,7 +89,7 @@ that the user has access to.
           }
 
     def Create(self, request, global_params=None):
-      """Creates a ServiceAccountKey.
+      r"""Creates a ServiceAccountKey.
 and returns it.
 
       Args:
@@ -117,7 +117,7 @@ and returns it.
     )
 
     def Delete(self, request, global_params=None):
-      """Deletes a ServiceAccountKey.
+      r"""Deletes a ServiceAccountKey.
 
       Args:
         request: (IamProjectsServiceAccountsKeysDeleteRequest) input message
@@ -144,7 +144,7 @@ and returns it.
     )
 
     def Get(self, request, global_params=None):
-      """Gets the ServiceAccountKey.
+      r"""Gets the ServiceAccountKey.
 by key id.
 
       Args:
@@ -172,7 +172,7 @@ by key id.
     )
 
     def List(self, request, global_params=None):
-      """Lists ServiceAccountKeys.
+      r"""Lists ServiceAccountKeys.
 
       Args:
         request: (IamProjectsServiceAccountsKeysListRequest) input message
@@ -209,7 +209,7 @@ by key id.
           }
 
     def Create(self, request, global_params=None):
-      """Creates a ServiceAccount.
+      r"""Creates a ServiceAccount.
 and returns it.
 
       Args:
@@ -237,7 +237,7 @@ and returns it.
     )
 
     def Delete(self, request, global_params=None):
-      """Deletes a ServiceAccount.
+      r"""Deletes a ServiceAccount.
 
       Args:
         request: (IamProjectsServiceAccountsDeleteRequest) input message
@@ -264,7 +264,7 @@ and returns it.
     )
 
     def Get(self, request, global_params=None):
-      """Gets a ServiceAccount.
+      r"""Gets a ServiceAccount.
 
       Args:
         request: (IamProjectsServiceAccountsGetRequest) input message
@@ -291,7 +291,7 @@ and returns it.
     )
 
     def GetIamPolicy(self, request, global_params=None):
-      """Returns the IAM access control policy for specified IAM resource.
+      r"""Returns the IAM access control policy for specified IAM resource.
 
       Args:
         request: (IamProjectsServiceAccountsGetIamPolicyRequest) input message
@@ -318,7 +318,7 @@ and returns it.
     )
 
     def List(self, request, global_params=None):
-      """Lists ServiceAccounts for a project.
+      r"""Lists ServiceAccounts for a project.
 
       Args:
         request: (IamProjectsServiceAccountsListRequest) input message
@@ -345,7 +345,7 @@ and returns it.
     )
 
     def SetIamPolicy(self, request, global_params=None):
-      """Sets the IAM access control policy for the specified IAM resource.
+      r"""Sets the IAM access control policy for the specified IAM resource.
 
       Args:
         request: (IamProjectsServiceAccountsSetIamPolicyRequest) input message
@@ -372,7 +372,7 @@ and returns it.
     )
 
     def SignBlob(self, request, global_params=None):
-      """Signs a blob using a service account's system-managed private key.
+      r"""Signs a blob using a service account's system-managed private key.
 
       Args:
         request: (IamProjectsServiceAccountsSignBlobRequest) input message
@@ -399,7 +399,7 @@ and returns it.
     )
 
     def SignJwt(self, request, global_params=None):
-      """Signs a JWT using a service account's system-managed private key.
+      r"""Signs a JWT using a service account's system-managed private key.
 
 If no `exp` (expiry) time is contained in the claims, we will
 provide an expiry of one hour in the future. If an expiry
@@ -431,7 +431,7 @@ will fail.
     )
 
     def TestIamPermissions(self, request, global_params=None):
-      """Tests the specified permissions against the IAM access control policy.
+      r"""Tests the specified permissions against the IAM access control policy.
 for the specified IAM resource.
 
       Args:
@@ -459,7 +459,7 @@ for the specified IAM resource.
     )
 
     def Update(self, request, global_params=None):
-      """Updates a ServiceAccount.
+      r"""Updates a ServiceAccount.
 
 Currently, only the following fields are updatable:
 `display_name` .
@@ -510,7 +510,7 @@ The `etag` is mandatory.
           }
 
     def QueryGrantableRoles(self, request, global_params=None):
-      """Queries roles that can be granted on a particular resource.
+      r"""Queries roles that can be granted on a particular resource.
 
       Args:
         request: (QueryGrantableRolesRequest) input message

--- a/samples/iam_sample/iam_v1/iam_v1_messages.py
+++ b/samples/iam_sample/iam_v1/iam_v1_messages.py
@@ -14,8 +14,8 @@ package = 'iam'
 
 
 class AuditConfig(_messages.Message):
-  """Enables "data access" audit logging for a service and specifies a list of
-  members that are log-exempted.
+  r"""Enables "data access" audit logging for a service and specifies a list
+  of members that are log-exempted.
 
   Fields:
     exemptedMembers: Specifies the identities that are exempted from "data
@@ -31,7 +31,7 @@ class AuditConfig(_messages.Message):
 
 
 class Binding(_messages.Message):
-  """Associates `members` with a `role`.
+  r"""Associates `members` with a `role`.
 
   Fields:
     members: Specifies the identities requesting access for a Cloud Platform
@@ -56,11 +56,11 @@ class Binding(_messages.Message):
 
 
 class CloudAuditOptions(_messages.Message):
-  """Write a Cloud Audit log"""
+  r"""Write a Cloud Audit log"""
 
 
 class Condition(_messages.Message):
-  """A condition to be met.
+  r"""A condition to be met.
 
   Enums:
     IamValueValuesEnum: Trusted attributes supplied by the IAM system.
@@ -80,7 +80,7 @@ class Condition(_messages.Message):
   """
 
   class IamValueValuesEnum(_messages.Enum):
-    """Trusted attributes supplied by the IAM system.
+    r"""Trusted attributes supplied by the IAM system.
 
     Values:
       NO_ATTR: Default non-attribute.
@@ -92,7 +92,7 @@ class Condition(_messages.Message):
     ATTRIBUTION = 2
 
   class OpValueValuesEnum(_messages.Enum):
-    """An operator to apply the subject with.
+    r"""An operator to apply the subject with.
 
     Values:
       NO_OP: Default no-op.
@@ -110,8 +110,8 @@ class Condition(_messages.Message):
     DISCHARGED = 5
 
   class SysValueValuesEnum(_messages.Enum):
-    """Trusted attributes supplied by any service that owns resources and uses
-    the IAM system for access control.
+    r"""Trusted attributes supplied by any service that owns resources and
+    uses the IAM system for access control.
 
     Values:
       NO_ATTR: Default non-attribute type
@@ -135,7 +135,7 @@ class Condition(_messages.Message):
 
 
 class CounterOptions(_messages.Message):
-  """Options for counters
+  r"""Options for counters
 
   Fields:
     field: The field value to attribute.
@@ -147,7 +147,7 @@ class CounterOptions(_messages.Message):
 
 
 class CreateServiceAccountKeyRequest(_messages.Message):
-  """The service account key create request.
+  r"""The service account key create request.
 
   Enums:
     PrivateKeyTypeValueValuesEnum: The output format of the private key.
@@ -159,7 +159,7 @@ class CreateServiceAccountKeyRequest(_messages.Message):
   """
 
   class PrivateKeyTypeValueValuesEnum(_messages.Enum):
-    """The output format of the private key. `GOOGLE_CREDENTIALS_FILE` is the
+    r"""The output format of the private key. `GOOGLE_CREDENTIALS_FILE` is the
     default output format.
 
     Values:
@@ -178,7 +178,7 @@ class CreateServiceAccountKeyRequest(_messages.Message):
 
 
 class CreateServiceAccountRequest(_messages.Message):
-  """The service account create request.
+  r"""The service account create request.
 
   Fields:
     accountId: Required. The account id that is used to generate the service
@@ -194,11 +194,11 @@ class CreateServiceAccountRequest(_messages.Message):
 
 
 class DataAccessOptions(_messages.Message):
-  """Write a Data Access (Gin) log"""
+  r"""Write a Data Access (Gin) log"""
 
 
 class Empty(_messages.Message):
-  """A generic empty message that you can re-use to avoid defining duplicated
+  r"""A generic empty message that you can re-use to avoid defining duplicated
   empty messages in your APIs. A typical example is to use it as the request
   or the response type of an API method. For instance:      service Foo {
   rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);     }  The
@@ -208,7 +208,7 @@ class Empty(_messages.Message):
 
 
 class GetPolicyDetailsRequest(_messages.Message):
-  """The request to get the current policy and the policies on the inherited
+  r"""The request to get the current policy and the policies on the inherited
   resources the user has access to.
 
   Fields:
@@ -229,7 +229,7 @@ class GetPolicyDetailsRequest(_messages.Message):
 
 
 class GetPolicyDetailsResponse(_messages.Message):
-  """The response to the `GetPolicyDetailsRequest` containing the current
+  r"""The response to the `GetPolicyDetailsRequest` containing the current
   policy and the policies on the inherited resources the user has access to.
 
   Fields:
@@ -247,7 +247,7 @@ class GetPolicyDetailsResponse(_messages.Message):
 
 
 class IamProjectsServiceAccountsCreateRequest(_messages.Message):
-  """A IamProjectsServiceAccountsCreateRequest object.
+  r"""A IamProjectsServiceAccountsCreateRequest object.
 
   Fields:
     createServiceAccountRequest: A CreateServiceAccountRequest resource to be
@@ -261,7 +261,7 @@ class IamProjectsServiceAccountsCreateRequest(_messages.Message):
 
 
 class IamProjectsServiceAccountsDeleteRequest(_messages.Message):
-  """A IamProjectsServiceAccountsDeleteRequest object.
+  r"""A IamProjectsServiceAccountsDeleteRequest object.
 
   Fields:
     name: The resource name of the service account in the following format:
@@ -275,7 +275,7 @@ class IamProjectsServiceAccountsDeleteRequest(_messages.Message):
 
 
 class IamProjectsServiceAccountsGetIamPolicyRequest(_messages.Message):
-  """A IamProjectsServiceAccountsGetIamPolicyRequest object.
+  r"""A IamProjectsServiceAccountsGetIamPolicyRequest object.
 
   Fields:
     resource: REQUIRED: The resource for which the policy is being requested.
@@ -289,7 +289,7 @@ class IamProjectsServiceAccountsGetIamPolicyRequest(_messages.Message):
 
 
 class IamProjectsServiceAccountsGetRequest(_messages.Message):
-  """A IamProjectsServiceAccountsGetRequest object.
+  r"""A IamProjectsServiceAccountsGetRequest object.
 
   Fields:
     name: The resource name of the service account in the following format:
@@ -303,7 +303,7 @@ class IamProjectsServiceAccountsGetRequest(_messages.Message):
 
 
 class IamProjectsServiceAccountsKeysCreateRequest(_messages.Message):
-  """A IamProjectsServiceAccountsKeysCreateRequest object.
+  r"""A IamProjectsServiceAccountsKeysCreateRequest object.
 
   Fields:
     createServiceAccountKeyRequest: A CreateServiceAccountKeyRequest resource
@@ -320,7 +320,7 @@ class IamProjectsServiceAccountsKeysCreateRequest(_messages.Message):
 
 
 class IamProjectsServiceAccountsKeysDeleteRequest(_messages.Message):
-  """A IamProjectsServiceAccountsKeysDeleteRequest object.
+  r"""A IamProjectsServiceAccountsKeysDeleteRequest object.
 
   Fields:
     name: The resource name of the service account key in the following
@@ -334,7 +334,7 @@ class IamProjectsServiceAccountsKeysDeleteRequest(_messages.Message):
 
 
 class IamProjectsServiceAccountsKeysGetRequest(_messages.Message):
-  """A IamProjectsServiceAccountsKeysGetRequest object.
+  r"""A IamProjectsServiceAccountsKeysGetRequest object.
 
   Enums:
     PublicKeyTypeValueValuesEnum: The output format of the public key
@@ -351,7 +351,7 @@ class IamProjectsServiceAccountsKeysGetRequest(_messages.Message):
   """
 
   class PublicKeyTypeValueValuesEnum(_messages.Enum):
-    """The output format of the public key requested. X509_PEM is the default
+    r"""The output format of the public key requested. X509_PEM is the default
     output format.
 
     Values:
@@ -368,7 +368,7 @@ class IamProjectsServiceAccountsKeysGetRequest(_messages.Message):
 
 
 class IamProjectsServiceAccountsKeysListRequest(_messages.Message):
-  """A IamProjectsServiceAccountsKeysListRequest object.
+  r"""A IamProjectsServiceAccountsKeysListRequest object.
 
   Enums:
     KeyTypesValueValuesEnum: Filters the types of keys the user wants to
@@ -387,7 +387,7 @@ class IamProjectsServiceAccountsKeysListRequest(_messages.Message):
   """
 
   class KeyTypesValueValuesEnum(_messages.Enum):
-    """Filters the types of keys the user wants to include in the list
+    r"""Filters the types of keys the user wants to include in the list
     response. Duplicate key types are not allowed. If no key type is provided,
     all keys are returned.
 
@@ -405,7 +405,7 @@ class IamProjectsServiceAccountsKeysListRequest(_messages.Message):
 
 
 class IamProjectsServiceAccountsListRequest(_messages.Message):
-  """A IamProjectsServiceAccountsListRequest object.
+  r"""A IamProjectsServiceAccountsListRequest object.
 
   Fields:
     name: Required. The resource name of the project associated with the
@@ -427,7 +427,7 @@ class IamProjectsServiceAccountsListRequest(_messages.Message):
 
 
 class IamProjectsServiceAccountsSetIamPolicyRequest(_messages.Message):
-  """A IamProjectsServiceAccountsSetIamPolicyRequest object.
+  r"""A IamProjectsServiceAccountsSetIamPolicyRequest object.
 
   Fields:
     resource: REQUIRED: The resource for which the policy is being specified.
@@ -444,7 +444,7 @@ class IamProjectsServiceAccountsSetIamPolicyRequest(_messages.Message):
 
 
 class IamProjectsServiceAccountsSignBlobRequest(_messages.Message):
-  """A IamProjectsServiceAccountsSignBlobRequest object.
+  r"""A IamProjectsServiceAccountsSignBlobRequest object.
 
   Fields:
     name: The resource name of the service account in the following format:
@@ -461,7 +461,7 @@ class IamProjectsServiceAccountsSignBlobRequest(_messages.Message):
 
 
 class IamProjectsServiceAccountsSignJwtRequest(_messages.Message):
-  """A IamProjectsServiceAccountsSignJwtRequest object.
+  r"""A IamProjectsServiceAccountsSignJwtRequest object.
 
   Fields:
     name: The resource name of the service account in the following format:
@@ -478,7 +478,7 @@ class IamProjectsServiceAccountsSignJwtRequest(_messages.Message):
 
 
 class IamProjectsServiceAccountsTestIamPermissionsRequest(_messages.Message):
-  """A IamProjectsServiceAccountsTestIamPermissionsRequest object.
+  r"""A IamProjectsServiceAccountsTestIamPermissionsRequest object.
 
   Fields:
     resource: REQUIRED: The resource for which the policy detail is being
@@ -495,7 +495,7 @@ class IamProjectsServiceAccountsTestIamPermissionsRequest(_messages.Message):
 
 
 class ListServiceAccountKeysResponse(_messages.Message):
-  """The service account keys list response.
+  r"""The service account keys list response.
 
   Fields:
     keys: The public keys for the service account.
@@ -505,7 +505,7 @@ class ListServiceAccountKeysResponse(_messages.Message):
 
 
 class ListServiceAccountsResponse(_messages.Message):
-  """The service account list response.
+  r"""The service account list response.
 
   Fields:
     accounts: The list of matching service accounts.
@@ -518,7 +518,7 @@ class ListServiceAccountsResponse(_messages.Message):
 
 
 class LogConfig(_messages.Message):
-  """Specifies what kind of log the caller must write Increment a streamz
+  r"""Specifies what kind of log the caller must write Increment a streamz
   counter with the specified metric and field names.  Metric names should
   start with a '/', generally be lowercase-only, and end in "_count". Field
   names should not contain an initial slash. The actual exported metric names
@@ -545,7 +545,7 @@ class LogConfig(_messages.Message):
 
 
 class Policy(_messages.Message):
-  """Defines an Identity and Access Management (IAM) policy. It is used to
+  r"""Defines an Identity and Access Management (IAM) policy. It is used to
   specify access control policies for Cloud Platform resources.   A `Policy`
   consists of a list of `bindings`. A `Binding` binds a list of `members` to a
   `role`, where the members can be user accounts, Google groups, Google
@@ -596,7 +596,7 @@ class Policy(_messages.Message):
 
 
 class PolicyDetail(_messages.Message):
-  """A policy and its full resource path.
+  r"""A policy and its full resource path.
 
   Fields:
     fullResourcePath: The full resource path of the policy e.g.,
@@ -610,7 +610,7 @@ class PolicyDetail(_messages.Message):
 
 
 class QueryGrantableRolesRequest(_messages.Message):
-  """The grantable role query request.
+  r"""The grantable role query request.
 
   Fields:
     fullResourceName: Required. The full resource name to query from the list
@@ -623,7 +623,7 @@ class QueryGrantableRolesRequest(_messages.Message):
 
 
 class QueryGrantableRolesResponse(_messages.Message):
-  """The grantable role query response.
+  r"""The grantable role query response.
 
   Fields:
     roles: The list of matching roles.
@@ -633,7 +633,7 @@ class QueryGrantableRolesResponse(_messages.Message):
 
 
 class Role(_messages.Message):
-  """A role in the Identity and Access Management API.
+  r"""A role in the Identity and Access Management API.
 
   Fields:
     apiTokens: A string attribute.
@@ -651,7 +651,7 @@ class Role(_messages.Message):
 
 
 class Rule(_messages.Message):
-  """A rule to be applied in a Policy.
+  r"""A rule to be applied in a Policy.
 
   Enums:
     ActionValueValuesEnum: Required
@@ -675,7 +675,7 @@ class Rule(_messages.Message):
   """
 
   class ActionValueValuesEnum(_messages.Enum):
-    """Required
+    r"""Required
 
     Values:
       NO_ACTION: Default no action.
@@ -704,8 +704,8 @@ class Rule(_messages.Message):
 
 
 class ServiceAccount(_messages.Message):
-  """A service account in the Identity and Access Management API.  To create a
-  service account, specify the `project_id` and the `account_id` for the
+  r"""A service account in the Identity and Access Management API.  To create
+  a service account, specify the `project_id` and the `account_id` for the
   account.  The `account_id` is unique within the project, and is used to
   generate the service account email address and a stable `unique_id`.  All
   other methods can identify the service account using the format
@@ -745,8 +745,8 @@ class ServiceAccount(_messages.Message):
 
 
 class ServiceAccountKey(_messages.Message):
-  """Represents a service account key.  A service account has two sets of key-
-  pairs: user-managed, and system-managed.  User-managed key-pairs can be
+  r"""Represents a service account key.  A service account has two sets of
+  key-pairs: user-managed, and system-managed.  User-managed key-pairs can be
   created and deleted by users.  Users are responsible for rotating these keys
   periodically to ensure security of their service accounts.  Users retain the
   private key of these key-pairs, and Google retains ONLY the public key.
@@ -778,7 +778,7 @@ class ServiceAccountKey(_messages.Message):
   """
 
   class PrivateKeyTypeValueValuesEnum(_messages.Enum):
-    """The output format for the private key. Only provided in
+    r"""The output format for the private key. Only provided in
     `CreateServiceAccountKey` responses, not in `GetServiceAccountKey` or
     `ListServiceAccountKey` responses.  Google never exposes system-managed
     private keys, and never retains user-managed private keys.
@@ -804,7 +804,7 @@ class ServiceAccountKey(_messages.Message):
 
 
 class SetIamPolicyRequest(_messages.Message):
-  """Request message for `SetIamPolicy` method.
+  r"""Request message for `SetIamPolicy` method.
 
   Fields:
     policy: REQUIRED: The complete policy to be applied to the `resource`. The
@@ -817,7 +817,7 @@ class SetIamPolicyRequest(_messages.Message):
 
 
 class SignBlobRequest(_messages.Message):
-  """The service account sign blob request.
+  r"""The service account sign blob request.
 
   Fields:
     bytesToSign: The bytes to sign.
@@ -827,7 +827,7 @@ class SignBlobRequest(_messages.Message):
 
 
 class SignBlobResponse(_messages.Message):
-  """The service account sign blob response.
+  r"""The service account sign blob response.
 
   Fields:
     keyId: The id of the key used to sign the blob.
@@ -839,7 +839,7 @@ class SignBlobResponse(_messages.Message):
 
 
 class SignJwtRequest(_messages.Message):
-  """The service account sign JWT request.
+  r"""The service account sign JWT request.
 
   Fields:
     payload: The JWT payload to sign, a JSON JWT Claim set.
@@ -849,7 +849,7 @@ class SignJwtRequest(_messages.Message):
 
 
 class SignJwtResponse(_messages.Message):
-  """The service account sign JWT response.
+  r"""The service account sign JWT response.
 
   Fields:
     keyId: The id of the key used to sign the JWT.
@@ -861,7 +861,7 @@ class SignJwtResponse(_messages.Message):
 
 
 class StandardQueryParameters(_messages.Message):
-  """Query parameters accepted by all methods.
+  r"""Query parameters accepted by all methods.
 
   Enums:
     FXgafvValueValuesEnum: V1 error format.
@@ -890,7 +890,7 @@ class StandardQueryParameters(_messages.Message):
   """
 
   class AltValueValuesEnum(_messages.Enum):
-    """Data format for response.
+    r"""Data format for response.
 
     Values:
       json: Responses with Content-Type of application/json
@@ -902,7 +902,7 @@ class StandardQueryParameters(_messages.Message):
     proto = 2
 
   class FXgafvValueValuesEnum(_messages.Enum):
-    """V1 error format.
+    r"""V1 error format.
 
     Values:
       _1: v1 error format
@@ -928,7 +928,7 @@ class StandardQueryParameters(_messages.Message):
 
 
 class TestIamPermissionsRequest(_messages.Message):
-  """Request message for `TestIamPermissions` method.
+  r"""Request message for `TestIamPermissions` method.
 
   Fields:
     permissions: The set of permissions to check for the `resource`.
@@ -940,7 +940,7 @@ class TestIamPermissionsRequest(_messages.Message):
 
 
 class TestIamPermissionsResponse(_messages.Message):
-  """Response message for `TestIamPermissions` method.
+  r"""Response message for `TestIamPermissions` method.
 
   Fields:
     permissions: A subset of `TestPermissionsRequest.permissions` that the

--- a/samples/servicemanagement_sample/servicemanagement_v1/servicemanagement_v1_client.py
+++ b/samples/servicemanagement_sample/servicemanagement_v1/servicemanagement_v1_client.py
@@ -54,7 +54,7 @@ class ServicemanagementV1(base_api.BaseApiClient):
           }
 
     def Get(self, request, global_params=None):
-      """Gets the latest state of a long-running operation.  Clients can use this.
+      r"""Gets the latest state of a long-running operation.  Clients can use this.
 method to poll the operation result at intervals as recommended by the API
 service.
 
@@ -92,7 +92,7 @@ service.
           }
 
     def Query(self, request, global_params=None):
-      """Method to query the accessibility of a service and any associated.
+      r"""Method to query the accessibility of a service and any associated.
 visibility labels for a specified user.
 
 Members of the producer project may call this method and specify any user.
@@ -135,7 +135,7 @@ the service.
           }
 
     def Create(self, request, global_params=None):
-      """Creates a new service config (version) for a managed service. This method.
+      r"""Creates a new service config (version) for a managed service. This method.
 only stores the service config, but does not apply the service config to
 any backend services.
 
@@ -163,7 +163,7 @@ any backend services.
     )
 
     def Get(self, request, global_params=None):
-      """Gets a service config (version) for a managed service. If `config_id` is.
+      r"""Gets a service config (version) for a managed service. If `config_id` is.
 not specified, the latest service config will be returned.
 
       Args:
@@ -190,7 +190,7 @@ not specified, the latest service config will be returned.
     )
 
     def List(self, request, global_params=None):
-      """Lists the history of the service config for a managed service,.
+      r"""Lists the history of the service config for a managed service,.
 from the newest to the oldest.
 
       Args:
@@ -217,7 +217,7 @@ from the newest to the oldest.
     )
 
     def Submit(self, request, global_params=None):
-      """Creates a new service config (version) for a managed service based on.
+      r"""Creates a new service config (version) for a managed service based on.
 user-supplied configuration sources files (for example: OpenAPI
 Specification). This method stores the source configurations as well as the
 generated service config. It does NOT apply the service config to any
@@ -259,7 +259,7 @@ Operation<response: SubmitConfigSourceResponse>
           }
 
     def Get(self, request, global_params=None):
-      """Retrieves the settings that control the specified customer's usage of the.
+      r"""Retrieves the settings that control the specified customer's usage of the.
 service.
 
       Args:
@@ -286,7 +286,7 @@ service.
     )
 
     def Patch(self, request, global_params=None):
-      """Updates specified subset of the settings that control the specified.
+      r"""Updates specified subset of the settings that control the specified.
 customer's usage of the service.  Attempts to update a field not
 controlled by the caller will result in an access denied error.
 
@@ -326,7 +326,7 @@ Operation<response: CustomerSettings>
           }
 
     def Get(self, request, global_params=None):
-      """Retrieves the settings that control the specified consumer project's usage.
+      r"""Retrieves the settings that control the specified consumer project's usage.
 of the service.
 
       Args:
@@ -353,7 +353,7 @@ of the service.
     )
 
     def Patch(self, request, global_params=None):
-      """Updates specified subset of the settings that control the specified.
+      r"""Updates specified subset of the settings that control the specified.
 consumer project's usage of the service.  Attempts to update a field not
 controlled by the caller will result in an access denied error.
 
@@ -383,7 +383,7 @@ Operation<response: ProjectSettings>
     )
 
     def Update(self, request, global_params=None):
-      """NOTE: Currently unsupported.  Use PatchProjectSettings instead.
+      r"""NOTE: Currently unsupported.  Use PatchProjectSettings instead.
 
 Updates the settings that control the specified consumer project's usage
 of the service.  Attempts to update a field not controlled by the caller
@@ -425,7 +425,7 @@ Operation<response: ProjectSettings>
           }
 
     def ConvertConfig(self, request, global_params=None):
-      """DEPRECATED. `SubmitConfigSource` with `validate_only=true` will provide.
+      r"""DEPRECATED. `SubmitConfigSource` with `validate_only=true` will provide.
 config conversion moving forward.
 
 Converts an API specification (e.g. Swagger spec) to an
@@ -455,7 +455,7 @@ equivalent `google.api.Service`.
     )
 
     def Create(self, request, global_params=None):
-      """Creates a new managed service.
+      r"""Creates a new managed service.
 
 Operation<response: ManagedService>
 
@@ -483,7 +483,7 @@ Operation<response: ManagedService>
     )
 
     def Delete(self, request, global_params=None):
-      """Deletes a managed service.
+      r"""Deletes a managed service.
 
 Operation<response: google.protobuf.Empty>
 
@@ -511,7 +511,7 @@ Operation<response: google.protobuf.Empty>
     )
 
     def Disable(self, request, global_params=None):
-      """Disable a managed service for a project.
+      r"""Disable a managed service for a project.
 Google Service Management will only disable the managed service even if
 there are other services depend on the managed service.
 
@@ -541,7 +541,7 @@ Operation<response: DisableServiceResponse>
     )
 
     def Enable(self, request, global_params=None):
-      """Enable a managed service for a project with default setting.
+      r"""Enable a managed service for a project with default setting.
 If the managed service has dependencies, they will be enabled as well.
 
 Operation<response: EnableServiceResponse>
@@ -570,7 +570,7 @@ Operation<response: EnableServiceResponse>
     )
 
     def Get(self, request, global_params=None):
-      """Gets a managed service. If the `consumer_project_id` is specified,.
+      r"""Gets a managed service. If the `consumer_project_id` is specified,.
 the project's settings for the specified service are also returned.
 
       Args:
@@ -597,7 +597,7 @@ the project's settings for the specified service are also returned.
     )
 
     def GetAccessPolicy(self, request, global_params=None):
-      """Producer method to retrieve current policy.
+      r"""Producer method to retrieve current policy.
 
       Args:
         request: (ServicemanagementServicesGetAccessPolicyRequest) input message
@@ -623,7 +623,7 @@ the project's settings for the specified service are also returned.
     )
 
     def GetConfig(self, request, global_params=None):
-      """Gets a service config (version) for a managed service. If `config_id` is.
+      r"""Gets a service config (version) for a managed service. If `config_id` is.
 not specified, the latest service config will be returned.
 
       Args:
@@ -650,7 +650,7 @@ not specified, the latest service config will be returned.
     )
 
     def List(self, request, global_params=None):
-      """Lists all managed services. If the `consumer_project_id` is specified,.
+      r"""Lists all managed services. If the `consumer_project_id` is specified,.
 the project's settings for the specified service are also returned.
 
       Args:
@@ -677,7 +677,7 @@ the project's settings for the specified service are also returned.
     )
 
     def Patch(self, request, global_params=None):
-      """Updates the specified subset of the configuration. If the specified service.
+      r"""Updates the specified subset of the configuration. If the specified service.
 does not exists the patch operation fails.
 
 Operation<response: ManagedService>
@@ -706,7 +706,7 @@ Operation<response: ManagedService>
     )
 
     def PatchConfig(self, request, global_params=None):
-      """Updates the specified subset of the service resource. Equivalent to.
+      r"""Updates the specified subset of the service resource. Equivalent to.
 calling `PatchService` with only the `service_config` field updated.
 
 Operation<response: google.api.Service>
@@ -735,7 +735,7 @@ Operation<response: google.api.Service>
     )
 
     def Update(self, request, global_params=None):
-      """Updates the configuration of a service.  If the specified service does not.
+      r"""Updates the configuration of a service.  If the specified service does not.
 already exist, then it is created.
 
 Operation<response: ManagedService>
@@ -764,7 +764,7 @@ Operation<response: ManagedService>
     )
 
     def UpdateAccessPolicy(self, request, global_params=None):
-      """Producer method to update the current policy.  This method will return an.
+      r"""Producer method to update the current policy.  This method will return an.
 error if the policy is too large (more than 50 entries across all lists).
 
       Args:
@@ -791,7 +791,7 @@ error if the policy is too large (more than 50 entries across all lists).
     )
 
     def UpdateConfig(self, request, global_params=None):
-      """Updates the specified subset of the service resource. Equivalent to.
+      r"""Updates the specified subset of the service resource. Equivalent to.
 calling `UpdateService` with only the `service_config` field updated.
 
 Operation<response: google.api.Service>
@@ -830,7 +830,7 @@ Operation<response: google.api.Service>
           }
 
     def ConvertConfig(self, request, global_params=None):
-      """DEPRECATED. `SubmitConfigSource` with `validate_only=true` will provide.
+      r"""DEPRECATED. `SubmitConfigSource` with `validate_only=true` will provide.
 config conversion moving forward.
 
 Converts an API specification (e.g. Swagger spec) to an

--- a/samples/servicemanagement_sample/servicemanagement_v1/servicemanagement_v1_messages.py
+++ b/samples/servicemanagement_sample/servicemanagement_v1/servicemanagement_v1_messages.py
@@ -13,7 +13,7 @@ package = 'servicemanagement'
 
 
 class Api(_messages.Message):
-  """Api is a light-weight descriptor for a protocol buffer service.
+  r"""Api is a light-weight descriptor for a protocol buffer service.
 
   Enums:
     SyntaxValueValuesEnum: The source syntax of the service.
@@ -45,7 +45,7 @@ class Api(_messages.Message):
   """
 
   class SyntaxValueValuesEnum(_messages.Enum):
-    """The source syntax of the service.
+    r"""The source syntax of the service.
 
     Values:
       SYNTAX_PROTO2: Syntax `proto2`.
@@ -64,7 +64,7 @@ class Api(_messages.Message):
 
 
 class AreaUnderCurveParams(_messages.Message):
-  """AreaUnderCurveParams groups the metrics relevant to generating duration
+  r"""AreaUnderCurveParams groups the metrics relevant to generating duration
   based metric from base (snapshot) metric and delta (change) metric.  The
   generated metric has two dimensions:    resource usage metric and the
   duration the metric applies.  Essentially the generated metric is the Area
@@ -90,9 +90,9 @@ class AreaUnderCurveParams(_messages.Message):
 
 
 class AuthProvider(_messages.Message):
-  """Configuration for an anthentication provider, including support for [JSON
-  Web Token (JWT)](https://tools.ietf.org/html/draft-ietf-oauth-json-web-
-  token-32).
+  r"""Configuration for an anthentication provider, including support for
+  [JSON Web Token (JWT)](https://tools.ietf.org/html/draft-ietf-oauth-json-
+  web-token-32).
 
   Fields:
     id: The unique identifier of the auth provider. It will be referred to by
@@ -117,8 +117,8 @@ class AuthProvider(_messages.Message):
 
 
 class AuthRequirement(_messages.Message):
-  """User-defined authentication requirements, including support for [JSON Web
-  Token (JWT)](https://tools.ietf.org/html/draft-ietf-oauth-json-web-
+  r"""User-defined authentication requirements, including support for [JSON
+  Web Token (JWT)](https://tools.ietf.org/html/draft-ietf-oauth-json-web-
   token-32).
 
   Fields:
@@ -141,7 +141,7 @@ class AuthRequirement(_messages.Message):
 
 
 class Authentication(_messages.Message):
-  """`Authentication` defines the authentication configuration for an API.
+  r"""`Authentication` defines the authentication configuration for an API.
   Example for an API targeted for external use:      name:
   calendar.googleapis.com     authentication:       rules:       - selector:
   "*"         oauth:           canonical_scopes:
@@ -160,7 +160,7 @@ class Authentication(_messages.Message):
 
 
 class AuthenticationRule(_messages.Message):
-  """Authentication rules for the service.  By default, if a method has any
+  r"""Authentication rules for the service.  By default, if a method has any
   authentication requirements, every request must include a valid credential
   matching one of the requirements. It's an error to include more than one
   kind of credential in a single request.  If a method doesn't have any auth
@@ -183,7 +183,7 @@ class AuthenticationRule(_messages.Message):
 
 
 class Backend(_messages.Message):
-  """`Backend` defines the backend configuration for a service.
+  r"""`Backend` defines the backend configuration for a service.
 
   Fields:
     rules: A list of backend rules providing configuration for individual API
@@ -194,7 +194,7 @@ class Backend(_messages.Message):
 
 
 class BackendRule(_messages.Message):
-  """A backend rule provides configuration for an individual API element.
+  r"""A backend rule provides configuration for an individual API element.
 
   Fields:
     address: The address of the API backend.
@@ -210,7 +210,7 @@ class BackendRule(_messages.Message):
 
 
 class Billing(_messages.Message):
-  """Billing related configuration of the service.  The following example
+  r"""Billing related configuration of the service.  The following example
   shows how to configure metrics for billing:      metrics:     - name:
   library.googleapis.com/read_calls       metric_kind: DELTA       value_type:
   INT64     - name: library.googleapis.com/write_calls       metric_kind:
@@ -245,7 +245,7 @@ class Billing(_messages.Message):
 
 
 class BillingStatusRule(_messages.Message):
-  """Defines the billing status requirements for operations.  When used with
+  r"""Defines the billing status requirements for operations.  When used with
   [Service Control API](https://cloud.google.com/service-control/), the
   following statuses are supported:  - **current**: the associated billing
   account is up to date and capable of                paying for resource
@@ -268,7 +268,7 @@ class BillingStatusRule(_messages.Message):
 
 
 class CompositeOperationMetadata(_messages.Message):
-  """Metadata for composite operations.
+  r"""Metadata for composite operations.
 
   Messages:
     OriginalRequestValue: Original request that triggered this operation.
@@ -297,7 +297,7 @@ class CompositeOperationMetadata(_messages.Message):
 
   @encoding.MapUnrecognizedFields('additionalProperties')
   class OriginalRequestValue(_messages.Message):
-    """Original request that triggered this operation.
+    r"""Original request that triggered this operation.
 
     Messages:
       AdditionalProperty: An additional property for a OriginalRequestValue
@@ -309,7 +309,7 @@ class CompositeOperationMetadata(_messages.Message):
     """
 
     class AdditionalProperty(_messages.Message):
-      """An additional property for a OriginalRequestValue object.
+      r"""An additional property for a OriginalRequestValue object.
 
       Fields:
         key: Name of the additional property.
@@ -323,7 +323,7 @@ class CompositeOperationMetadata(_messages.Message):
 
   @encoding.MapUnrecognizedFields('additionalProperties')
   class ResponseFieldMasksValue(_messages.Message):
-    """Defines which part of the response a child operation will contribute.
+    r"""Defines which part of the response a child operation will contribute.
     Each key of the map is the name of a child operation. Each value is a
     field mask that identifies what that child operation contributes to the
     response, for example, "quota_settings", "visiblity_settings", etc.
@@ -338,7 +338,7 @@ class CompositeOperationMetadata(_messages.Message):
     """
 
     class AdditionalProperty(_messages.Message):
-      """An additional property for a ResponseFieldMasksValue object.
+      r"""An additional property for a ResponseFieldMasksValue object.
 
       Fields:
         key: Name of the additional property.
@@ -357,7 +357,7 @@ class CompositeOperationMetadata(_messages.Message):
 
 
 class ConfigFile(_messages.Message):
-  """Generic specification of a source configuration file
+  r"""Generic specification of a source configuration file
 
   Enums:
     FileTypeValueValuesEnum: The kind of configuration file represented. This
@@ -375,7 +375,7 @@ class ConfigFile(_messages.Message):
   """
 
   class FileTypeValueValuesEnum(_messages.Enum):
-    """The kind of configuration file represented. This is used to determine
+    r"""The kind of configuration file represented. This is used to determine
     the method for generating `google.api.Service` using this file.
 
     Values:
@@ -402,14 +402,14 @@ class ConfigFile(_messages.Message):
 
 
 class ConfigOptions(_messages.Message):
-  """A set of options to cover use of source config within `ServiceManager`
+  r"""A set of options to cover use of source config within `ServiceManager`
   and related tools.
   """
 
 
 
 class ConfigSource(_messages.Message):
-  """Represents a user-specified configuration for a service (as opposed to
+  r"""Represents a user-specified configuration for a service (as opposed to
   the the generated service config form provided by `google.api.Service`).
   This is meant to encode service config as manipulated directly by customers,
   rather than the config form resulting from toolchain generation and
@@ -435,8 +435,8 @@ class ConfigSource(_messages.Message):
 
 
 class Context(_messages.Message):
-  """`Context` defines which contexts an API requests.  Example:      context:
-  rules:       - selector: "*"         requested:         -
+  r"""`Context` defines which contexts an API requests.  Example:
+  context:       rules:       - selector: "*"         requested:         -
   google.rpc.context.ProjectContext         - google.rpc.context.OriginContext
   The above specifies that all methods in the API request
   `google.rpc.context.ProjectContext` and `google.rpc.context.OriginContext`.
@@ -450,7 +450,7 @@ class Context(_messages.Message):
 
 
 class ContextRule(_messages.Message):
-  """A context rule provides information about the context for an individual
+  r"""A context rule provides information about the context for an individual
   API element.
 
   Fields:
@@ -466,7 +466,7 @@ class ContextRule(_messages.Message):
 
 
 class Control(_messages.Message):
-  """Selects and configures the service controller used by the service.  The
+  r"""Selects and configures the service controller used by the service.  The
   service controller handles features like abuse, quota, billing, logging,
   monitoring, etc.
 
@@ -479,7 +479,7 @@ class Control(_messages.Message):
 
 
 class ConvertConfigRequest(_messages.Message):
-  """Request message for `ConvertConfig` method.
+  r"""Request message for `ConvertConfig` method.
 
   Messages:
     ConfigSpecValue: Input configuration For this version of API, the
@@ -497,7 +497,7 @@ class ConvertConfigRequest(_messages.Message):
 
   @encoding.MapUnrecognizedFields('additionalProperties')
   class ConfigSpecValue(_messages.Message):
-    """Input configuration For this version of API, the supported type is
+    r"""Input configuration For this version of API, the supported type is
     OpenApiSpec
 
     Messages:
@@ -509,7 +509,7 @@ class ConvertConfigRequest(_messages.Message):
     """
 
     class AdditionalProperty(_messages.Message):
-      """An additional property for a ConfigSpecValue object.
+      r"""An additional property for a ConfigSpecValue object.
 
       Fields:
         key: Name of the additional property.
@@ -528,7 +528,7 @@ class ConvertConfigRequest(_messages.Message):
 
 
 class ConvertConfigResponse(_messages.Message):
-  """Response message for `ConvertConfig` method.
+  r"""Response message for `ConvertConfig` method.
 
   Fields:
     diagnostics: Any errors or warnings that occured during config conversion.
@@ -541,7 +541,7 @@ class ConvertConfigResponse(_messages.Message):
 
 
 class CustomError(_messages.Message):
-  """Customize service error responses.  For example, list any service
+  r"""Customize service error responses.  For example, list any service
   specific protobuf types that can appear in error detail lists of error
   responses.  Example:      custom_error:       types:       -
   google.foo.v1.CustomError       - google.foo.v1.AnotherError
@@ -558,7 +558,7 @@ class CustomError(_messages.Message):
 
 
 class CustomErrorRule(_messages.Message):
-  """A custom error rule.
+  r"""A custom error rule.
 
   Fields:
     isErrorType: Mark this message as possible payload in error response.
@@ -573,7 +573,7 @@ class CustomErrorRule(_messages.Message):
 
 
 class CustomHttpPattern(_messages.Message):
-  """A custom pattern is used for defining custom HTTP verb.
+  r"""A custom pattern is used for defining custom HTTP verb.
 
   Fields:
     kind: The name of this custom HTTP verb.
@@ -585,7 +585,7 @@ class CustomHttpPattern(_messages.Message):
 
 
 class CustomerSettings(_messages.Message):
-  """Settings that control how a customer (identified by a billing account)
+  r"""Settings that control how a customer (identified by a billing account)
   uses a service
 
   Fields:
@@ -606,7 +606,7 @@ class CustomerSettings(_messages.Message):
 
 
 class Diagnostic(_messages.Message):
-  """A collection that represents a diagnostic message (error or warning)
+  r"""A collection that represents a diagnostic message (error or warning)
 
   Enums:
     KindValueValuesEnum: The kind of diagnostic information provided.
@@ -618,7 +618,7 @@ class Diagnostic(_messages.Message):
   """
 
   class KindValueValuesEnum(_messages.Enum):
-    """The kind of diagnostic information provided.
+    r"""The kind of diagnostic information provided.
 
     Values:
       WARNING: Warnings and errors
@@ -633,7 +633,7 @@ class Diagnostic(_messages.Message):
 
 
 class DisableServiceRequest(_messages.Message):
-  """Request message for DisableService method.
+  r"""Request message for DisableService method.
 
   Fields:
     consumerId: The identity of consumer resource which service disablement
@@ -647,7 +647,7 @@ class DisableServiceRequest(_messages.Message):
 
 
 class Documentation(_messages.Message):
-  """`Documentation` provides the information for describing a service.
+  r"""`Documentation` provides the information for describing a service.
   Example: <pre><code>documentation:   summary: >     The Google Calendar API
   gives access     to most calendar features.   pages:   - name: Overview
   content: &#40;== include google/foo/overview.md ==&#41;   - name: Tutorial
@@ -705,7 +705,7 @@ class Documentation(_messages.Message):
 
 
 class DocumentationRule(_messages.Message):
-  """A documentation rule provides information about individual API elements.
+  r"""A documentation rule provides information about individual API elements.
 
   Fields:
     deprecationDescription: Deprecation description of the selected
@@ -725,7 +725,7 @@ class DocumentationRule(_messages.Message):
 
 
 class EffectiveQuotaGroup(_messages.Message):
-  """An effective quota group contains both the metadata for a quota group as
+  r"""An effective quota group contains both the metadata for a quota group as
   derived from the service config, and the effective limits in that group as
   calculated from producer and consumer overrides together with service
   defaults.
@@ -742,7 +742,7 @@ class EffectiveQuotaGroup(_messages.Message):
   """
 
   class BillingInteractionValueValuesEnum(_messages.Enum):
-    """BillingInteractionValueValuesEnum enum type.
+    r"""BillingInteractionValueValuesEnum enum type.
 
     Values:
       BILLING_INTERACTION_UNSPECIFIED: The interaction between this quota
@@ -765,7 +765,7 @@ class EffectiveQuotaGroup(_messages.Message):
 
 
 class EffectiveQuotaLimit(_messages.Message):
-  """An effective quota limit contains the metadata for a quota limit as
+  r"""An effective quota limit contains the metadata for a quota limit as
   derived from the service config, together with fields that describe the
   effective limit value and what overrides can be applied to it.
 
@@ -787,7 +787,7 @@ class EffectiveQuotaLimit(_messages.Message):
 
 
 class EnableServiceRequest(_messages.Message):
-  """Request message for EnableService method.
+  r"""Request message for EnableService method.
 
   Fields:
     consumerId: The identity of consumer resource which service enablement
@@ -801,7 +801,7 @@ class EnableServiceRequest(_messages.Message):
 
 
 class Enum(_messages.Message):
-  """Enum type definition.
+  r"""Enum type definition.
 
   Enums:
     SyntaxValueValuesEnum: The source syntax.
@@ -815,7 +815,7 @@ class Enum(_messages.Message):
   """
 
   class SyntaxValueValuesEnum(_messages.Enum):
-    """The source syntax.
+    r"""The source syntax.
 
     Values:
       SYNTAX_PROTO2: Syntax `proto2`.
@@ -832,7 +832,7 @@ class Enum(_messages.Message):
 
 
 class EnumValue(_messages.Message):
-  """Enum value definition.
+  r"""Enum value definition.
 
   Fields:
     name: Enum value name.
@@ -846,7 +846,7 @@ class EnumValue(_messages.Message):
 
 
 class Field(_messages.Message):
-  """A single field of a message type.
+  r"""A single field of a message type.
 
   Enums:
     CardinalityValueValuesEnum: The field cardinality.
@@ -871,7 +871,7 @@ class Field(_messages.Message):
   """
 
   class CardinalityValueValuesEnum(_messages.Enum):
-    """The field cardinality.
+    r"""The field cardinality.
 
     Values:
       CARDINALITY_UNKNOWN: For fields with unknown cardinality.
@@ -885,7 +885,7 @@ class Field(_messages.Message):
     CARDINALITY_REPEATED = 3
 
   class KindValueValuesEnum(_messages.Enum):
-    """The field type.
+    r"""The field type.
 
     Values:
       TYPE_UNKNOWN: Field type unknown.
@@ -941,7 +941,7 @@ class Field(_messages.Message):
 
 
 class File(_messages.Message):
-  """A single swagger specification file.
+  r"""A single swagger specification file.
 
   Fields:
     contents: The contents of the swagger spec file.
@@ -953,7 +953,7 @@ class File(_messages.Message):
 
 
 class Http(_messages.Message):
-  """Defines the HTTP configuration for a service. It contains a list of
+  r"""Defines the HTTP configuration for a service. It contains a list of
   HttpRule, each specifying the mapping of an RPC method to one or more HTTP
   REST API methods.
 
@@ -965,7 +965,7 @@ class Http(_messages.Message):
 
 
 class HttpRule(_messages.Message):
-  """`HttpRule` defines the mapping of an RPC method to one or more HTTP REST
+  r"""`HttpRule` defines the mapping of an RPC method to one or more HTTP REST
   APIs.  The mapping determines what portions of the request message are
   populated from the path, query parameters, or body of the HTTP request.  The
   mapping is typically specified as an `google.api.http` annotation, see
@@ -1094,7 +1094,7 @@ class HttpRule(_messages.Message):
 
 
 class LabelDescriptor(_messages.Message):
-  """A description of a label.
+  r"""A description of a label.
 
   Enums:
     ValueTypeValueValuesEnum: The type of data that can be assigned to the
@@ -1107,7 +1107,7 @@ class LabelDescriptor(_messages.Message):
   """
 
   class ValueTypeValueValuesEnum(_messages.Enum):
-    """The type of data that can be assigned to the label.
+    r"""The type of data that can be assigned to the label.
 
     Values:
       STRING: A variable-length string. This is the default.
@@ -1124,7 +1124,7 @@ class LabelDescriptor(_messages.Message):
 
 
 class ListServiceConfigsResponse(_messages.Message):
-  """Response message for ListServiceConfigs method.
+  r"""Response message for ListServiceConfigs method.
 
   Fields:
     nextPageToken: The token of the next page of results.
@@ -1136,7 +1136,7 @@ class ListServiceConfigsResponse(_messages.Message):
 
 
 class ListServicesResponse(_messages.Message):
-  """Response message for `ListServices` method.
+  r"""Response message for `ListServices` method.
 
   Fields:
     nextPageToken: Token that can be passed to `ListServices` to resume a
@@ -1149,7 +1149,7 @@ class ListServicesResponse(_messages.Message):
 
 
 class LogDescriptor(_messages.Message):
-  """A description of a log type. Example in YAML format:      - name:
+  r"""A description of a log type. Example in YAML format:      - name:
   library.googleapis.com/activity_history       description: The history of
   borrowing and returning library items.       display_name: Activity
   labels:       - key: /customer_id         description: Identifier of a
@@ -1176,8 +1176,8 @@ class LogDescriptor(_messages.Message):
 
 
 class Logging(_messages.Message):
-  """Logging configuration of the service.  The following example shows how to
-  configure logs to be sent to the producer and consumer projects. In the
+  r"""Logging configuration of the service.  The following example shows how
+  to configure logs to be sent to the producer and consumer projects. In the
   example, the `library.googleapis.com/activity_history` log is sent to both
   the producer and consumer projects, whereas the
   `library.googleapis.com/purchase_history` log is only sent to the producer
@@ -1210,7 +1210,7 @@ class Logging(_messages.Message):
 
 
 class LoggingDestination(_messages.Message):
-  """Configuration of a specific logging destination (the producer project or
+  r"""Configuration of a specific logging destination (the producer project or
   the consumer project).
 
   Fields:
@@ -1225,7 +1225,7 @@ class LoggingDestination(_messages.Message):
 
 
 class ManagedService(_messages.Message):
-  """The full representation of an API Service that is managed by the
+  r"""The full representation of an API Service that is managed by the
   `ServiceManager` API.  Includes both the service configuration, as well as
   other control plane deployment related information.
 
@@ -1260,7 +1260,7 @@ class ManagedService(_messages.Message):
 
 
 class MediaDownload(_messages.Message):
-  """Do not use this. For media support, add instead
+  r"""Do not use this. For media support, add instead
   [][google.bytestream.RestByteStream] as an API to your configuration.
 
   Fields:
@@ -1271,7 +1271,7 @@ class MediaDownload(_messages.Message):
 
 
 class MediaUpload(_messages.Message):
-  """Do not use this. For media support, add instead
+  r"""Do not use this. For media support, add instead
   [][google.bytestream.RestByteStream] as an API to your configuration.
 
   Fields:
@@ -1282,7 +1282,7 @@ class MediaUpload(_messages.Message):
 
 
 class Method(_messages.Message):
-  """Method represents a method of an api.
+  r"""Method represents a method of an api.
 
   Enums:
     SyntaxValueValuesEnum: The source syntax of this method.
@@ -1298,7 +1298,7 @@ class Method(_messages.Message):
   """
 
   class SyntaxValueValuesEnum(_messages.Enum):
-    """The source syntax of this method.
+    r"""The source syntax of this method.
 
     Values:
       SYNTAX_PROTO2: Syntax `proto2`.
@@ -1317,7 +1317,7 @@ class Method(_messages.Message):
 
 
 class MetricDescriptor(_messages.Message):
-  """Defines a metric type and its schema.
+  r"""Defines a metric type and its schema.
 
   Enums:
     MetricKindValueValuesEnum: Whether the metric records instantaneous
@@ -1382,7 +1382,7 @@ class MetricDescriptor(_messages.Message):
   """
 
   class MetricKindValueValuesEnum(_messages.Enum):
-    """Whether the metric records instantaneous values, changes to a value,
+    r"""Whether the metric records instantaneous values, changes to a value,
     etc.
 
     Values:
@@ -1398,7 +1398,7 @@ class MetricDescriptor(_messages.Message):
     CUMULATIVE = 3
 
   class ValueTypeValueValuesEnum(_messages.Enum):
-    """Whether the measurement is an integer, a floating-point number, etc.
+    r"""Whether the measurement is an integer, a floating-point number, etc.
 
     Values:
       VALUE_TYPE_UNSPECIFIED: Do not use this default value.
@@ -1430,7 +1430,7 @@ class MetricDescriptor(_messages.Message):
 
 
 class Mixin(_messages.Message):
-  """Declares an API to be included in this API. The including API must
+  r"""Declares an API to be included in this API. The including API must
   redeclare all the methods from the included API, but documentation and
   options are inherited as follows:  - If after comment and whitespace
   stripping, the documentation   string of the redeclared method is empty, it
@@ -1475,8 +1475,8 @@ class Mixin(_messages.Message):
 
 
 class MonitoredResourceDescriptor(_messages.Message):
-  """An object that describes the schema of a MonitoredResource object using a
-  type name and a set of labels.  For example, the monitored resource
+  r"""An object that describes the schema of a MonitoredResource object using
+  a type name and a set of labels.  For example, the monitored resource
   descriptor for Google Compute Engine VM instances has a type of
   `"gce_instance"` and specifies the use of the labels `"instance_id"` and
   `"zone"` to identify particular VM instances.  Different APIs can support
@@ -1512,7 +1512,7 @@ class MonitoredResourceDescriptor(_messages.Message):
 
 
 class Monitoring(_messages.Message):
-  """Monitoring configuration of the service.  The example below shows how to
+  r"""Monitoring configuration of the service.  The example below shows how to
   configure monitored resources and metrics for monitoring. In the example, a
   monitored resource and two metrics are defined. The
   `library.googleapis.com/book/returned_count` metric is sent to both producer
@@ -1549,7 +1549,7 @@ class Monitoring(_messages.Message):
 
 
 class MonitoringDestination(_messages.Message):
-  """Configuration of a specific monitoring destination (the producer project
+  r"""Configuration of a specific monitoring destination (the producer project
   or the consumer project).
 
   Fields:
@@ -1564,7 +1564,7 @@ class MonitoringDestination(_messages.Message):
 
 
 class OAuthRequirements(_messages.Message):
-  """OAuth scopes are a way to define data and permissions on data. For
+  r"""OAuth scopes are a way to define data and permissions on data. For
   example, there are scopes defined for "Read-only access to Google Calendar"
   and "Access to Cloud Platform". Users can consent to a scope for an
   application, giving it permission to access that data on their behalf.
@@ -1591,7 +1591,7 @@ class OAuthRequirements(_messages.Message):
 
 
 class OpenApiSpec(_messages.Message):
-  """A collection of OpenAPI specification files.
+  r"""A collection of OpenAPI specification files.
 
   Fields:
     openApiFiles: Individual files.
@@ -1601,8 +1601,8 @@ class OpenApiSpec(_messages.Message):
 
 
 class Operation(_messages.Message):
-  """This resource represents a long-running operation that is the result of a
-  network API call.
+  r"""This resource represents a long-running operation that is the result of
+  a network API call.
 
   Messages:
     MetadataValue: Service-specific metadata associated with the operation.
@@ -1642,7 +1642,7 @@ class Operation(_messages.Message):
 
   @encoding.MapUnrecognizedFields('additionalProperties')
   class MetadataValue(_messages.Message):
-    """Service-specific metadata associated with the operation.  It typically
+    r"""Service-specific metadata associated with the operation.  It typically
     contains progress information and common metadata such as create time.
     Some services might not provide such metadata.  Any method that returns a
     long-running operation should document the metadata type, if any.
@@ -1656,7 +1656,7 @@ class Operation(_messages.Message):
     """
 
     class AdditionalProperty(_messages.Message):
-      """An additional property for a MetadataValue object.
+      r"""An additional property for a MetadataValue object.
 
       Fields:
         key: Name of the additional property.
@@ -1670,7 +1670,7 @@ class Operation(_messages.Message):
 
   @encoding.MapUnrecognizedFields('additionalProperties')
   class ResponseValue(_messages.Message):
-    """The normal response of the operation in case of success.  If the
+    r"""The normal response of the operation in case of success.  If the
     original method returns no data on success, such as `Delete`, the response
     is `google.protobuf.Empty`.  If the original method is standard
     `Get`/`Create`/`Update`, the response should be the resource.  For other
@@ -1687,7 +1687,7 @@ class Operation(_messages.Message):
     """
 
     class AdditionalProperty(_messages.Message):
-      """An additional property for a ResponseValue object.
+      r"""An additional property for a ResponseValue object.
 
       Fields:
         key: Name of the additional property.
@@ -1707,7 +1707,7 @@ class Operation(_messages.Message):
 
 
 class OperationMetadata(_messages.Message):
-  """The metadata associated with a long running operation resource.
+  r"""The metadata associated with a long running operation resource.
 
   Fields:
     progressPercentage: Percentage of completion of this operation, ranging
@@ -1726,7 +1726,7 @@ class OperationMetadata(_messages.Message):
 
 
 class Option(_messages.Message):
-  """A protocol buffer option, which can be attached to a message, field,
+  r"""A protocol buffer option, which can be attached to a message, field,
   enumeration, etc.
 
   Messages:
@@ -1739,7 +1739,7 @@ class Option(_messages.Message):
 
   @encoding.MapUnrecognizedFields('additionalProperties')
   class ValueValue(_messages.Message):
-    """The option's value. For example, `"com.google.protobuf"`.
+    r"""The option's value. For example, `"com.google.protobuf"`.
 
     Messages:
       AdditionalProperty: An additional property for a ValueValue object.
@@ -1750,7 +1750,7 @@ class Option(_messages.Message):
     """
 
     class AdditionalProperty(_messages.Message):
-      """An additional property for a ValueValue object.
+      r"""An additional property for a ValueValue object.
 
       Fields:
         key: Name of the additional property.
@@ -1767,8 +1767,8 @@ class Option(_messages.Message):
 
 
 class Page(_messages.Message):
-  """Represents a documentation page. A page can contain subpages to represent
-  nested documentation set structure.
+  r"""Represents a documentation page. A page can contain subpages to
+  represent nested documentation set structure.
 
   Fields:
     content: The Markdown content of the page. You can use <code>&#40;==
@@ -1791,7 +1791,7 @@ class Page(_messages.Message):
 
 
 class ProjectProperties(_messages.Message):
-  """A descriptor for defining project properties for a service. One service
+  r"""A descriptor for defining project properties for a service. One service
   may have many consumer projects, and the service may want to behave
   differently depending on some properties on the project. For example, a
   project may be associated with a school, or a business, or a government
@@ -1810,7 +1810,7 @@ class ProjectProperties(_messages.Message):
 
 
 class ProjectSettings(_messages.Message):
-  """Settings that control how a consumer project uses a service.
+  r"""Settings that control how a consumer project uses a service.
 
   Messages:
     PropertiesValue: Service-defined per-consumer properties.  A key-value
@@ -1838,7 +1838,7 @@ class ProjectSettings(_messages.Message):
 
   @encoding.MapUnrecognizedFields('additionalProperties')
   class PropertiesValue(_messages.Message):
-    """Service-defined per-consumer properties.  A key-value mapping a string
+    r"""Service-defined per-consumer properties.  A key-value mapping a string
     key to a google.protobuf.ListValue proto. Values in the list are typed as
     defined in the Service configuration's consumer.properties field.
 
@@ -1850,7 +1850,7 @@ class ProjectSettings(_messages.Message):
     """
 
     class AdditionalProperty(_messages.Message):
-      """An additional property for a PropertiesValue object.
+      r"""An additional property for a PropertiesValue object.
 
       Fields:
         key: Name of the additional property.
@@ -1872,7 +1872,7 @@ class ProjectSettings(_messages.Message):
 
 
 class Property(_messages.Message):
-  """Defines project properties.  API services can define properties that can
+  r"""Defines project properties.  API services can define properties that can
   be assigned to consumer projects so that backends can perform response
   customization without having to make additional calls or maintain additional
   storage. For example, Maps API defines properties that controls map tile
@@ -1890,7 +1890,7 @@ class Property(_messages.Message):
   """
 
   class TypeValueValuesEnum(_messages.Enum):
-    """The type of this property.
+    r"""The type of this property.
 
     Values:
       UNSPECIFIED: The type is unspecified, and will result in an error.
@@ -1911,8 +1911,9 @@ class Property(_messages.Message):
 
 
 class ProtoDescriptor(_messages.Message):
-  """Contains a serialized protoc-generated protocol buffer message descriptor
-  set along with a URL that describes the type of the descriptor message.
+  r"""Contains a serialized protoc-generated protocol buffer message
+  descriptor set along with a URL that describes the type of the descriptor
+  message.
 
   Fields:
     typeUrl: A URL/resource name whose content describes the type of the
@@ -1932,7 +1933,7 @@ class ProtoDescriptor(_messages.Message):
 
 
 class ProtoSpec(_messages.Message):
-  """A collection of protocol buffer service specification files.
+  r"""A collection of protocol buffer service specification files.
 
   Fields:
     protoDescriptor: A complete descriptor of a protocol buffer specification
@@ -1942,7 +1943,7 @@ class ProtoSpec(_messages.Message):
 
 
 class QueryUserAccessResponse(_messages.Message):
-  """Request message for QueryUserAccess method.
+  r"""Request message for QueryUserAccess method.
 
   Fields:
     accessibleVisibilityLabels: Any visibility labels on the service that are
@@ -1956,7 +1957,7 @@ class QueryUserAccessResponse(_messages.Message):
 
 
 class Quota(_messages.Message):
-  """Quota configuration helps to achieve fairness and budgeting in service
+  r"""Quota configuration helps to achieve fairness and budgeting in service
   usage.  - Fairness is achieved through the use of short-term quota limits
   that are usually defined over a time window of several seconds or   minutes.
   When such a limit is applied, for example at the user   level, it ensures
@@ -2030,7 +2031,7 @@ class Quota(_messages.Message):
 
 
 class QuotaGroup(_messages.Message):
-  """`QuotaGroup` defines a set of quota limits to enforce.
+  r"""`QuotaGroup` defines a set of quota limits to enforce.
 
   Fields:
     billable: Indicates if the quota limits defined in this quota group apply
@@ -2055,7 +2056,7 @@ class QuotaGroup(_messages.Message):
 
 
 class QuotaGroupMapping(_messages.Message):
-  """A quota group mapping.
+  r"""A quota group mapping.
 
   Fields:
     cost: Number of tokens to consume for each request. This allows different
@@ -2070,7 +2071,7 @@ class QuotaGroupMapping(_messages.Message):
 
 
 class QuotaInfo(_messages.Message):
-  """Metadata about an individual quota, containing usage and limit
+  r"""Metadata about an individual quota, containing usage and limit
   information.
 
   Fields:
@@ -2088,7 +2089,7 @@ class QuotaInfo(_messages.Message):
 
 
 class QuotaLimit(_messages.Message):
-  """`QuotaLimit` defines a specific limit that applies over a specified
+  r"""`QuotaLimit` defines a specific limit that applies over a specified
   duration for a limit type. There can be at most one limit for a duration and
   limit type combination defined within a `QuotaGroup`.
 
@@ -2152,7 +2153,7 @@ class QuotaLimit(_messages.Message):
   """
 
   class LimitByValueValuesEnum(_messages.Enum):
-    """Limit type to use for enforcing this quota limit. Each unique value
+    r"""Limit type to use for enforcing this quota limit. Each unique value
     gets the defined number of tokens to consume from. For a quota limit that
     uses user type, each user making requests through the same client
     application project will get his/her own pool of tokens to consume,
@@ -2180,8 +2181,8 @@ class QuotaLimit(_messages.Message):
 
 
 class QuotaLimitOverride(_messages.Message):
-  """Specifies a custom quota limit that is applied for this consumer project.
-  This overrides the default value in google.api.QuotaLimit.
+  r"""Specifies a custom quota limit that is applied for this consumer
+  project. This overrides the default value in google.api.QuotaLimit.
 
   Fields:
     limit: The new limit for this project. May be -1 (unlimited), 0 (block),
@@ -2196,7 +2197,7 @@ class QuotaLimitOverride(_messages.Message):
 
 
 class QuotaRule(_messages.Message):
-  """`QuotaRule` maps a method to a set of `QuotaGroup`s.
+  r"""`QuotaRule` maps a method to a set of `QuotaGroup`s.
 
   Fields:
     disableQuota: Indicates if quota checking should be enforced. Quota will
@@ -2215,8 +2216,9 @@ class QuotaRule(_messages.Message):
 
 
 class QuotaSettings(_messages.Message):
-  """Per-consumer overrides for quota settings. See google/api/quota.proto for
-  the corresponding service configuration which provides the default values.
+  r"""Per-consumer overrides for quota settings. See google/api/quota.proto
+  for the corresponding service configuration which provides the default
+  values.
 
   Messages:
     ConsumerOverridesValue: Quota overrides set by the consumer. Consumer
@@ -2282,7 +2284,7 @@ class QuotaSettings(_messages.Message):
 
   @encoding.MapUnrecognizedFields('additionalProperties')
   class ConsumerOverridesValue(_messages.Message):
-    """Quota overrides set by the consumer. Consumer overrides will only have
+    r"""Quota overrides set by the consumer. Consumer overrides will only have
     an effect up to the max_limit specified in the service config, or the the
     producer override, if one exists.  The key for this map is one of the
     following:  - '<GROUP_NAME>/<LIMIT_NAME>' for quotas defined within quota
@@ -2303,7 +2305,7 @@ class QuotaSettings(_messages.Message):
     """
 
     class AdditionalProperty(_messages.Message):
-      """An additional property for a ConsumerOverridesValue object.
+      r"""An additional property for a ConsumerOverridesValue object.
 
       Fields:
         key: Name of the additional property.
@@ -2317,7 +2319,7 @@ class QuotaSettings(_messages.Message):
 
   @encoding.MapUnrecognizedFields('additionalProperties')
   class EffectiveQuotasValue(_messages.Message):
-    """The effective quota limits for each group, derived from the service
+    r"""The effective quota limits for each group, derived from the service
     defaults together with any producer or consumer overrides. For each limit,
     the effective value is the minimum of the producer and consumer overrides
     if either is present, or else the service default if neither is present.
@@ -2332,7 +2334,7 @@ class QuotaSettings(_messages.Message):
     """
 
     class AdditionalProperty(_messages.Message):
-      """An additional property for a EffectiveQuotasValue object.
+      r"""An additional property for a EffectiveQuotasValue object.
 
       Fields:
         key: Name of the additional property.
@@ -2346,7 +2348,7 @@ class QuotaSettings(_messages.Message):
 
   @encoding.MapUnrecognizedFields('additionalProperties')
   class ProducerOverridesValue(_messages.Message):
-    """Quota overrides set by the producer. Note that if a consumer override
+    r"""Quota overrides set by the producer. Note that if a consumer override
     is also specified, then the minimum of the two will be used. This allows
     consumers to cap their usage voluntarily.  The key for this map is one of
     the following:  - '<GROUP_NAME>/<LIMIT_NAME>' for quotas defined within
@@ -2367,7 +2369,7 @@ class QuotaSettings(_messages.Message):
     """
 
     class AdditionalProperty(_messages.Message):
-      """An additional property for a ProducerOverridesValue object.
+      r"""An additional property for a ProducerOverridesValue object.
 
       Fields:
         key: Name of the additional property.
@@ -2387,7 +2389,7 @@ class QuotaSettings(_messages.Message):
 
 
 class QuotaUsage(_messages.Message):
-  """Specifies the used quota amount for a quota limit at a particular time.
+  r"""Specifies the used quota amount for a quota limit at a particular time.
 
   Fields:
     endTime: The time the quota duration ended.
@@ -2403,7 +2405,7 @@ class QuotaUsage(_messages.Message):
 
 
 class Service(_messages.Message):
-  """`Service` is the root object of the configuration schema. It describes
+  r"""`Service` is the root object of the configuration schema. It describes
   basic information like the name of the service and the exposed API
   interfaces, and delegates other aspects to configuration sub-sections.
   Example:      type: google.api.Service     config_version: 1     name:
@@ -2498,7 +2500,7 @@ class Service(_messages.Message):
 
 
 class ServiceAccessList(_messages.Message):
-  """List of users and groups that are granted access to a service or
+  r"""List of users and groups that are granted access to a service or
   visibility label.
 
   Fields:
@@ -2515,7 +2517,7 @@ class ServiceAccessList(_messages.Message):
 
 
 class ServiceAccessPolicy(_messages.Message):
-  """Policy describing who can access a service and any visibility labels on
+  r"""Policy describing who can access a service and any visibility labels on
   that service.
 
   Messages:
@@ -2535,9 +2537,9 @@ class ServiceAccessPolicy(_messages.Message):
 
   @encoding.MapUnrecognizedFields('additionalProperties')
   class VisibilityLabelAccessListsValue(_messages.Message):
-    """ACLs for access to restricted parts of the service.  The map key is the
-    visibility label that is being controlled.  Note that access to any label
-    also implies access to the unrestricted surface.
+    r"""ACLs for access to restricted parts of the service.  The map key is
+    the visibility label that is being controlled.  Note that access to any
+    label also implies access to the unrestricted surface.
 
     Messages:
       AdditionalProperty: An additional property for a
@@ -2549,7 +2551,7 @@ class ServiceAccessPolicy(_messages.Message):
     """
 
     class AdditionalProperty(_messages.Message):
-      """An additional property for a VisibilityLabelAccessListsValue object.
+      r"""An additional property for a VisibilityLabelAccessListsValue object.
 
       Fields:
         key: Name of the additional property.
@@ -2567,7 +2569,7 @@ class ServiceAccessPolicy(_messages.Message):
 
 
 class ServicemanagementOperationsGetRequest(_messages.Message):
-  """A ServicemanagementOperationsGetRequest object.
+  r"""A ServicemanagementOperationsGetRequest object.
 
   Fields:
     operationsId: Part of `name`. The name of the operation resource.
@@ -2577,7 +2579,7 @@ class ServicemanagementOperationsGetRequest(_messages.Message):
 
 
 class ServicemanagementServicesAccessPolicyQueryRequest(_messages.Message):
-  """A ServicemanagementServicesAccessPolicyQueryRequest object.
+  r"""A ServicemanagementServicesAccessPolicyQueryRequest object.
 
   Fields:
     serviceName: The service to query access for.
@@ -2589,7 +2591,7 @@ class ServicemanagementServicesAccessPolicyQueryRequest(_messages.Message):
 
 
 class ServicemanagementServicesConfigsCreateRequest(_messages.Message):
-  """A ServicemanagementServicesConfigsCreateRequest object.
+  r"""A ServicemanagementServicesConfigsCreateRequest object.
 
   Fields:
     service: A Service resource to be passed as the request body.
@@ -2602,7 +2604,7 @@ class ServicemanagementServicesConfigsCreateRequest(_messages.Message):
 
 
 class ServicemanagementServicesConfigsGetRequest(_messages.Message):
-  """A ServicemanagementServicesConfigsGetRequest object.
+  r"""A ServicemanagementServicesConfigsGetRequest object.
 
   Fields:
     configId: The id of the service config resource. Optional. If it is not
@@ -2616,7 +2618,7 @@ class ServicemanagementServicesConfigsGetRequest(_messages.Message):
 
 
 class ServicemanagementServicesConfigsListRequest(_messages.Message):
-  """A ServicemanagementServicesConfigsListRequest object.
+  r"""A ServicemanagementServicesConfigsListRequest object.
 
   Fields:
     pageSize: The max number of items to include in the response list.
@@ -2631,7 +2633,7 @@ class ServicemanagementServicesConfigsListRequest(_messages.Message):
 
 
 class ServicemanagementServicesConfigsSubmitRequest(_messages.Message):
-  """A ServicemanagementServicesConfigsSubmitRequest object.
+  r"""A ServicemanagementServicesConfigsSubmitRequest object.
 
   Fields:
     serviceName: The name of the service.  See the `ServiceManager` overview
@@ -2645,7 +2647,7 @@ class ServicemanagementServicesConfigsSubmitRequest(_messages.Message):
 
 
 class ServicemanagementServicesCustomerSettingsGetRequest(_messages.Message):
-  """A ServicemanagementServicesCustomerSettingsGetRequest object.
+  r"""A ServicemanagementServicesCustomerSettingsGetRequest object.
 
   Enums:
     ViewValueValuesEnum: Request only fields for the specified view.
@@ -2662,7 +2664,7 @@ class ServicemanagementServicesCustomerSettingsGetRequest(_messages.Message):
   """
 
   class ViewValueValuesEnum(_messages.Enum):
-    """Request only fields for the specified view.
+    r"""Request only fields for the specified view.
 
     Values:
       PROJECT_SETTINGS_VIEW_UNSPECIFIED: <no description>
@@ -2682,7 +2684,7 @@ class ServicemanagementServicesCustomerSettingsGetRequest(_messages.Message):
 
 
 class ServicemanagementServicesCustomerSettingsPatchRequest(_messages.Message):
-  """A ServicemanagementServicesCustomerSettingsPatchRequest object.
+  r"""A ServicemanagementServicesCustomerSettingsPatchRequest object.
 
   Fields:
     customerId: ID for the customer. See the comment for
@@ -2703,7 +2705,7 @@ class ServicemanagementServicesCustomerSettingsPatchRequest(_messages.Message):
 
 
 class ServicemanagementServicesDeleteRequest(_messages.Message):
-  """A ServicemanagementServicesDeleteRequest object.
+  r"""A ServicemanagementServicesDeleteRequest object.
 
   Fields:
     serviceName: The name of the service.  See the `ServiceManager` overview
@@ -2714,7 +2716,7 @@ class ServicemanagementServicesDeleteRequest(_messages.Message):
 
 
 class ServicemanagementServicesDisableRequest(_messages.Message):
-  """A ServicemanagementServicesDisableRequest object.
+  r"""A ServicemanagementServicesDisableRequest object.
 
   Fields:
     disableServiceRequest: A DisableServiceRequest resource to be passed as
@@ -2728,7 +2730,7 @@ class ServicemanagementServicesDisableRequest(_messages.Message):
 
 
 class ServicemanagementServicesEnableRequest(_messages.Message):
-  """A ServicemanagementServicesEnableRequest object.
+  r"""A ServicemanagementServicesEnableRequest object.
 
   Fields:
     enableServiceRequest: A EnableServiceRequest resource to be passed as the
@@ -2742,7 +2744,7 @@ class ServicemanagementServicesEnableRequest(_messages.Message):
 
 
 class ServicemanagementServicesGetAccessPolicyRequest(_messages.Message):
-  """A ServicemanagementServicesGetAccessPolicyRequest object.
+  r"""A ServicemanagementServicesGetAccessPolicyRequest object.
 
   Fields:
     serviceName: The name of the service.  For example:
@@ -2753,7 +2755,7 @@ class ServicemanagementServicesGetAccessPolicyRequest(_messages.Message):
 
 
 class ServicemanagementServicesGetConfigRequest(_messages.Message):
-  """A ServicemanagementServicesGetConfigRequest object.
+  r"""A ServicemanagementServicesGetConfigRequest object.
 
   Fields:
     configId: The id of the service config resource. Optional. If it is not
@@ -2767,7 +2769,7 @@ class ServicemanagementServicesGetConfigRequest(_messages.Message):
 
 
 class ServicemanagementServicesGetRequest(_messages.Message):
-  """A ServicemanagementServicesGetRequest object.
+  r"""A ServicemanagementServicesGetRequest object.
 
   Enums:
     ViewValueValuesEnum: If project_settings is expanded, request only fields
@@ -2788,7 +2790,7 @@ class ServicemanagementServicesGetRequest(_messages.Message):
   """
 
   class ViewValueValuesEnum(_messages.Enum):
-    """If project_settings is expanded, request only fields for the specified
+    r"""If project_settings is expanded, request only fields for the specified
     view.
 
     Values:
@@ -2809,7 +2811,7 @@ class ServicemanagementServicesGetRequest(_messages.Message):
 
 
 class ServicemanagementServicesListRequest(_messages.Message):
-  """A ServicemanagementServicesListRequest object.
+  r"""A ServicemanagementServicesListRequest object.
 
   Fields:
     category: Include services only in the specified category. Supported
@@ -2837,7 +2839,7 @@ class ServicemanagementServicesListRequest(_messages.Message):
 
 
 class ServicemanagementServicesPatchConfigRequest(_messages.Message):
-  """A ServicemanagementServicesPatchConfigRequest object.
+  r"""A ServicemanagementServicesPatchConfigRequest object.
 
   Fields:
     service: A Service resource to be passed as the request body.
@@ -2852,7 +2854,7 @@ class ServicemanagementServicesPatchConfigRequest(_messages.Message):
 
 
 class ServicemanagementServicesPatchRequest(_messages.Message):
-  """A ServicemanagementServicesPatchRequest object.
+  r"""A ServicemanagementServicesPatchRequest object.
 
   Fields:
     managedService: A ManagedService resource to be passed as the request
@@ -2868,7 +2870,7 @@ class ServicemanagementServicesPatchRequest(_messages.Message):
 
 
 class ServicemanagementServicesProjectSettingsGetRequest(_messages.Message):
-  """A ServicemanagementServicesProjectSettingsGetRequest object.
+  r"""A ServicemanagementServicesProjectSettingsGetRequest object.
 
   Enums:
     ViewValueValuesEnum: Request only the fields for the specified view.
@@ -2883,7 +2885,7 @@ class ServicemanagementServicesProjectSettingsGetRequest(_messages.Message):
   """
 
   class ViewValueValuesEnum(_messages.Enum):
-    """Request only the fields for the specified view.
+    r"""Request only the fields for the specified view.
 
     Values:
       PROJECT_SETTINGS_VIEW_UNSPECIFIED: <no description>
@@ -2903,7 +2905,7 @@ class ServicemanagementServicesProjectSettingsGetRequest(_messages.Message):
 
 
 class ServicemanagementServicesProjectSettingsPatchRequest(_messages.Message):
-  """A ServicemanagementServicesProjectSettingsPatchRequest object.
+  r"""A ServicemanagementServicesProjectSettingsPatchRequest object.
 
   Fields:
     consumerProjectId: The project ID of the consumer.
@@ -2921,7 +2923,7 @@ class ServicemanagementServicesProjectSettingsPatchRequest(_messages.Message):
 
 
 class ServicemanagementServicesUpdateConfigRequest(_messages.Message):
-  """A ServicemanagementServicesUpdateConfigRequest object.
+  r"""A ServicemanagementServicesUpdateConfigRequest object.
 
   Fields:
     service: A Service resource to be passed as the request body.
@@ -2938,7 +2940,7 @@ class ServicemanagementServicesUpdateConfigRequest(_messages.Message):
 
 
 class ServicemanagementServicesUpdateRequest(_messages.Message):
-  """A ServicemanagementServicesUpdateRequest object.
+  r"""A ServicemanagementServicesUpdateRequest object.
 
   Fields:
     managedService: A ManagedService resource to be passed as the request
@@ -2956,7 +2958,7 @@ class ServicemanagementServicesUpdateRequest(_messages.Message):
 
 
 class SourceContext(_messages.Message):
-  """`SourceContext` represents information about the source of a protobuf
+  r"""`SourceContext` represents information about the source of a protobuf
   element, like the file in which it is defined.
 
   Fields:
@@ -2969,7 +2971,7 @@ class SourceContext(_messages.Message):
 
 
 class StandardQueryParameters(_messages.Message):
-  """Query parameters accepted by all methods.
+  r"""Query parameters accepted by all methods.
 
   Enums:
     FXgafvValueValuesEnum: V1 error format.
@@ -2998,7 +3000,7 @@ class StandardQueryParameters(_messages.Message):
   """
 
   class AltValueValuesEnum(_messages.Enum):
-    """Data format for response.
+    r"""Data format for response.
 
     Values:
       json: Responses with Content-Type of application/json
@@ -3010,7 +3012,7 @@ class StandardQueryParameters(_messages.Message):
     proto = 2
 
   class FXgafvValueValuesEnum(_messages.Enum):
-    """V1 error format.
+    r"""V1 error format.
 
     Values:
       _1: v1 error format
@@ -3036,7 +3038,7 @@ class StandardQueryParameters(_messages.Message):
 
 
 class Status(_messages.Message):
-  """The `Status` type defines a logical error model that is suitable for
+  r"""The `Status` type defines a logical error model that is suitable for
   different programming environments, including REST APIs and RPC APIs. It is
   used by [gRPC](https://github.com/grpc). The error model is designed to be:
   - Simple to use and understand for most users - Flexible enough to meet
@@ -3084,7 +3086,7 @@ class Status(_messages.Message):
 
   @encoding.MapUnrecognizedFields('additionalProperties')
   class DetailsValueListEntry(_messages.Message):
-    """A DetailsValueListEntry object.
+    r"""A DetailsValueListEntry object.
 
     Messages:
       AdditionalProperty: An additional property for a DetailsValueListEntry
@@ -3096,7 +3098,7 @@ class Status(_messages.Message):
     """
 
     class AdditionalProperty(_messages.Message):
-      """An additional property for a DetailsValueListEntry object.
+      r"""An additional property for a DetailsValueListEntry object.
 
       Fields:
         key: Name of the additional property.
@@ -3114,7 +3116,7 @@ class Status(_messages.Message):
 
 
 class Step(_messages.Message):
-  """Represents the status of one operation step.
+  r"""Represents the status of one operation step.
 
   Enums:
     StatusValueValuesEnum: The status code.
@@ -3125,7 +3127,7 @@ class Step(_messages.Message):
   """
 
   class StatusValueValuesEnum(_messages.Enum):
-    """The status code.
+    r"""The status code.
 
     Values:
       STATUS_UNSPECIFIED: Unspecifed code.
@@ -3145,7 +3147,7 @@ class Step(_messages.Message):
 
 
 class SubmitConfigSourceRequest(_messages.Message):
-  """Request message for SubmitConfigSource method.
+  r"""Request message for SubmitConfigSource method.
 
   Fields:
     configSource: The source configuration for the service.
@@ -3159,7 +3161,7 @@ class SubmitConfigSourceRequest(_messages.Message):
 
 
 class SwaggerSpec(_messages.Message):
-  """A collection of swagger specification files.
+  r"""A collection of swagger specification files.
 
   Fields:
     swaggerFiles: The individual files.
@@ -3169,7 +3171,7 @@ class SwaggerSpec(_messages.Message):
 
 
 class SystemParameter(_messages.Message):
-  """Define a parameter's name and location. The parameter may be passed as
+  r"""Define a parameter's name and location. The parameter may be passed as
   either an HTTP header or a URL query parameter, and if both are passed the
   behavior is implementation-dependent.
 
@@ -3188,7 +3190,7 @@ class SystemParameter(_messages.Message):
 
 
 class SystemParameterRule(_messages.Message):
-  """Define a system parameter rule mapping system parameter definitions to
+  r"""Define a system parameter rule mapping system parameter definitions to
   methods.
 
   Fields:
@@ -3206,7 +3208,7 @@ class SystemParameterRule(_messages.Message):
 
 
 class SystemParameters(_messages.Message):
-  """### System parameter configuration  A system parameter is a special kind
+  r"""### System parameter configuration  A system parameter is a special kind
   of parameter defined by the API system, not by an individual API. It is
   typically mapped to an HTTP header and/or a URL query parameter. This
   configuration specifies which methods change the names of the system
@@ -3230,7 +3232,7 @@ class SystemParameters(_messages.Message):
 
 
 class Type(_messages.Message):
-  """A protocol buffer message type.
+  r"""A protocol buffer message type.
 
   Enums:
     SyntaxValueValuesEnum: The source syntax.
@@ -3245,7 +3247,7 @@ class Type(_messages.Message):
   """
 
   class SyntaxValueValuesEnum(_messages.Enum):
-    """The source syntax.
+    r"""The source syntax.
 
     Values:
       SYNTAX_PROTO2: Syntax `proto2`.
@@ -3263,7 +3265,7 @@ class Type(_messages.Message):
 
 
 class Usage(_messages.Message):
-  """Configuration controlling usage of a service.
+  r"""Configuration controlling usage of a service.
 
   Enums:
     ServiceAccessValueValuesEnum: Controls which users can see or activate the
@@ -3294,7 +3296,7 @@ class Usage(_messages.Message):
   """
 
   class ServiceAccessValueValuesEnum(_messages.Enum):
-    """Controls which users can see or activate the service.
+    r"""Controls which users can see or activate the service.
 
     Values:
       RESTRICTED: The service can only be seen/used by users identified in the
@@ -3329,7 +3331,7 @@ class Usage(_messages.Message):
 
 
 class UsageRule(_messages.Message):
-  """Usage configuration rules for the service.  NOTE: Under development.
+  r"""Usage configuration rules for the service.  NOTE: Under development.
   Use this rule to configure unregistered calls for the service. Unregistered
   calls are calls that do not contain consumer project identity. (Example:
   calls that do not contain an API key). By default, API methods do not allow
@@ -3354,7 +3356,7 @@ class UsageRule(_messages.Message):
 
 
 class UsageSettings(_messages.Message):
-  """Usage settings for a consumer of a service.
+  r"""Usage settings for a consumer of a service.
 
   Enums:
     ConsumerEnableStatusValueValuesEnum: Consumer controlled setting to
@@ -3368,7 +3370,7 @@ class UsageSettings(_messages.Message):
   """
 
   class ConsumerEnableStatusValueValuesEnum(_messages.Enum):
-    """Consumer controlled setting to enable/disable use of this service by
+    r"""Consumer controlled setting to enable/disable use of this service by
     the consumer project. The default value of this is controlled by the
     service configuration.
 
@@ -3383,7 +3385,7 @@ class UsageSettings(_messages.Message):
 
 
 class VariableTermQuota(_messages.Message):
-  """A variable term quota is a bucket of tokens that is consumed over a
+  r"""A variable term quota is a bucket of tokens that is consumed over a
   specified (usually long) time period. When present, it overrides any "1d"
   duration per-project quota specified on the group.  Variable terms run from
   midnight to midnight, start_date to end_date (inclusive) in the
@@ -3418,17 +3420,18 @@ class VariableTermQuota(_messages.Message):
 
 
 class Visibility(_messages.Message):
-  """`Visibility` defines restrictions for the visibility of service elements.
-  Restrictions are specified using visibility labels (e.g., TRUSTED_TESTER)
-  that are elsewhere linked to users and projects.  Users and projects can
-  have access to more than one visibility label. The effective visibility for
-  multiple labels is the union of each label's elements, plus any unrestricted
-  elements.  If an element and its parents have no restrictions, visibility is
-  unconditionally granted.  Example:      visibility:       rules:       -
-  selector: google.calendar.Calendar.EnhancedSearch         restriction:
-  TRUSTED_TESTER       - selector: google.calendar.Calendar.Delegate
-  restriction: GOOGLE_INTERNAL  Here, all methods are publicly visible except
-  for the restricted methods EnhancedSearch and Delegate.
+  r"""`Visibility` defines restrictions for the visibility of service
+  elements.  Restrictions are specified using visibility labels (e.g.,
+  TRUSTED_TESTER) that are elsewhere linked to users and projects.  Users and
+  projects can have access to more than one visibility label. The effective
+  visibility for multiple labels is the union of each label's elements, plus
+  any unrestricted elements.  If an element and its parents have no
+  restrictions, visibility is unconditionally granted.  Example:
+  visibility:       rules:       - selector:
+  google.calendar.Calendar.EnhancedSearch         restriction: TRUSTED_TESTER
+  - selector: google.calendar.Calendar.Delegate         restriction:
+  GOOGLE_INTERNAL  Here, all methods are publicly visible except for the
+  restricted methods EnhancedSearch and Delegate.
 
   Fields:
     enforceRuntimeVisibility: Controls whether visibility rules are enforced
@@ -3448,8 +3451,8 @@ class Visibility(_messages.Message):
 
 
 class VisibilityRule(_messages.Message):
-  """A visibility rule provides visibility configuration for an individual API
-  element.
+  r"""A visibility rule provides visibility configuration for an individual
+  API element.
 
   Fields:
     enforceRuntimeVisibility: Controls whether visibility is enforced at
@@ -3477,7 +3480,7 @@ class VisibilityRule(_messages.Message):
 
 
 class VisibilitySettings(_messages.Message):
-  """Settings that control which features of the service are visible to the
+  r"""Settings that control which features of the service are visible to the
   consumer project.
 
   Fields:

--- a/samples/storage_sample/storage_v1/storage_v1_client.py
+++ b/samples/storage_sample/storage_v1/storage_v1_client.py
@@ -54,7 +54,7 @@ class StorageV1(base_api.BaseApiClient):
           }
 
     def Delete(self, request, global_params=None):
-      """Permanently deletes the ACL entry for the specified entity on the specified bucket.
+      r"""Permanently deletes the ACL entry for the specified entity on the specified bucket.
 
       Args:
         request: (StorageBucketAccessControlsDeleteRequest) input message
@@ -80,7 +80,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Get(self, request, global_params=None):
-      """Returns the ACL entry for the specified entity on the specified bucket.
+      r"""Returns the ACL entry for the specified entity on the specified bucket.
 
       Args:
         request: (StorageBucketAccessControlsGetRequest) input message
@@ -106,7 +106,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Insert(self, request, global_params=None):
-      """Creates a new ACL entry on the specified bucket.
+      r"""Creates a new ACL entry on the specified bucket.
 
       Args:
         request: (BucketAccessControl) input message
@@ -132,7 +132,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def List(self, request, global_params=None):
-      """Retrieves ACL entries on the specified bucket.
+      r"""Retrieves ACL entries on the specified bucket.
 
       Args:
         request: (StorageBucketAccessControlsListRequest) input message
@@ -158,7 +158,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Patch(self, request, global_params=None):
-      """Updates an ACL entry on the specified bucket. This method supports patch semantics.
+      r"""Updates an ACL entry on the specified bucket. This method supports patch semantics.
 
       Args:
         request: (BucketAccessControl) input message
@@ -184,7 +184,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Update(self, request, global_params=None):
-      """Updates an ACL entry on the specified bucket.
+      r"""Updates an ACL entry on the specified bucket.
 
       Args:
         request: (BucketAccessControl) input message
@@ -220,7 +220,7 @@ class StorageV1(base_api.BaseApiClient):
           }
 
     def Delete(self, request, global_params=None):
-      """Permanently deletes an empty bucket.
+      r"""Permanently deletes an empty bucket.
 
       Args:
         request: (StorageBucketsDeleteRequest) input message
@@ -246,7 +246,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Get(self, request, global_params=None):
-      """Returns metadata for the specified bucket.
+      r"""Returns metadata for the specified bucket.
 
       Args:
         request: (StorageBucketsGetRequest) input message
@@ -272,7 +272,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def GetIamPolicy(self, request, global_params=None):
-      """Returns an IAM policy for the specified bucket.
+      r"""Returns an IAM policy for the specified bucket.
 
       Args:
         request: (StorageBucketsGetIamPolicyRequest) input message
@@ -298,7 +298,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Insert(self, request, global_params=None):
-      """Creates a new bucket.
+      r"""Creates a new bucket.
 
       Args:
         request: (StorageBucketsInsertRequest) input message
@@ -324,7 +324,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def List(self, request, global_params=None):
-      """Retrieves a list of buckets for a given project.
+      r"""Retrieves a list of buckets for a given project.
 
       Args:
         request: (StorageBucketsListRequest) input message
@@ -350,7 +350,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Patch(self, request, global_params=None):
-      """Updates a bucket. This method supports patch semantics.
+      r"""Updates a bucket. This method supports patch semantics.
 
       Args:
         request: (StorageBucketsPatchRequest) input message
@@ -376,7 +376,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def SetIamPolicy(self, request, global_params=None):
-      """Updates an IAM policy for the specified bucket.
+      r"""Updates an IAM policy for the specified bucket.
 
       Args:
         request: (StorageBucketsSetIamPolicyRequest) input message
@@ -402,7 +402,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def TestIamPermissions(self, request, global_params=None):
-      """Tests a set of permissions on the given bucket to see which, if any, are held by the caller.
+      r"""Tests a set of permissions on the given bucket to see which, if any, are held by the caller.
 
       Args:
         request: (StorageBucketsTestIamPermissionsRequest) input message
@@ -428,7 +428,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Update(self, request, global_params=None):
-      """Updates a bucket.
+      r"""Updates a bucket.
 
       Args:
         request: (StorageBucketsUpdateRequest) input message
@@ -464,7 +464,7 @@ class StorageV1(base_api.BaseApiClient):
           }
 
     def Stop(self, request, global_params=None):
-      """Stop watching resources through this channel.
+      r"""Stop watching resources through this channel.
 
       Args:
         request: (Channel) input message
@@ -500,7 +500,7 @@ class StorageV1(base_api.BaseApiClient):
           }
 
     def Delete(self, request, global_params=None):
-      """Permanently deletes the default object ACL entry for the specified entity on the specified bucket.
+      r"""Permanently deletes the default object ACL entry for the specified entity on the specified bucket.
 
       Args:
         request: (StorageDefaultObjectAccessControlsDeleteRequest) input message
@@ -526,7 +526,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Get(self, request, global_params=None):
-      """Returns the default object ACL entry for the specified entity on the specified bucket.
+      r"""Returns the default object ACL entry for the specified entity on the specified bucket.
 
       Args:
         request: (StorageDefaultObjectAccessControlsGetRequest) input message
@@ -552,7 +552,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Insert(self, request, global_params=None):
-      """Creates a new default object ACL entry on the specified bucket.
+      r"""Creates a new default object ACL entry on the specified bucket.
 
       Args:
         request: (ObjectAccessControl) input message
@@ -578,7 +578,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def List(self, request, global_params=None):
-      """Retrieves default object ACL entries on the specified bucket.
+      r"""Retrieves default object ACL entries on the specified bucket.
 
       Args:
         request: (StorageDefaultObjectAccessControlsListRequest) input message
@@ -604,7 +604,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Patch(self, request, global_params=None):
-      """Updates a default object ACL entry on the specified bucket. This method supports patch semantics.
+      r"""Updates a default object ACL entry on the specified bucket. This method supports patch semantics.
 
       Args:
         request: (ObjectAccessControl) input message
@@ -630,7 +630,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Update(self, request, global_params=None):
-      """Updates a default object ACL entry on the specified bucket.
+      r"""Updates a default object ACL entry on the specified bucket.
 
       Args:
         request: (ObjectAccessControl) input message
@@ -666,7 +666,7 @@ class StorageV1(base_api.BaseApiClient):
           }
 
     def Delete(self, request, global_params=None):
-      """Permanently deletes a notification subscription.
+      r"""Permanently deletes a notification subscription.
 
       Args:
         request: (StorageNotificationsDeleteRequest) input message
@@ -692,7 +692,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Get(self, request, global_params=None):
-      """View a notification configuration.
+      r"""View a notification configuration.
 
       Args:
         request: (StorageNotificationsGetRequest) input message
@@ -718,7 +718,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Insert(self, request, global_params=None):
-      """Creates a notification subscription for a given bucket.
+      r"""Creates a notification subscription for a given bucket.
 
       Args:
         request: (Notification) input message
@@ -744,7 +744,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def List(self, request, global_params=None):
-      """Retrieves a list of notification subscriptions for a given bucket.
+      r"""Retrieves a list of notification subscriptions for a given bucket.
 
       Args:
         request: (StorageNotificationsListRequest) input message
@@ -780,7 +780,7 @@ class StorageV1(base_api.BaseApiClient):
           }
 
     def Delete(self, request, global_params=None):
-      """Permanently deletes the ACL entry for the specified entity on the specified object.
+      r"""Permanently deletes the ACL entry for the specified entity on the specified object.
 
       Args:
         request: (StorageObjectAccessControlsDeleteRequest) input message
@@ -806,7 +806,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Get(self, request, global_params=None):
-      """Returns the ACL entry for the specified entity on the specified object.
+      r"""Returns the ACL entry for the specified entity on the specified object.
 
       Args:
         request: (StorageObjectAccessControlsGetRequest) input message
@@ -832,7 +832,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Insert(self, request, global_params=None):
-      """Creates a new ACL entry on the specified object.
+      r"""Creates a new ACL entry on the specified object.
 
       Args:
         request: (StorageObjectAccessControlsInsertRequest) input message
@@ -858,7 +858,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def List(self, request, global_params=None):
-      """Retrieves ACL entries on the specified object.
+      r"""Retrieves ACL entries on the specified object.
 
       Args:
         request: (StorageObjectAccessControlsListRequest) input message
@@ -884,7 +884,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Patch(self, request, global_params=None):
-      """Updates an ACL entry on the specified object. This method supports patch semantics.
+      r"""Updates an ACL entry on the specified object. This method supports patch semantics.
 
       Args:
         request: (StorageObjectAccessControlsPatchRequest) input message
@@ -910,7 +910,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Update(self, request, global_params=None):
-      """Updates an ACL entry on the specified object.
+      r"""Updates an ACL entry on the specified object.
 
       Args:
         request: (StorageObjectAccessControlsUpdateRequest) input message
@@ -954,7 +954,7 @@ class StorageV1(base_api.BaseApiClient):
           }
 
     def Compose(self, request, global_params=None, download=None):
-      """Concatenates a list of existing objects into a new object in the same bucket.
+      r"""Concatenates a list of existing objects into a new object in the same bucket.
 
       Args:
         request: (StorageObjectsComposeRequest) input message
@@ -983,7 +983,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Copy(self, request, global_params=None, download=None):
-      """Copies a source object to a destination object. Optionally overrides metadata.
+      r"""Copies a source object to a destination object. Optionally overrides metadata.
 
       Args:
         request: (StorageObjectsCopyRequest) input message
@@ -1012,7 +1012,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Delete(self, request, global_params=None):
-      """Deletes an object and its metadata. Deletions are permanent if versioning is not enabled for the bucket, or if the generation parameter is used.
+      r"""Deletes an object and its metadata. Deletions are permanent if versioning is not enabled for the bucket, or if the generation parameter is used.
 
       Args:
         request: (StorageObjectsDeleteRequest) input message
@@ -1038,7 +1038,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Get(self, request, global_params=None, download=None):
-      """Retrieves an object or its metadata.
+      r"""Retrieves an object or its metadata.
 
       Args:
         request: (StorageObjectsGetRequest) input message
@@ -1067,7 +1067,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def GetIamPolicy(self, request, global_params=None):
-      """Returns an IAM policy for the specified object.
+      r"""Returns an IAM policy for the specified object.
 
       Args:
         request: (StorageObjectsGetIamPolicyRequest) input message
@@ -1093,7 +1093,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Insert(self, request, global_params=None, upload=None, download=None):
-      """Stores a new object and metadata.
+      r"""Stores a new object and metadata.
 
       Args:
         request: (StorageObjectsInsertRequest) input message
@@ -1126,7 +1126,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def List(self, request, global_params=None):
-      """Retrieves a list of objects matching the criteria.
+      r"""Retrieves a list of objects matching the criteria.
 
       Args:
         request: (StorageObjectsListRequest) input message
@@ -1152,7 +1152,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Patch(self, request, global_params=None):
-      """Updates an object's metadata. This method supports patch semantics.
+      r"""Updates an object's metadata. This method supports patch semantics.
 
       Args:
         request: (StorageObjectsPatchRequest) input message
@@ -1178,7 +1178,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Rewrite(self, request, global_params=None):
-      """Rewrites a source object to a destination object. Optionally overrides metadata.
+      r"""Rewrites a source object to a destination object. Optionally overrides metadata.
 
       Args:
         request: (StorageObjectsRewriteRequest) input message
@@ -1204,7 +1204,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def SetIamPolicy(self, request, global_params=None):
-      """Updates an IAM policy for the specified object.
+      r"""Updates an IAM policy for the specified object.
 
       Args:
         request: (StorageObjectsSetIamPolicyRequest) input message
@@ -1230,7 +1230,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def TestIamPermissions(self, request, global_params=None):
-      """Tests a set of permissions on the given object to see which, if any, are held by the caller.
+      r"""Tests a set of permissions on the given object to see which, if any, are held by the caller.
 
       Args:
         request: (StorageObjectsTestIamPermissionsRequest) input message
@@ -1256,7 +1256,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def Update(self, request, global_params=None, download=None):
-      """Updates an object's metadata.
+      r"""Updates an object's metadata.
 
       Args:
         request: (StorageObjectsUpdateRequest) input message
@@ -1285,7 +1285,7 @@ class StorageV1(base_api.BaseApiClient):
     )
 
     def WatchAll(self, request, global_params=None):
-      """Watch for changes on all objects in a bucket.
+      r"""Watch for changes on all objects in a bucket.
 
       Args:
         request: (StorageObjectsWatchAllRequest) input message

--- a/samples/storage_sample/storage_v1/storage_v1_messages.py
+++ b/samples/storage_sample/storage_v1/storage_v1_messages.py
@@ -14,7 +14,7 @@ package = 'storage'
 
 
 class Bucket(_messages.Message):
-  """A bucket.
+  r"""A bucket.
 
   Messages:
     CorsValueListEntry: A CorsValueListEntry object.
@@ -65,7 +65,7 @@ class Bucket(_messages.Message):
   """
 
   class CorsValueListEntry(_messages.Message):
-    """A CorsValueListEntry object.
+    r"""A CorsValueListEntry object.
 
     Fields:
       maxAgeSeconds: The value, in seconds, to return in the  Access-Control-
@@ -85,8 +85,8 @@ class Bucket(_messages.Message):
     responseHeader = _messages.StringField(4, repeated=True)
 
   class LifecycleValue(_messages.Message):
-    """The bucket's lifecycle configuration. See lifecycle management for more
-    information.
+    r"""The bucket's lifecycle configuration. See lifecycle management for
+    more information.
 
     Messages:
       RuleValueListEntry: A RuleValueListEntry object.
@@ -97,7 +97,7 @@ class Bucket(_messages.Message):
     """
 
     class RuleValueListEntry(_messages.Message):
-      """A RuleValueListEntry object.
+      r"""A RuleValueListEntry object.
 
       Messages:
         ActionValue: The action to take.
@@ -109,7 +109,7 @@ class Bucket(_messages.Message):
       """
 
       class ActionValue(_messages.Message):
-        """The action to take.
+        r"""The action to take.
 
         Fields:
           type: Type of the action. Currently, only Delete is supported.
@@ -118,7 +118,7 @@ class Bucket(_messages.Message):
         type = _messages.StringField(1)
 
       class ConditionValue(_messages.Message):
-        """The condition(s) under which the action will be taken.
+        r"""The condition(s) under which the action will be taken.
 
         Fields:
           age: Age of an object (in days). This condition is satisfied when an
@@ -146,7 +146,7 @@ class Bucket(_messages.Message):
     rule = _messages.MessageField('RuleValueListEntry', 1, repeated=True)
 
   class LoggingValue(_messages.Message):
-    """The bucket's logging configuration, which defines the destination
+    r"""The bucket's logging configuration, which defines the destination
     bucket and optional name prefix for the current bucket's logs.
 
     Fields:
@@ -159,7 +159,8 @@ class Bucket(_messages.Message):
     logObjectPrefix = _messages.StringField(2)
 
   class OwnerValue(_messages.Message):
-    """The owner of the bucket. This is always the project team's owner group.
+    r"""The owner of the bucket. This is always the project team's owner
+    group.
 
     Fields:
       entity: The entity, in the form project-owner-projectId.
@@ -170,7 +171,7 @@ class Bucket(_messages.Message):
     entityId = _messages.StringField(2)
 
   class VersioningValue(_messages.Message):
-    """The bucket's versioning configuration.
+    r"""The bucket's versioning configuration.
 
     Fields:
       enabled: While set to true, versioning is fully enabled for this bucket.
@@ -179,9 +180,9 @@ class Bucket(_messages.Message):
     enabled = _messages.BooleanField(1)
 
   class WebsiteValue(_messages.Message):
-    """The bucket's website configuration, controlling how the service behaves
-    when accessing bucket contents as a web site. See the Static Website
-    Examples for more information.
+    r"""The bucket's website configuration, controlling how the service
+    behaves when accessing bucket contents as a web site. See the Static
+    Website Examples for more information.
 
     Fields:
       mainPageSuffix: If the requested object path is missing, the service
@@ -219,7 +220,7 @@ class Bucket(_messages.Message):
 
 
 class BucketAccessControl(_messages.Message):
-  """An access-control entry.
+  r"""An access-control entry.
 
   Messages:
     ProjectTeamValue: The project team associated with the entity, if any.
@@ -247,7 +248,7 @@ class BucketAccessControl(_messages.Message):
   """
 
   class ProjectTeamValue(_messages.Message):
-    """The project team associated with the entity, if any.
+    r"""The project team associated with the entity, if any.
 
     Fields:
       projectNumber: The project number.
@@ -271,7 +272,7 @@ class BucketAccessControl(_messages.Message):
 
 
 class BucketAccessControls(_messages.Message):
-  """An access-control list.
+  r"""An access-control list.
 
   Fields:
     items: The list of items.
@@ -284,7 +285,7 @@ class BucketAccessControls(_messages.Message):
 
 
 class Buckets(_messages.Message):
-  """A list of buckets.
+  r"""A list of buckets.
 
   Fields:
     items: The list of items.
@@ -301,7 +302,7 @@ class Buckets(_messages.Message):
 
 
 class Channel(_messages.Message):
-  """An notification channel used to watch for resource changes.
+  r"""An notification channel used to watch for resource changes.
 
   Messages:
     ParamsValue: Additional parameters controlling delivery channel behavior.
@@ -327,7 +328,7 @@ class Channel(_messages.Message):
 
   @encoding.MapUnrecognizedFields('additionalProperties')
   class ParamsValue(_messages.Message):
-    """Additional parameters controlling delivery channel behavior. Optional.
+    r"""Additional parameters controlling delivery channel behavior. Optional.
 
     Messages:
       AdditionalProperty: An additional property for a ParamsValue object.
@@ -337,7 +338,7 @@ class Channel(_messages.Message):
     """
 
     class AdditionalProperty(_messages.Message):
-      """An additional property for a ParamsValue object.
+      r"""An additional property for a ParamsValue object.
 
       Fields:
         key: Name of the additional property.
@@ -362,7 +363,7 @@ class Channel(_messages.Message):
 
 
 class ComposeRequest(_messages.Message):
-  """A Compose request.
+  r"""A Compose request.
 
   Messages:
     SourceObjectsValueListEntry: A SourceObjectsValueListEntry object.
@@ -375,7 +376,7 @@ class ComposeRequest(_messages.Message):
   """
 
   class SourceObjectsValueListEntry(_messages.Message):
-    """A SourceObjectsValueListEntry object.
+    r"""A SourceObjectsValueListEntry object.
 
     Messages:
       ObjectPreconditionsValue: Conditions that must be met for this operation
@@ -390,7 +391,7 @@ class ComposeRequest(_messages.Message):
     """
 
     class ObjectPreconditionsValue(_messages.Message):
-      """Conditions that must be met for this operation to execute.
+      r"""Conditions that must be met for this operation to execute.
 
       Fields:
         ifGenerationMatch: Only perform the composition if the generation of
@@ -411,7 +412,7 @@ class ComposeRequest(_messages.Message):
 
 
 class Notification(_messages.Message):
-  """A subscription to receive Google PubSub notifications.
+  r"""A subscription to receive Google PubSub notifications.
 
   Messages:
     CustomAttributesValue: An optional list of additional attributes to attach
@@ -442,7 +443,7 @@ class Notification(_messages.Message):
 
   @encoding.MapUnrecognizedFields('additionalProperties')
   class CustomAttributesValue(_messages.Message):
-    """An optional list of additional attributes to attach to each Cloud
+    r"""An optional list of additional attributes to attach to each Cloud
     PubSub message published for this notification subscription.
 
     Messages:
@@ -455,7 +456,7 @@ class Notification(_messages.Message):
     """
 
     class AdditionalProperty(_messages.Message):
-      """An additional property for a CustomAttributesValue object.
+      r"""An additional property for a CustomAttributesValue object.
 
       Fields:
         key: Name of the additional property.
@@ -481,7 +482,7 @@ class Notification(_messages.Message):
 
 
 class Notifications(_messages.Message):
-  """A list of notification subscriptions.
+  r"""A list of notification subscriptions.
 
   Fields:
     items: The list of items.
@@ -494,7 +495,7 @@ class Notifications(_messages.Message):
 
 
 class Object(_messages.Message):
-  """An object.
+  r"""An object.
 
   Messages:
     CustomerEncryptionValue: Metadata of customer-supplied encryption key, if
@@ -546,7 +547,7 @@ class Object(_messages.Message):
   """
 
   class CustomerEncryptionValue(_messages.Message):
-    """Metadata of customer-supplied encryption key, if the object is
+    r"""Metadata of customer-supplied encryption key, if the object is
     encrypted by such a key.
 
     Fields:
@@ -559,7 +560,7 @@ class Object(_messages.Message):
 
   @encoding.MapUnrecognizedFields('additionalProperties')
   class MetadataValue(_messages.Message):
-    """User-provided metadata, in key/value pairs.
+    r"""User-provided metadata, in key/value pairs.
 
     Messages:
       AdditionalProperty: An additional property for a MetadataValue object.
@@ -569,7 +570,7 @@ class Object(_messages.Message):
     """
 
     class AdditionalProperty(_messages.Message):
-      """An additional property for a MetadataValue object.
+      r"""An additional property for a MetadataValue object.
 
       Fields:
         key: Name of the additional property.
@@ -582,7 +583,7 @@ class Object(_messages.Message):
     additionalProperties = _messages.MessageField('AdditionalProperty', 1, repeated=True)
 
   class OwnerValue(_messages.Message):
-    """The owner of the object. This will always be the uploader of the
+    r"""The owner of the object. This will always be the uploader of the
     object.
 
     Fields:
@@ -622,7 +623,7 @@ class Object(_messages.Message):
 
 
 class ObjectAccessControl(_messages.Message):
-  """An access-control entry.
+  r"""An access-control entry.
 
   Messages:
     ProjectTeamValue: The project team associated with the entity, if any.
@@ -651,7 +652,7 @@ class ObjectAccessControl(_messages.Message):
   """
 
   class ProjectTeamValue(_messages.Message):
-    """The project team associated with the entity, if any.
+    r"""The project team associated with the entity, if any.
 
     Fields:
       projectNumber: The project number.
@@ -677,7 +678,7 @@ class ObjectAccessControl(_messages.Message):
 
 
 class ObjectAccessControls(_messages.Message):
-  """An access-control list.
+  r"""An access-control list.
 
   Fields:
     items: The list of items.
@@ -690,7 +691,7 @@ class ObjectAccessControls(_messages.Message):
 
 
 class Objects(_messages.Message):
-  """A list of objects.
+  r"""A list of objects.
 
   Fields:
     items: The list of items.
@@ -710,7 +711,7 @@ class Objects(_messages.Message):
 
 
 class Policy(_messages.Message):
-  """A bucket/object IAM policy.
+  r"""A bucket/object IAM policy.
 
   Messages:
     BindingsValueListEntry: A BindingsValueListEntry object.
@@ -730,7 +731,7 @@ class Policy(_messages.Message):
   """
 
   class BindingsValueListEntry(_messages.Message):
-    """A BindingsValueListEntry object.
+    r"""A BindingsValueListEntry object.
 
     Fields:
       members: A collection of identifiers for members who may assume the
@@ -786,7 +787,7 @@ class Policy(_messages.Message):
 
 
 class RewriteResponse(_messages.Message):
-  """A rewrite response.
+  r"""A rewrite response.
 
   Fields:
     done: true if the copy is finished; otherwise, false if the copy is in
@@ -813,7 +814,7 @@ class RewriteResponse(_messages.Message):
 
 
 class StandardQueryParameters(_messages.Message):
-  """Query parameters accepted by all methods.
+  r"""Query parameters accepted by all methods.
 
   Enums:
     AltValueValuesEnum: Data format for the response.
@@ -836,7 +837,7 @@ class StandardQueryParameters(_messages.Message):
   """
 
   class AltValueValuesEnum(_messages.Enum):
-    """Data format for the response.
+    r"""Data format for the response.
 
     Values:
       json: Responses with Content-Type of application/json
@@ -854,7 +855,7 @@ class StandardQueryParameters(_messages.Message):
 
 
 class StorageBucketAccessControlsDeleteRequest(_messages.Message):
-  """A StorageBucketAccessControlsDeleteRequest object.
+  r"""A StorageBucketAccessControlsDeleteRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -868,11 +869,11 @@ class StorageBucketAccessControlsDeleteRequest(_messages.Message):
 
 
 class StorageBucketAccessControlsDeleteResponse(_messages.Message):
-  """An empty StorageBucketAccessControlsDelete response."""
+  r"""An empty StorageBucketAccessControlsDelete response."""
 
 
 class StorageBucketAccessControlsGetRequest(_messages.Message):
-  """A StorageBucketAccessControlsGetRequest object.
+  r"""A StorageBucketAccessControlsGetRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -886,7 +887,7 @@ class StorageBucketAccessControlsGetRequest(_messages.Message):
 
 
 class StorageBucketAccessControlsListRequest(_messages.Message):
-  """A StorageBucketAccessControlsListRequest object.
+  r"""A StorageBucketAccessControlsListRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -896,7 +897,7 @@ class StorageBucketAccessControlsListRequest(_messages.Message):
 
 
 class StorageBucketsDeleteRequest(_messages.Message):
-  """A StorageBucketsDeleteRequest object.
+  r"""A StorageBucketsDeleteRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -912,11 +913,11 @@ class StorageBucketsDeleteRequest(_messages.Message):
 
 
 class StorageBucketsDeleteResponse(_messages.Message):
-  """An empty StorageBucketsDelete response."""
+  r"""An empty StorageBucketsDelete response."""
 
 
 class StorageBucketsGetIamPolicyRequest(_messages.Message):
-  """A StorageBucketsGetIamPolicyRequest object.
+  r"""A StorageBucketsGetIamPolicyRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -926,7 +927,7 @@ class StorageBucketsGetIamPolicyRequest(_messages.Message):
 
 
 class StorageBucketsGetRequest(_messages.Message):
-  """A StorageBucketsGetRequest object.
+  r"""A StorageBucketsGetRequest object.
 
   Enums:
     ProjectionValueValuesEnum: Set of properties to return. Defaults to noAcl.
@@ -942,7 +943,7 @@ class StorageBucketsGetRequest(_messages.Message):
   """
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Set of properties to return. Defaults to noAcl.
+    r"""Set of properties to return. Defaults to noAcl.
 
     Values:
       full: Include all properties.
@@ -958,7 +959,7 @@ class StorageBucketsGetRequest(_messages.Message):
 
 
 class StorageBucketsInsertRequest(_messages.Message):
-  """A StorageBucketsInsertRequest object.
+  r"""A StorageBucketsInsertRequest object.
 
   Enums:
     PredefinedAclValueValuesEnum: Apply a predefined set of access controls to
@@ -981,7 +982,7 @@ class StorageBucketsInsertRequest(_messages.Message):
   """
 
   class PredefinedAclValueValuesEnum(_messages.Enum):
-    """Apply a predefined set of access controls to this bucket.
+    r"""Apply a predefined set of access controls to this bucket.
 
     Values:
       authenticatedRead: Project team owners get OWNER access, and
@@ -1001,7 +1002,7 @@ class StorageBucketsInsertRequest(_messages.Message):
     publicReadWrite = 4
 
   class PredefinedDefaultObjectAclValueValuesEnum(_messages.Enum):
-    """Apply a predefined set of default object access controls to this
+    r"""Apply a predefined set of default object access controls to this
     bucket.
 
     Values:
@@ -1025,7 +1026,7 @@ class StorageBucketsInsertRequest(_messages.Message):
     publicRead = 5
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Set of properties to return. Defaults to noAcl, unless the bucket
+    r"""Set of properties to return. Defaults to noAcl, unless the bucket
     resource specifies acl or defaultObjectAcl properties, when it defaults to
     full.
 
@@ -1044,7 +1045,7 @@ class StorageBucketsInsertRequest(_messages.Message):
 
 
 class StorageBucketsListRequest(_messages.Message):
-  """A StorageBucketsListRequest object.
+  r"""A StorageBucketsListRequest object.
 
   Enums:
     ProjectionValueValuesEnum: Set of properties to return. Defaults to noAcl.
@@ -1059,7 +1060,7 @@ class StorageBucketsListRequest(_messages.Message):
   """
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Set of properties to return. Defaults to noAcl.
+    r"""Set of properties to return. Defaults to noAcl.
 
     Values:
       full: Include all properties.
@@ -1076,7 +1077,7 @@ class StorageBucketsListRequest(_messages.Message):
 
 
 class StorageBucketsPatchRequest(_messages.Message):
-  """A StorageBucketsPatchRequest object.
+  r"""A StorageBucketsPatchRequest object.
 
   Enums:
     PredefinedAclValueValuesEnum: Apply a predefined set of access controls to
@@ -1100,7 +1101,7 @@ class StorageBucketsPatchRequest(_messages.Message):
   """
 
   class PredefinedAclValueValuesEnum(_messages.Enum):
-    """Apply a predefined set of access controls to this bucket.
+    r"""Apply a predefined set of access controls to this bucket.
 
     Values:
       authenticatedRead: Project team owners get OWNER access, and
@@ -1120,7 +1121,7 @@ class StorageBucketsPatchRequest(_messages.Message):
     publicReadWrite = 4
 
   class PredefinedDefaultObjectAclValueValuesEnum(_messages.Enum):
-    """Apply a predefined set of default object access controls to this
+    r"""Apply a predefined set of default object access controls to this
     bucket.
 
     Values:
@@ -1144,7 +1145,7 @@ class StorageBucketsPatchRequest(_messages.Message):
     publicRead = 5
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Set of properties to return. Defaults to full.
+    r"""Set of properties to return. Defaults to full.
 
     Values:
       full: Include all properties.
@@ -1163,7 +1164,7 @@ class StorageBucketsPatchRequest(_messages.Message):
 
 
 class StorageBucketsSetIamPolicyRequest(_messages.Message):
-  """A StorageBucketsSetIamPolicyRequest object.
+  r"""A StorageBucketsSetIamPolicyRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1175,7 +1176,7 @@ class StorageBucketsSetIamPolicyRequest(_messages.Message):
 
 
 class StorageBucketsTestIamPermissionsRequest(_messages.Message):
-  """A StorageBucketsTestIamPermissionsRequest object.
+  r"""A StorageBucketsTestIamPermissionsRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1187,7 +1188,7 @@ class StorageBucketsTestIamPermissionsRequest(_messages.Message):
 
 
 class StorageBucketsUpdateRequest(_messages.Message):
-  """A StorageBucketsUpdateRequest object.
+  r"""A StorageBucketsUpdateRequest object.
 
   Enums:
     PredefinedAclValueValuesEnum: Apply a predefined set of access controls to
@@ -1211,7 +1212,7 @@ class StorageBucketsUpdateRequest(_messages.Message):
   """
 
   class PredefinedAclValueValuesEnum(_messages.Enum):
-    """Apply a predefined set of access controls to this bucket.
+    r"""Apply a predefined set of access controls to this bucket.
 
     Values:
       authenticatedRead: Project team owners get OWNER access, and
@@ -1231,7 +1232,7 @@ class StorageBucketsUpdateRequest(_messages.Message):
     publicReadWrite = 4
 
   class PredefinedDefaultObjectAclValueValuesEnum(_messages.Enum):
-    """Apply a predefined set of default object access controls to this
+    r"""Apply a predefined set of default object access controls to this
     bucket.
 
     Values:
@@ -1255,7 +1256,7 @@ class StorageBucketsUpdateRequest(_messages.Message):
     publicRead = 5
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Set of properties to return. Defaults to full.
+    r"""Set of properties to return. Defaults to full.
 
     Values:
       full: Include all properties.
@@ -1274,11 +1275,11 @@ class StorageBucketsUpdateRequest(_messages.Message):
 
 
 class StorageChannelsStopResponse(_messages.Message):
-  """An empty StorageChannelsStop response."""
+  r"""An empty StorageChannelsStop response."""
 
 
 class StorageDefaultObjectAccessControlsDeleteRequest(_messages.Message):
-  """A StorageDefaultObjectAccessControlsDeleteRequest object.
+  r"""A StorageDefaultObjectAccessControlsDeleteRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1292,11 +1293,11 @@ class StorageDefaultObjectAccessControlsDeleteRequest(_messages.Message):
 
 
 class StorageDefaultObjectAccessControlsDeleteResponse(_messages.Message):
-  """An empty StorageDefaultObjectAccessControlsDelete response."""
+  r"""An empty StorageDefaultObjectAccessControlsDelete response."""
 
 
 class StorageDefaultObjectAccessControlsGetRequest(_messages.Message):
-  """A StorageDefaultObjectAccessControlsGetRequest object.
+  r"""A StorageDefaultObjectAccessControlsGetRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1310,7 +1311,7 @@ class StorageDefaultObjectAccessControlsGetRequest(_messages.Message):
 
 
 class StorageDefaultObjectAccessControlsListRequest(_messages.Message):
-  """A StorageDefaultObjectAccessControlsListRequest object.
+  r"""A StorageDefaultObjectAccessControlsListRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1326,7 +1327,7 @@ class StorageDefaultObjectAccessControlsListRequest(_messages.Message):
 
 
 class StorageNotificationsDeleteRequest(_messages.Message):
-  """A StorageNotificationsDeleteRequest object.
+  r"""A StorageNotificationsDeleteRequest object.
 
   Fields:
     notification: ID of the notification to delete.
@@ -1336,11 +1337,11 @@ class StorageNotificationsDeleteRequest(_messages.Message):
 
 
 class StorageNotificationsDeleteResponse(_messages.Message):
-  """An empty StorageNotificationsDelete response."""
+  r"""An empty StorageNotificationsDelete response."""
 
 
 class StorageNotificationsGetRequest(_messages.Message):
-  """A StorageNotificationsGetRequest object.
+  r"""A StorageNotificationsGetRequest object.
 
   Fields:
     notification: Notification ID
@@ -1350,7 +1351,7 @@ class StorageNotificationsGetRequest(_messages.Message):
 
 
 class StorageNotificationsListRequest(_messages.Message):
-  """A StorageNotificationsListRequest object.
+  r"""A StorageNotificationsListRequest object.
 
   Fields:
     bucket: Name of a GCS bucket.
@@ -1360,7 +1361,7 @@ class StorageNotificationsListRequest(_messages.Message):
 
 
 class StorageObjectAccessControlsDeleteRequest(_messages.Message):
-  """A StorageObjectAccessControlsDeleteRequest object.
+  r"""A StorageObjectAccessControlsDeleteRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1380,11 +1381,11 @@ class StorageObjectAccessControlsDeleteRequest(_messages.Message):
 
 
 class StorageObjectAccessControlsDeleteResponse(_messages.Message):
-  """An empty StorageObjectAccessControlsDelete response."""
+  r"""An empty StorageObjectAccessControlsDelete response."""
 
 
 class StorageObjectAccessControlsGetRequest(_messages.Message):
-  """A StorageObjectAccessControlsGetRequest object.
+  r"""A StorageObjectAccessControlsGetRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1404,7 +1405,7 @@ class StorageObjectAccessControlsGetRequest(_messages.Message):
 
 
 class StorageObjectAccessControlsInsertRequest(_messages.Message):
-  """A StorageObjectAccessControlsInsertRequest object.
+  r"""A StorageObjectAccessControlsInsertRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1423,7 +1424,7 @@ class StorageObjectAccessControlsInsertRequest(_messages.Message):
 
 
 class StorageObjectAccessControlsListRequest(_messages.Message):
-  """A StorageObjectAccessControlsListRequest object.
+  r"""A StorageObjectAccessControlsListRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1439,7 +1440,7 @@ class StorageObjectAccessControlsListRequest(_messages.Message):
 
 
 class StorageObjectAccessControlsPatchRequest(_messages.Message):
-  """A StorageObjectAccessControlsPatchRequest object.
+  r"""A StorageObjectAccessControlsPatchRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1462,7 +1463,7 @@ class StorageObjectAccessControlsPatchRequest(_messages.Message):
 
 
 class StorageObjectAccessControlsUpdateRequest(_messages.Message):
-  """A StorageObjectAccessControlsUpdateRequest object.
+  r"""A StorageObjectAccessControlsUpdateRequest object.
 
   Fields:
     bucket: Name of a bucket.
@@ -1485,7 +1486,7 @@ class StorageObjectAccessControlsUpdateRequest(_messages.Message):
 
 
 class StorageObjectsComposeRequest(_messages.Message):
-  """A StorageObjectsComposeRequest object.
+  r"""A StorageObjectsComposeRequest object.
 
   Enums:
     DestinationPredefinedAclValueValuesEnum: Apply a predefined set of access
@@ -1506,7 +1507,7 @@ class StorageObjectsComposeRequest(_messages.Message):
   """
 
   class DestinationPredefinedAclValueValuesEnum(_messages.Enum):
-    """Apply a predefined set of access controls to the destination object.
+    r"""Apply a predefined set of access controls to the destination object.
 
     Values:
       authenticatedRead: Object owner gets OWNER access, and
@@ -1537,7 +1538,7 @@ class StorageObjectsComposeRequest(_messages.Message):
 
 
 class StorageObjectsCopyRequest(_messages.Message):
-  """A StorageObjectsCopyRequest object.
+  r"""A StorageObjectsCopyRequest object.
 
   Enums:
     DestinationPredefinedAclValueValuesEnum: Apply a predefined set of access
@@ -1585,7 +1586,7 @@ class StorageObjectsCopyRequest(_messages.Message):
   """
 
   class DestinationPredefinedAclValueValuesEnum(_messages.Enum):
-    """Apply a predefined set of access controls to the destination object.
+    r"""Apply a predefined set of access controls to the destination object.
 
     Values:
       authenticatedRead: Object owner gets OWNER access, and
@@ -1608,7 +1609,7 @@ class StorageObjectsCopyRequest(_messages.Message):
     publicRead = 5
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Set of properties to return. Defaults to noAcl, unless the object
+    r"""Set of properties to return. Defaults to noAcl, unless the object
     resource specifies the acl property, when it defaults to full.
 
     Values:
@@ -1637,7 +1638,7 @@ class StorageObjectsCopyRequest(_messages.Message):
 
 
 class StorageObjectsDeleteRequest(_messages.Message):
-  """A StorageObjectsDeleteRequest object.
+  r"""A StorageObjectsDeleteRequest object.
 
   Fields:
     bucket: Name of the bucket in which the object resides.
@@ -1665,11 +1666,11 @@ class StorageObjectsDeleteRequest(_messages.Message):
 
 
 class StorageObjectsDeleteResponse(_messages.Message):
-  """An empty StorageObjectsDelete response."""
+  r"""An empty StorageObjectsDelete response."""
 
 
 class StorageObjectsGetIamPolicyRequest(_messages.Message):
-  """A StorageObjectsGetIamPolicyRequest object.
+  r"""A StorageObjectsGetIamPolicyRequest object.
 
   Fields:
     bucket: Name of the bucket in which the object resides.
@@ -1685,7 +1686,7 @@ class StorageObjectsGetIamPolicyRequest(_messages.Message):
 
 
 class StorageObjectsGetRequest(_messages.Message):
-  """A StorageObjectsGetRequest object.
+  r"""A StorageObjectsGetRequest object.
 
   Enums:
     ProjectionValueValuesEnum: Set of properties to return. Defaults to noAcl.
@@ -1708,7 +1709,7 @@ class StorageObjectsGetRequest(_messages.Message):
   """
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Set of properties to return. Defaults to noAcl.
+    r"""Set of properties to return. Defaults to noAcl.
 
     Values:
       full: Include all properties.
@@ -1728,7 +1729,7 @@ class StorageObjectsGetRequest(_messages.Message):
 
 
 class StorageObjectsInsertRequest(_messages.Message):
-  """A StorageObjectsInsertRequest object.
+  r"""A StorageObjectsInsertRequest object.
 
   Enums:
     PredefinedAclValueValuesEnum: Apply a predefined set of access controls to
@@ -1764,7 +1765,7 @@ class StorageObjectsInsertRequest(_messages.Message):
   """
 
   class PredefinedAclValueValuesEnum(_messages.Enum):
-    """Apply a predefined set of access controls to this object.
+    r"""Apply a predefined set of access controls to this object.
 
     Values:
       authenticatedRead: Object owner gets OWNER access, and
@@ -1787,7 +1788,7 @@ class StorageObjectsInsertRequest(_messages.Message):
     publicRead = 5
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Set of properties to return. Defaults to noAcl, unless the object
+    r"""Set of properties to return. Defaults to noAcl, unless the object
     resource specifies the acl property, when it defaults to full.
 
     Values:
@@ -1810,7 +1811,7 @@ class StorageObjectsInsertRequest(_messages.Message):
 
 
 class StorageObjectsListRequest(_messages.Message):
-  """A StorageObjectsListRequest object.
+  r"""A StorageObjectsListRequest object.
 
   Enums:
     ProjectionValueValuesEnum: Set of properties to return. Defaults to noAcl.
@@ -1834,7 +1835,7 @@ class StorageObjectsListRequest(_messages.Message):
   """
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Set of properties to return. Defaults to noAcl.
+    r"""Set of properties to return. Defaults to noAcl.
 
     Values:
       full: Include all properties.
@@ -1853,7 +1854,7 @@ class StorageObjectsListRequest(_messages.Message):
 
 
 class StorageObjectsPatchRequest(_messages.Message):
-  """A StorageObjectsPatchRequest object.
+  r"""A StorageObjectsPatchRequest object.
 
   Enums:
     PredefinedAclValueValuesEnum: Apply a predefined set of access controls to
@@ -1880,7 +1881,7 @@ class StorageObjectsPatchRequest(_messages.Message):
   """
 
   class PredefinedAclValueValuesEnum(_messages.Enum):
-    """Apply a predefined set of access controls to this object.
+    r"""Apply a predefined set of access controls to this object.
 
     Values:
       authenticatedRead: Object owner gets OWNER access, and
@@ -1903,7 +1904,7 @@ class StorageObjectsPatchRequest(_messages.Message):
     publicRead = 5
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Set of properties to return. Defaults to full.
+    r"""Set of properties to return. Defaults to full.
 
     Values:
       full: Include all properties.
@@ -1925,7 +1926,7 @@ class StorageObjectsPatchRequest(_messages.Message):
 
 
 class StorageObjectsRewriteRequest(_messages.Message):
-  """A StorageObjectsRewriteRequest object.
+  r"""A StorageObjectsRewriteRequest object.
 
   Enums:
     DestinationPredefinedAclValueValuesEnum: Apply a predefined set of access
@@ -1985,7 +1986,7 @@ class StorageObjectsRewriteRequest(_messages.Message):
   """
 
   class DestinationPredefinedAclValueValuesEnum(_messages.Enum):
-    """Apply a predefined set of access controls to the destination object.
+    r"""Apply a predefined set of access controls to the destination object.
 
     Values:
       authenticatedRead: Object owner gets OWNER access, and
@@ -2008,7 +2009,7 @@ class StorageObjectsRewriteRequest(_messages.Message):
     publicRead = 5
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Set of properties to return. Defaults to noAcl, unless the object
+    r"""Set of properties to return. Defaults to noAcl, unless the object
     resource specifies the acl property, when it defaults to full.
 
     Values:
@@ -2039,7 +2040,7 @@ class StorageObjectsRewriteRequest(_messages.Message):
 
 
 class StorageObjectsSetIamPolicyRequest(_messages.Message):
-  """A StorageObjectsSetIamPolicyRequest object.
+  r"""A StorageObjectsSetIamPolicyRequest object.
 
   Fields:
     bucket: Name of the bucket in which the object resides.
@@ -2057,7 +2058,7 @@ class StorageObjectsSetIamPolicyRequest(_messages.Message):
 
 
 class StorageObjectsTestIamPermissionsRequest(_messages.Message):
-  """A StorageObjectsTestIamPermissionsRequest object.
+  r"""A StorageObjectsTestIamPermissionsRequest object.
 
   Fields:
     bucket: Name of the bucket in which the object resides.
@@ -2075,7 +2076,7 @@ class StorageObjectsTestIamPermissionsRequest(_messages.Message):
 
 
 class StorageObjectsUpdateRequest(_messages.Message):
-  """A StorageObjectsUpdateRequest object.
+  r"""A StorageObjectsUpdateRequest object.
 
   Enums:
     PredefinedAclValueValuesEnum: Apply a predefined set of access controls to
@@ -2102,7 +2103,7 @@ class StorageObjectsUpdateRequest(_messages.Message):
   """
 
   class PredefinedAclValueValuesEnum(_messages.Enum):
-    """Apply a predefined set of access controls to this object.
+    r"""Apply a predefined set of access controls to this object.
 
     Values:
       authenticatedRead: Object owner gets OWNER access, and
@@ -2125,7 +2126,7 @@ class StorageObjectsUpdateRequest(_messages.Message):
     publicRead = 5
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Set of properties to return. Defaults to full.
+    r"""Set of properties to return. Defaults to full.
 
     Values:
       full: Include all properties.
@@ -2147,7 +2148,7 @@ class StorageObjectsUpdateRequest(_messages.Message):
 
 
 class StorageObjectsWatchAllRequest(_messages.Message):
-  """A StorageObjectsWatchAllRequest object.
+  r"""A StorageObjectsWatchAllRequest object.
 
   Enums:
     ProjectionValueValuesEnum: Set of properties to return. Defaults to noAcl.
@@ -2172,7 +2173,7 @@ class StorageObjectsWatchAllRequest(_messages.Message):
   """
 
   class ProjectionValueValuesEnum(_messages.Enum):
-    """Set of properties to return. Defaults to noAcl.
+    r"""Set of properties to return. Defaults to noAcl.
 
     Values:
       full: Include all properties.
@@ -2192,7 +2193,7 @@ class StorageObjectsWatchAllRequest(_messages.Message):
 
 
 class TestIamPermissionsResponse(_messages.Message):
-  """A storage.(buckets|objects).testIamPermissions response.
+  r"""A storage.(buckets|objects).testIamPermissions response.
 
   Fields:
     kind: The kind of item this is.


### PR DESCRIPTION
In Python 3, illegal escape sequences in strings throw deprecation
warnings. Since there are no restrictions on the descriptions of the
docstrings, converting docstrings to raw strings will prevent
deprecation warnings from being thrown.

For more information: https://bugs.python.org/issue27364