### PR TITLE
Old style exceptions --> New style for Python 3

### DIFF
--- a/ez_setup.py
+++ b/ez_setup.py
@@ -91,7 +91,7 @@ def use_setuptools(
         return do_download()       
     try:
         pkg_resources.require("setuptools>="+version); return
-    except pkg_resources.VersionConflict, e:
+    except pkg_resources.VersionConflict as e:
         if was_imported:
             print >>sys.stderr, (
             "The required version of setuptools (>=%s) is not available, and\n"


### PR DESCRIPTION
Old style exceptions are a syntax error in Python 3.