### PR TITLE
Replace imports of apitools.base.py with imports of submodules.

### DIFF
--- a/apitools/base/py/testing/mock_test.py
+++ b/apitools/base/py/testing/mock_test.py
@@ -21,7 +21,8 @@ import six
 
 from apitools.base.protorpclite import messages
 
-import apitools.base.py as apitools_base
+from apitools.base.py import base_api
+from apitools.base.py import exceptions
 from apitools.base.py.testing import mock
 from samples.fusiontables_sample.fusiontables_v1 import \
     fusiontables_v1_client as fusiontables
@@ -34,7 +35,7 @@ def _GetApiServices(api_client_class):
         (name, potential_service)
         for name, potential_service in six.iteritems(api_client_class.__dict__)
         if (isinstance(potential_service, type) and
-            issubclass(potential_service, apitools_base.BaseApiService)))
+            issubclass(potential_service, base_api.BaseApiService)))
 
 
 class CustomException(Exception):
@@ -55,9 +56,9 @@ class MockTest(unittest2.TestCase):
         with mock.Client(fusiontables.FusiontablesV1) as client_class:
             client_class.column.List.Expect(
                 request=1,
-                exception=apitools_base.HttpError({'status': 404}, '', ''))
+                exception=exceptions.HttpError({'status': 404}, '', ''))
             client = fusiontables.FusiontablesV1(get_credentials=False)
-            with self.assertRaises(apitools_base.HttpError):
+            with self.assertRaises(exceptions.HttpError):
                 client.column.List(1)
 
     def testMockIfAnotherException(self):

--- a/apitools/gen/extended_descriptor.py
+++ b/apitools/gen/extended_descriptor.py
@@ -36,7 +36,7 @@ import six
 from apitools.base.protorpclite import descriptor as protorpc_descriptor
 from apitools.base.protorpclite import message_types
 from apitools.base.protorpclite import messages
-import apitools.base.py as apitools_base
+from apitools.base.py import extra_types
 
 
 class ExtendedEnumValueDescriptor(messages.Message):
@@ -507,7 +507,7 @@ def _PrintFields(fields, printer):
             field_type = message_field
         elif field.type_name == 'extra_types.DateField':
             printed_field_info['module'] = 'extra_types'
-            field_type = apitools_base.DateField
+            field_type = extra_types.DateField
         else:
             field_type = messages.Field.lookup_field_type_by_variant(
                 field.variant)

--- a/samples/storage_sample/downloads_test.py
+++ b/samples/storage_sample/downloads_test.py
@@ -25,7 +25,7 @@ import unittest
 
 import six
 
-import apitools.base.py as apitools_base
+from apitools.base.py import exceptions
 import storage
 
 _CLIENT = None
@@ -81,7 +81,7 @@ class DownloadsTest(unittest.TestCase):
 
     def testObjectDoesNotExist(self):
         self.__ResetDownload(auto_transfer=True)
-        with self.assertRaises(apitools_base.HttpError):
+        with self.assertRaises(exceptions.HttpError):
             self.__GetFile(self.__GetRequest('nonexistent_file'))
 
     def testAutoTransfer(self):

--- a/samples/storage_sample/uploads_test.py
+++ b/samples/storage_sample/uploads_test.py
@@ -27,7 +27,7 @@ import unittest
 
 import six
 
-import apitools.base.py as apitools_base
+from apitools.base.py import transfer
 import storage
 
 _CLIENT = None
@@ -148,12 +148,12 @@ class UploadsTest(unittest.TestCase):
         # Pretend the process died, and resume with a new attempt at the
         # same upload.
         upload_data = json.dumps(self.__upload.serialization_data)
-        second_upload_attempt = apitools_base.Upload.FromData(
+        second_upload_attempt = transfer.Upload.FromData(
             self.__buffer, upload_data, self.__upload.http)
         second_upload_attempt._Upload__SendChunk(0)
         self.assertEqual(second_upload_attempt.chunksize, self.__buffer.tell())
         # Simulate a third try, and stream from there.
-        final_upload_attempt = apitools_base.Upload.FromData(
+        final_upload_attempt = transfer.Upload.FromData(
             self.__buffer, upload_data, self.__upload.http)
         final_upload_attempt.StreamInChunks()
         self.assertEqual(size, self.__buffer.tell())
@@ -161,7 +161,7 @@ class UploadsTest(unittest.TestCase):
         object_info = self.__client.objects.Get(self.__GetRequest(filename))
         self.assertEqual(size, object_info.size)
         # Confirm that a new attempt successfully does nothing.
-        completed_upload_attempt = apitools_base.Upload.FromData(
+        completed_upload_attempt = transfer.Upload.FromData(
             self.__buffer, upload_data, self.__upload.http)
         self.assertTrue(completed_upload_attempt.complete)
         completed_upload_attempt.StreamInChunks()


### PR DESCRIPTION
Prerequisite for addressing #232. Updates the only 4 imports in apitools that depend on the wildcard imports in `apitools/base/py/__init__.py` to instead import directly from the submodules with the desired classes.