### PR TITLE
Pass empty strings instead of None to urllib.parse.urlunsplit.

### DIFF
--- a/apitools/base/py/batch.py
+++ b/apitools/base/py/batch.py
@@ -322,7 +322,7 @@ class BatchHttpRequest(object):
         request_line = urllib_parse.urlunsplit(
             ('', '', parsed.path, parsed.query, ''))
         if not isinstance(request_line, six.text_type):
-          request_line = request_line.decode('utf-8')
+            request_line = request_line.decode('utf-8')
         status_line = u' '.join((
             request.http_method,
             request_line,

--- a/apitools/base/py/batch.py
+++ b/apitools/base/py/batch.py
@@ -320,10 +320,12 @@ class BatchHttpRequest(object):
         # Construct status line
         parsed = urllib_parse.urlsplit(request.url)
         request_line = urllib_parse.urlunsplit(
-            (None, None, parsed.path, parsed.query, None))
+            ('', '', parsed.path, parsed.query, ''))
+        if not isinstance(request_line, six.text_type):
+          request_line = request_line.decode('utf-8')
         status_line = u' '.join((
             request.http_method,
-            request_line.decode('utf-8'),
+            request_line,
             u'HTTP/1.1\n'
         ))
         major, minor = request.headers.get(

--- a/apitools/base/py/batch_test.py
+++ b/apitools/base/py/batch_test.py
@@ -427,6 +427,24 @@ class BatchTest(unittest2.TestCase):
         self.assertEqual(expected_serialized_request,
                          batch_request._SerializeRequest(request))
 
+    def testSerializeRequestWithPathAndQueryParams(self):
+        request = http_wrapper.Request(
+            url='my/path?query=param',
+            body='Hello World',
+            headers={'content-type': 'protocol/version'})
+        expected_serialized_request = '\n'.join([
+            'GET my/path?query=param HTTP/1.1',
+            'Content-Type: protocol/version',
+            'MIME-Version: 1.0',
+            'content-length: 11',
+            'Host: ',
+            '',
+            'Hello World',
+        ])
+        batch_request = batch.BatchHttpRequest('https://www.example.com')
+        self.assertEqual(expected_serialized_request,
+                         batch_request._SerializeRequest(request))
+
     def testDeserializeRequest(self):
         serialized_payload = '\n'.join([
             'GET  HTTP/1.1',


### PR DESCRIPTION
This is because urllib_parse.urlunsplit takes a single tuple as an argument
and uses the first index in the tuple to determine if any
encoding needs to be done on the rest of the arguments in the tuple. If None is
passed as the first argument and then a string is passed as a later
argument in the tuple, urlunsplit throws an error.

This also adds a test for this particular code path.