### PR TITLE
Handle encoded response content in batch http request in Python 3

### DIFF
--- a/apitools/base/py/base_api.py
+++ b/apitools/base/py/base_api.py
@@ -610,7 +610,7 @@ class BaseApiService(object):
                 request_url=http_response.request_url)
 
         content = http_response.content
-        if self._client.response_encoding:
+        if self._client.response_encoding and isinstance(content, bytes):
             content = content.decode(self._client.response_encoding)
 
         if self.__client.response_type_model == 'json':

--- a/apitools/base/py/batch.py
+++ b/apitools/base/py/batch.py
@@ -140,16 +140,19 @@ class BatchApiRequest(object):
                 self.__response = self.__service.ProcessHttpResponse(
                     self.__method_config, self.__http_response)
 
-    def __init__(self, batch_url=None, retryable_codes=None):
+    def __init__(self, batch_url=None, retryable_codes=None,
+                 response_encoding=None):
         """Initialize a batch API request object.
 
         Args:
           batch_url: Base URL for batch API calls.
           retryable_codes: A list of integer HTTP codes that can be retried.
+          response_encoding: The encoding type of response content.
         """
         self.api_requests = []
         self.retryable_codes = retryable_codes or []
         self.batch_url = batch_url or 'https://www.googleapis.com/batch'
+        self.response_encoding = response_encoding
 
     def Add(self, service, method, request, global_params=None):
         """Add a request to the batch.
@@ -213,7 +216,8 @@ class BatchApiRequest(object):
                 # incomplete requests.
                 batch_http_request = BatchHttpRequest(
                     batch_url=self.batch_url,
-                    callback=batch_request_callback
+                    callback=batch_request_callback,
+                    response_encoding=self.response_encoding
                 )
                 for request in itertools.islice(requests,
                                                 i, i + batch_size):
@@ -240,7 +244,7 @@ class BatchHttpRequest(object):
 
     """Batches multiple http_wrapper.Request objects into a single request."""
 
-    def __init__(self, batch_url, callback=None):
+    def __init__(self, batch_url, callback=None, response_encoding=None):
         """Constructor for a BatchHttpRequest.
 
         Args:
@@ -251,6 +255,7 @@ class BatchHttpRequest(object):
               apiclient.errors.HttpError exception object if an HTTP error
               occurred while processing the request, or None if no error
               occurred.
+          response_encoding: The encoding type of response content.
         """
         # Endpoint to which these requests are sent.
         self.__batch_url = batch_url
@@ -258,6 +263,9 @@ class BatchHttpRequest(object):
         # Global callback to be called for each individual response in the
         # batch.
         self.__callback = callback
+
+        # Response content will be decoded if this is provided.
+        self.__response_encoding = response_encoding
 
         # List of requests, responses and handlers.
         self.__request_response_handlers = {}
@@ -447,8 +455,8 @@ class BatchHttpRequest(object):
         header = 'content-type: %s\r\n\r\n' % response.info['content-type']
 
         content = response.content
-        if isinstance(content, bytes):
-            content = response.content.decode('utf-8')
+        if isinstance(content, bytes) and self.__response_encoding:
+            content = response.content.decode(self.__response_encoding)
 
         parser = email_parser.Parser()
         mime_response = parser.parsestr(header + content)

--- a/apitools/base/py/batch.py
+++ b/apitools/base/py/batch.py
@@ -446,8 +446,12 @@ class BatchHttpRequest(object):
         # Prepend with a content-type header so Parser can handle it.
         header = 'content-type: %s\r\n\r\n' % response.info['content-type']
 
+        content = response.content
+        if isinstance(content, bytes):
+            content = response.content.decode('utf-8')
+
         parser = email_parser.Parser()
-        mime_response = parser.parsestr(header + response.content)
+        mime_response = parser.parsestr(header + content)
 
         if not mime_response.is_multipart():
             raise exceptions.BatchError(

--- a/apitools/base/py/batch_test.py
+++ b/apitools/base/py/batch_test.py
@@ -582,6 +582,48 @@ class BatchTest(unittest2.TestCase):
             self.assertIn(
                 'Second response', test_responses['2'].response.content)
 
+    def testInternalExecuteWithEncodedResponse(self):
+        with mock.patch.object(http_wrapper, 'MakeRequest',
+                               autospec=True) as mock_request:
+            self.__ConfigureMock(
+                mock_request,
+                http_wrapper.Request('https://www.example.com', 'POST', {
+                    'content-type': 'multipart/mixed; boundary="None"',
+                    'content-length': 274,
+                }, 'x' * 274),
+                http_wrapper.Response({
+                    'status': '200',
+                    'content-type': 'multipart/mixed; boundary="boundary"',
+                }, textwrap.dedent("""\
+                --boundary
+                content-type: text/plain
+                content-id: <id+1>
+
+                HTTP/1.1 200 OK
+                response
+
+                --boundary--""").encode('utf-8'), None))
+
+            test_request = {
+                '1': batch.RequestResponseAndHandler(
+                    http_wrapper.Request(body='first'), None, None),
+            }
+
+            batch_request = batch.BatchHttpRequest('https://www.example.com')
+            batch_request._BatchHttpRequest__request_response_handlers = (
+                test_request)
+
+            batch_request._Execute(FakeHttp())
+
+            test_responses = (
+                batch_request._BatchHttpRequest__request_response_handlers)
+
+            self.assertEqual(http_client.OK,
+                             test_responses['1'].response.status_code)
+
+            self.assertIn(
+                'response', test_responses['1'].response.content)
+
     def testPublicExecute(self):
 
         def LocalCallback(response, exception):

--- a/apitools/base/py/batch_test.py
+++ b/apitools/base/py/batch_test.py
@@ -609,7 +609,8 @@ class BatchTest(unittest2.TestCase):
                     http_wrapper.Request(body='first'), None, None),
             }
 
-            batch_request = batch.BatchHttpRequest('https://www.example.com')
+            batch_request = batch.BatchHttpRequest('https://www.example.com',
+                                                   response_encoding='utf-8')
             batch_request._BatchHttpRequest__request_response_handlers = (
                 test_request)
 


### PR DESCRIPTION
Fix issue reported in https://github.com/google/apitools/issues/249.

The problem happens in Python 3 when execute a http request and encoded content is returned. This breaks `email_parser.Parser().parsestr()` call in `batch.py` since the function argument only accepted `str` (not bytes). There is a callback `__ProcessHttpResponse` that handles encoded response content but the call happens later.