### PR TITLE
Builtin cmp() was removed in Python 3

### DIFF
--- a/apitools/base/protorpclite/messages.py
+++ b/apitools/base/protorpclite/messages.py
@@ -49,6 +49,12 @@ import six
 
 from apitools.base.protorpclite import util
 
+try:
+  cmp             # Python 2
+except NameError:
+  def cmp(x, y):  # Python 3
+    return (x > y) - (x < y)
+
 __all__ = [
     'MAX_ENUM_VALUE',
     'MAX_FIELD_NUMBER',

--- a/apitools/base/protorpclite/messages.py
+++ b/apitools/base/protorpclite/messages.py
@@ -50,10 +50,10 @@ import six
 from apitools.base.protorpclite import util
 
 try:
-  cmp             # Python 2
+    cmp             # Python 2
 except NameError:
-  def cmp(x, y):  # Python 3
-    return (x > y) - (x < y)
+    def cmp(x, y):  # Python 3
+        return (x > y) - (x < y)
 
 __all__ = [
     'MAX_ENUM_VALUE',

--- a/apitools/base/protorpclite/messages.py
+++ b/apitools/base/protorpclite/messages.py
@@ -49,12 +49,6 @@ import six
 
 from apitools.base.protorpclite import util
 
-try:
-    cmp             # Python 2
-except NameError:
-    def cmp(x, y):  # Python 3
-        return (x > y) - (x < y)
-
 __all__ = [
     'MAX_ENUM_VALUE',
     'MAX_FIELD_NUMBER',
@@ -481,12 +475,6 @@ class Enum(six.with_metaclass(_EnumClass, object)):
 
         """
         return self.__class__, (self.number,)
-
-    def __cmp__(self, other):
-        """Order is by number."""
-        if isinstance(other, type(self)):
-            return cmp(self.number, other.number)
-        return NotImplemented
 
     def __lt__(self, other):
         """Order is by number."""


### PR DESCRIPTION
http://portingguide.readthedocs.io/en/latest/comparisons.html#the-cmp-function