### PR TITLE
Define long() in Python 3

### DIFF
--- a/apitools/base/protorpclite/messages_test.py
+++ b/apitools/base/protorpclite/messages_test.py
@@ -39,6 +39,11 @@ from apitools.base.protorpclite import test_util
 # pylint:disable=unused-variable
 # pylint:disable=too-many-lines
 
+try:
+  long        # Python 2
+except NameError:
+  long = int  # Python 3
+
 
 class ModuleInterfaceTest(test_util.ModuleInterfaceTest,
                           test_util.TestCase):

--- a/apitools/base/protorpclite/messages_test.py
+++ b/apitools/base/protorpclite/messages_test.py
@@ -40,9 +40,9 @@ from apitools.base.protorpclite import test_util
 # pylint:disable=too-many-lines
 
 try:
-  long        # Python 2
+    long        # Python 2
 except NameError:
-  long = int  # Python 3
+    long = int  # Python 3
 
 
 class ModuleInterfaceTest(test_util.ModuleInterfaceTest,


### PR DESCRIPTION
__long()__ was remove in Python 3 in favor of __int()__.