### PR TITLE
Clean service names in the registry so as not to write syntax errors

### DIFF
--- a/apitools/gen/service_registry.py
+++ b/apitools/gen/service_registry.py
@@ -443,6 +443,7 @@ class ServiceRegistry(object):
 
     def AddServiceFromResource(self, service_name, methods):
         """Add a new service named service_name with the given methods."""
+        service_name = self.__names.CleanName(service_name)
         method_descriptions = methods.get('methods', {})
         method_info_map = collections.OrderedDict()
         items = sorted(method_descriptions.items())


### PR DESCRIPTION
Generating a client with a dash in the service name produced invalid code.