### PR TITLE
Fixes issue where forced retry would cause timeout.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ matrix:
   - python: "3.5"
     env: TOX_ENV=py35-oauth2client4
 install:
+  # See https://github.com/aws/base64io-python/issues/4#issuecomment-397857642
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then pip install virtualenv==15.2.0; fi
   - pip install tox
   - pip install . --allow-external argparse
 script: tox -e $TOX_ENV

--- a/apitools/base/py/transfer_test.py
+++ b/apitools/base/py/transfer_test.py
@@ -451,7 +451,7 @@ class UploadTest(unittest2.TestCase):
         # Ensure data is compressed
         self.assertLess(len(self.request.body), len(self.sample_data))
         # Ensure uncompressed data includes the sample data.
-        with gzip.GzipFile(fileobj=self.request.body) as f:
+        with gzip.GzipFile(fileobj=six.BytesIO(self.request.body)) as f:
             original = f.read()
             self.assertTrue(self.sample_data in original)
 
@@ -479,7 +479,7 @@ class UploadTest(unittest2.TestCase):
         # Ensure data is compressed
         self.assertLess(len(self.request.body), len(self.sample_data))
         # Ensure uncompressed data includes the sample data.
-        with gzip.GzipFile(fileobj=self.request.body) as f:
+        with gzip.GzipFile(fileobj=six.BytesIO(self.request.body)) as f:
             original = f.read()
             self.assertTrue(self.sample_data in original)
 


### PR DESCRIPTION
Side note: This also fixes TravisCI builds that have been failing on
Python 3.3.

This fixes https://issuetracker.google.com/issues/111486730 -- if
using an expired access token from a cache, a forced retry will occur
and attempt to re-read bytes from the compression stream. This fails
because the bytes have already been consumed, and the server hangs
waiting for us to send the intended bytes from the first attempt. In
gsutil, this manifested itself as an SSLError with the message 'The read
operation timed out'.

While I'd normally avoid reading in an entire stream all at once, this
edge case should be fine because:

- We start off the entire (uncompressed) byte sequence anyway to begin
  with and only create the stream because that's the format needed for
  compression.
- This is only used for uploads using the SIMPLE strategy. Note that
  this isn't an issue for resumable uploads, since the first request in
  that flow is to create the resumable upload session (which isn't a
  media transfer request, thus it doesn't try to consume any bytes from
  the stream), so the credential refresh (if needed) would happen on that
  request.