### PR TITLE
Travis CI: Lint with Flake8 instead of pycodestyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 sudo: false
 matrix:
   include:
-  - python: "2.7"
+  - python: "3.5"
     env: TOX_ENV=lint
   - python: "2.7"
     env: TOX_ENV=py27-oauth2client1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: python
-sudo: false
 matrix:
   include:
-  - python: "3.5"
+  - python: "2.7"
+    env: TOX_ENV=lint
+  - python: "3.7"
+    dist: xenial
     env: TOX_ENV=lint
   - python: "2.7"
     env: TOX_ENV=py27-oauth2client1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,2 @@
-[pycodestyle]
-count = False
-ignore = E722,E741,W504
+[flake8]
+ignore = E111,E722,E741,W504

--- a/tox.ini
+++ b/tox.ini
@@ -21,12 +21,15 @@ passenv = TRAVIS*
 
 [testenv:lint]
 basepython =
-    python2.7
+    python3.5
 commands =
     pip install six google-apitools
-    pycodestyle apitools
+    # stop the build if there are Python syntax errors or undefined names
+    flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    flake8 . --count --exit-zero --max-complexity=10 --statistics
 deps =
-    pycodestyle==2.4.0
+    flake8==3.6.0
     pylint
     unittest2
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,8 +20,6 @@ commands =
 passenv = TRAVIS*
 
 [testenv:lint]
-basepython =
-    python3.5
 commands =
     pip install six google-apitools
     # stop the build if there are Python syntax errors or undefined names


### PR DESCRIPTION
Blocked by #231 and #252

This PR finds __Python syntax errors and undefined names__ that have the potential to halt the Python 3 runtime.  The Travis CI tests will fail until the fixes in ~#228 #229 #230~ #231 #252 (or similar) are applied.

https://pypi.org/project/flake8 is a superset of 
* PyFlakes
* pycodestyle
* Ned Batchelder’s McCabe script

Output: https://travis-ci.org/google/apitools/jobs/471520183#L510

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree