### PR TITLE
 Adding type checking of method request and response mocks

### DIFF
--- a/apitools/base/py/testing/mock_test.py
+++ b/apitools/base/py/testing/mock_test.py
@@ -46,7 +46,8 @@ class MockTest(unittest2.TestCase):
 
     def testMockFusionBasic(self):
         with mock.Client(fusiontables.FusiontablesV1) as client_class:
-            client_class.column.List.Expect(request=1, response=2)
+            client_class.column.List.Expect(request=1, response=2,
+                enable_type_checking=False)
             client = fusiontables.FusiontablesV1(get_credentials=False)
             self.assertEqual(client.column.List(1), 2)
             with self.assertRaises(mock.UnexpectedRequestException):
@@ -56,29 +57,66 @@ class MockTest(unittest2.TestCase):
         with mock.Client(fusiontables.FusiontablesV1) as client_class:
             client_class.column.List.Expect(
                 request=1,
-                exception=exceptions.HttpError({'status': 404}, '', ''))
+                exception=exceptions.HttpError({'status': 404}, '', ''),
+                enable_type_checking=False)
             client = fusiontables.FusiontablesV1(get_credentials=False)
             with self.assertRaises(exceptions.HttpError):
                 client.column.List(1)
 
+    def testMockFusionTypeChecking(self):
+        with mock.Client(fusiontables.FusiontablesV1) as client_class:
+            messages = client_class.MESSAGES_MODULE
+            client_class.column.List.Expect(
+                messages.FusiontablesColumnListRequest(tableId='foo'),
+                messages.ColumnList(items=[], totalItems=0))
+            client = fusiontables.FusiontablesV1(get_credentials=False)
+            self.assertEqual(
+                client.column.List(
+                    messages.FusiontablesColumnListRequest(tableId='foo')),
+                messages.ColumnList(items=[], totalItems=0))
+
+    def testMockFusionTypeCheckingErrors(self):
+        with mock.Client(fusiontables.FusiontablesV1) as client_class:
+            messages = client_class.MESSAGES_MODULE
+            # Wrong request type.
+            with self.assertRaises(exceptions.ConfigurationValueError):
+                client_class.column.List.Expect(
+                    messages.FusiontablesColumnInsertRequest(),
+                    messages.ColumnList(items=[], totalItems=0))
+            # Wrong response type.
+            with self.assertRaises(exceptions.ConfigurationValueError):
+                client_class.column.List.Expect(
+                    messages.FusiontablesColumnListRequest(tableId='foo'),
+                    messages.Column())
+            # No error if checking is disabled.
+            client_class.column.List.Expect(
+                messages.FusiontablesColumnInsertRequest(),
+                messages.Column(),
+                enable_type_checking=False)
+
     def testMockIfAnotherException(self):
         with self.assertRaises(CustomException):
             with mock.Client(fusiontables.FusiontablesV1) as client_class:
-                client_class.column.List.Expect(request=1, response=2)
+                client_class.column.List.Expect(request=1, response=2,
+                enable_type_checking=False)
                 raise CustomException('Something when wrong')
 
     def testMockFusionOrder(self):
         with mock.Client(fusiontables.FusiontablesV1) as client_class:
-            client_class.column.List.Expect(request=1, response=2)
-            client_class.column.List.Expect(request=2, response=1)
+            client_class.column.List.Expect(request=1, response=2,
+                enable_type_checking=False)
+            client_class.column.List.Expect(request=2, response=1,
+                enable_type_checking=False)
             client = fusiontables.FusiontablesV1(get_credentials=False)
             self.assertEqual(client.column.List(1), 2)
             self.assertEqual(client.column.List(2), 1)
 
     def testMockFusionWrongOrder(self):
         with mock.Client(fusiontables.FusiontablesV1) as client_class:
-            client_class.column.List.Expect(request=1, response=2)
-            client_class.column.List.Expect(request=2, response=1)
+            client_class.column.List.Expect(request=1, response=2,
+                enable_type_checking=False)
+            client_class.column.List.Expect(request=2, response=1,
+                enable_type_checking=False)
             client = fusiontables.FusiontablesV1(get_credentials=False)
             with self.assertRaises(mock.UnexpectedRequestException):
                 self.assertEqual(client.column.List(2), 1)
@@ -87,7 +125,8 @@ class MockTest(unittest2.TestCase):
 
     def testMockFusionTooMany(self):
         with mock.Client(fusiontables.FusiontablesV1) as client_class:
-            client_class.column.List.Expect(request=1, response=2)
+            client_class.column.List.Expect(request=1, response=2,
+                enable_type_checking=False)
             client = fusiontables.FusiontablesV1(get_credentials=False)
             self.assertEqual(client.column.List(1), 2)
             with self.assertRaises(mock.UnexpectedRequestException):
@@ -96,8 +135,10 @@ class MockTest(unittest2.TestCase):
     def testMockFusionTooFew(self):
         with self.assertRaises(mock.ExpectedRequestsException):
             with mock.Client(fusiontables.FusiontablesV1) as client_class:
-                client_class.column.List.Expect(request=1, response=2)
-                client_class.column.List.Expect(request=2, response=1)
+                client_class.column.List.Expect(request=1, response=2,
+                enable_type_checking=False)
+                client_class.column.List.Expect(request=2, response=1,
+                enable_type_checking=False)
                 client = fusiontables.FusiontablesV1(get_credentials=False)
                 self.assertEqual(client.column.List(1), 2)
 


### PR DESCRIPTION
Currently these mocks are not checked to ensure that the messages being expected and returned could actually occur. It is generally invalid to use types that don't match, but if you want to, you can set enable_type_checking=False on your expect statement.