### PR TITLE
Fix lint errors in apitools and pin pycodestyle to version 2.4.0.

### DIFF
--- a/apitools/base/protorpclite/test_util.py
+++ b/apitools/base/protorpclite/test_util.py
@@ -88,7 +88,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual(params1, params2)
 
     def assertIterEqual(self, iter1, iter2):
-        """Check that two iterators or iterables are equal independent of order.
+        """Check two iterators or iterables are equal independent of order.
 
         Similar to Python 2.7 assertItemsEqual.  Named differently in order to
         avoid potential conflict.

--- a/apitools/base/protorpclite/util.py
+++ b/apitools/base/protorpclite/util.py
@@ -53,7 +53,7 @@ _TIME_ZONE_RE = re.compile(_TIME_ZONE_RE_STRING, re.IGNORECASE | re.VERBOSE)
 
 
 def positional(max_positional_args):
-    """A decorator to declare that only the first N arguments may be positional.
+    """A decorator that declares only the first N arguments may be positional.
 
     This decorator makes it easy to support Python 3 style keyword-only
     parameters. For example, in Python 3 it is possible to write:

--- a/apitools/base/py/batch.py
+++ b/apitools/base/py/batch.py
@@ -123,7 +123,7 @@ class BatchApiRequest(object):
             return response_code not in self.__retryable_codes
 
         def HandleResponse(self, http_response, exception):
-            """Handles an incoming http response to the request in http_request.
+            """Handles incoming http response to the request in http_request.
 
             This is intended to be used as a callback function for
             BatchHttpRequest.Add.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [pycodestyle]
 count = False
-ignore = E722,E741
+ignore = E722,E741,W504

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ commands =
     pip install six google-apitools
     pycodestyle apitools
 deps =
-    pycodestyle
+    pycodestyle==2.4.0
     pylint
     unittest2
 


### PR DESCRIPTION
Fixes #217.