### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/samples/storage_sample/downloads_test.py
+++ b/samples/storage_sample/downloads_test.py
@@ -171,7 +171,7 @@ class DownloadsTest(unittest.TestCase):
     def testSerializedDownload(self):
 
         def _ProgressCallback(unused_response, download_object):
-            print 'Progress %s' % download_object.progress
+            print('Progress %s' % download_object.progress)
 
         file_contents = self.__GetTestdataFileContents('fifteen_byte_file')
         object_name = os.path.join(self._TESTDATA_PREFIX, 'fifteen_byte_file')


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.