### PR TITLE
Use UTF-8 instead of ASCII for the StringField validator encoding

### DIFF
--- a/apitools/base/protorpclite/messages.py
+++ b/apitools/base/protorpclite/messages.py
@@ -1520,12 +1520,12 @@ class StringField(Field):
         """Validate StringField allowing for str and unicode.
 
         Raises:
-          ValidationError if a str value is not 7-bit ascii.
+          ValidationError if a str value is not UTF-8.
         """
         # If value is str is it considered valid.  Satisfies "required=True".
         if isinstance(value, bytes):
             try:
-                six.text_type(value, 'ascii')
+                six.text_type(value, 'UTF-8')
             except UnicodeDecodeError as err:
                 try:
                     _ = self.name

--- a/apitools/base/protorpclite/messages.py
+++ b/apitools/base/protorpclite/messages.py
@@ -1531,11 +1531,11 @@ class StringField(Field):
                     _ = self.name
                 except AttributeError:
                     validation_error = ValidationError(
-                        'Field encountered non-ASCII string %r: %s' % (value,
+                        'Field encountered non-UTF-8 string %r: %s' % (value,
                                                                        err))
                 else:
                     validation_error = ValidationError(
-                        'Field %s encountered non-ASCII string %r: %s' % (
+                        'Field %s encountered non-UTF-8 string %r: %s' % (
                             self.name, value, err))
                     validation_error.field_name = self.name
                 raise validation_error

--- a/apitools/base/protorpclite/messages_test.py
+++ b/apitools/base/protorpclite/messages_test.py
@@ -616,7 +616,7 @@ class FieldTest(test_util.TestCase):
             messages.InvalidDefaultError,
             r"Invalid default value for StringField:.*: "
             r"Field encountered non-UTF-8 string .*: "
-            r"'utf.*8' codec can't decode byte 0xc3 in position 0: "
+            r"'utf.?8' codec can't decode byte 0xc3 in position 0: "
             r"invalid continuation byte",
             messages.StringField, 1, default=b'\xc3\x28')
 

--- a/apitools/base/protorpclite/messages_test.py
+++ b/apitools/base/protorpclite/messages_test.py
@@ -616,7 +616,7 @@ class FieldTest(test_util.TestCase):
             messages.InvalidDefaultError,
             r"Invalid default value for StringField:.*: "
             r"Field encountered non-UTF-8 string .*: "
-            r"'utf8' codec can't decode byte 0xc3 in position 0: "
+            r"'utf.*8' codec can't decode byte 0xc3 in position 0: "
             r"invalid continuation byte",
             messages.StringField, 1, default=b'\xc3\x28')
 

--- a/apitools/base/protorpclite/messages_test.py
+++ b/apitools/base/protorpclite/messages_test.py
@@ -615,10 +615,10 @@ class FieldTest(test_util.TestCase):
         self.assertRaisesWithRegexpMatch(
             messages.InvalidDefaultError,
             r"Invalid default value for StringField:.*: "
-            r"Field encountered non-ASCII string .*: "
-            r"'ascii' codec can't decode byte 0x89 in position 0: "
-            r"ordinal not in range",
-            messages.StringField, 1, default=b'\x89')
+            r"Field encountered non-UTF-8 string .*: "
+            r"'utf8' codec can't decode byte 0xc3 in position 0: "
+            r"invalid continuation byte",
+            messages.StringField, 1, default=b'\xc3\x28')
 
     def testDefaultFields_InvalidSingle(self):
         """Test default field is correct type (invalid single)."""
@@ -1159,17 +1159,6 @@ class FieldTest(test_util.TestCase):
         m2 = MyMessage()
         m2.my_field = None
         self.assertEquals(m1, m2)
-
-    def testNonAsciiStr(self):
-        """Test validation fails for non-ascii StringField values."""
-        class Thing(messages.Message):
-            string_field = messages.StringField(2)
-
-        thing = Thing()
-        self.assertRaisesWithRegexpMatch(
-            messages.ValidationError,
-            'Field string_field encountered non-ASCII string',
-            setattr, thing, 'string_field', test_util.BINARY)
 
 
 class MessageTest(test_util.TestCase):

--- a/apitools/base/protorpclite/messages_test.py
+++ b/apitools/base/protorpclite/messages_test.py
@@ -1160,6 +1160,17 @@ class FieldTest(test_util.TestCase):
         m2.my_field = None
         self.assertEquals(m1, m2)
 
+    def testNonUtf8Str(self):
+        """Test validation fails for non-UTF-8 StringField values."""
+        class Thing(messages.Message):
+            string_field = messages.StringField(2)
+
+        thing = Thing()
+        self.assertRaisesWithRegexpMatch(
+            messages.ValidationError,
+            'Field string_field encountered non-UTF-8 string',
+            setattr, thing, 'string_field', test_util.BINARY)
+
 
 class MessageTest(test_util.TestCase):
     """Tests for message class."""


### PR DESCRIPTION
Use UTF-8 instead of ASCII for the StringField validator encoding.