### PR TITLE
Update batchPath" in storage_v1.json to point to service-specific endpoint

### DIFF
--- a/samples/storage_sample/storage_v1.json
+++ b/samples/storage_sample/storage_v1.json
@@ -22,7 +22,7 @@
  "basePath": "/storage/v1/",
  "rootUrl": "https://www.googleapis.com/",
  "servicePath": "storage/v1/",
- "batchPath": "batch",
+ "batchPath": "batch/storage/v1",
  "parameters": {
   "alt": {
    "type": "string",


### PR DESCRIPTION
Background: https://developers.googleblog.com/2018/03/discontinuing-support-for-json-rpc-and.html

GCS now has a service-specific endpoint, which is what's advertised in our discovery document (https://www.googleapis.com/discovery/v1/apis/storage/v1/rest)
We should update the sample here to point to that endpoint.