### PR TITLE
Fix bug in handling chunked transfer-encoding downloads

### DIFF
--- a/apitools/base/py/transfer.py
+++ b/apitools/base/py/transfer.py
@@ -336,10 +336,12 @@ class Download(_Transfer):
         if end is not None:
             if start < 0:
                 raise exceptions.TransferInvalidError(
-                    'Cannot have end index with negative start index')
+                    'Cannot have end index with negative start index '
+                    + '[start=%d, end=%d]' % (start, end))
             elif start >= self.total_size:
                 raise exceptions.TransferInvalidError(
-                    'Cannot have start index greater than total size')
+                    'Cannot have start index greater than total size '
+                    + '[start=%d, total_size=%d]' % (start, self.total_size))
             end = min(end, self.total_size - 1)
             if end < start:
                 raise exceptions.TransferInvalidError(
@@ -481,6 +483,13 @@ class Download(_Transfer):
             response = self.__ProcessResponse(response)
             progress += response.length
             if response.length == 0:
+                if response.status_code == http_client.OK:
+                    # There can legitimately be no Content-Length header sent in
+                    # some cases (e.g., when there's a Transfer-Encoding header)
+                    # and if this was a 200 response (as opposed to 206 Partial
+                    # Content) we know we're done now without looping further on
+                    # received length.
+                    return
                 raise exceptions.TransferRetryError(
                     'Zero bytes unexpectedly returned in download response')
 


### PR DESCRIPTION
This pull fixes a bug reported by a GCS customer (https://cases.corp.google.com/Client.html#e7-6969000023324)

The problem happens because GetRange in apitools/base/py/transfer.py raises an exception if response.length == 0, which can legitimately happen with chunked transfer-encoding downloads, per RFC 2616 section 4.4, #3

See more complete discussion at b/117280402

Also added logging detail in the case where the start index is greater than total size (which is how this bug showed up to the user).