### PR TITLE
Reorganize encoding.py so it doesn't rely on imports in __init__.py

### DIFF
--- a/apitools/base/py/encoding.py
+++ b/apitools/base/py/encoding.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+#
+# Copyright 2015 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Common code for converting proto to other formats, such as JSON."""
+
+# pylint:disable=wildcard-import
+from apitools.base.py.encoding_helper import *
+import apitools.base.py.extra_types  # pylint:disable=unused-import
+
+
+# pylint:disable=undefined-all-variable
+__all__ = [
+    'CopyProtoMessage',
+    'JsonToMessage',
+    'MessageToJson',
+    'DictToMessage',
+    'MessageToDict',
+    'PyValueToMessage',
+    'MessageToPyValue',
+    'MessageToRepr',
+    'GetCustomJsonFieldMapping',
+    'AddCustomJsonFieldMapping',
+    'GetCustomJsonEnumMapping',
+    'AddCustomJsonEnumMapping',
+]

--- a/apitools/base/py/encoding_helper.py
+++ b/apitools/base/py/encoding_helper.py
@@ -28,21 +28,6 @@ from apitools.base.protorpclite import messages
 from apitools.base.protorpclite import protojson
 from apitools.base.py import exceptions
 
-__all__ = [
-    'CopyProtoMessage',
-    'JsonToMessage',
-    'MessageToJson',
-    'DictToMessage',
-    'MessageToDict',
-    'PyValueToMessage',
-    'MessageToPyValue',
-    'MessageToRepr',
-    'GetCustomJsonFieldMapping',
-    'AddCustomJsonFieldMapping',
-    'GetCustomJsonEnumMapping',
-    'AddCustomJsonEnumMapping',
-]
-
 
 _Codec = collections.namedtuple('_Codec', ['encoder', 'decoder'])
 CodecResult = collections.namedtuple('CodecResult', ['value', 'complete'])

--- a/apitools/base/py/encoding_helper.py
+++ b/apitools/base/py/encoding_helper.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2015 Google Inc.
+# Copyright 2018 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/apitools/base/py/extra_types.py
+++ b/apitools/base/py/extra_types.py
@@ -26,7 +26,7 @@ import six
 from apitools.base.protorpclite import message_types
 from apitools.base.protorpclite import messages
 from apitools.base.protorpclite import protojson
-from apitools.base.py import encoding
+from apitools.base.py import encoding_helper as encoding
 from apitools.base.py import exceptions
 from apitools.base.py import util
 

--- a/apitools/base/py/util.py
+++ b/apitools/base/py/util.py
@@ -27,7 +27,7 @@ import six.moves.urllib.parse as urllib_parse
 import six.moves.urllib.request as urllib_request
 
 from apitools.base.protorpclite import messages
-from apitools.base.py import encoding
+from apitools.base.py import encoding_helper as encoding
 from apitools.base.py import exceptions
 
 __all__ = [


### PR DESCRIPTION
Prerequisite for addressing #232.

Currently, when you import `apitools.base.py.encoding`, it triggers the imports in `apitools/base/py/__init__.py`. This includes importing `extra_types.py`, which makes patches to `encoding`, such as:
```python
encoding.RegisterCustomMessageCodec(
    encoder=JsonProtoEncoder, decoder=_JsonToJsonValue)(JsonValue)
```
That means that if you remove the imports in `__init__.py`, then `encoding` behaves differently because `extra_types` isn't imported. This change reorganizes `encoding.py`, so that whenever it is imported, `extra_types.py` is also imported.