### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/ez_setup.py
+++ b/ez_setup.py
@@ -60,9 +60,9 @@ def _validate_md5(egg_name, data):
         digest = md5(data).hexdigest()
         if digest != md5_data[egg_name]:
             print(
-                "md5 validation of %s failed!  (Possible download problem?)"
-                % egg_name
-            , file=sys.stderr)
+                "md5 validation of %s failed!  (Possible download problem?)" % (
+                    egg_name),
+                file=sys.stderr)
             sys.exit(2)
     return data
 
@@ -94,12 +94,13 @@ def use_setuptools(
         pkg_resources.require("setuptools>="+version); return
     except pkg_resources.VersionConflict as e:
         if was_imported:
-            print((
-            "The required version of setuptools (>=%s) is not available, and\n"
-            "can't be installed while this script is running. Please install\n"
-            " a more recent version first, using 'easy_install -U setuptools'."
-            "\n\n(Currently using %r)"
-            ) % (version, e.args[0]), file=sys.stderr)
+            print(
+                "The required version of setuptools (>=%s) is not available,\n"
+                "and can't be installed while this script is running. Please\n"
+                "install a more recent version first, using\n"
+                "'easy_install -U setuptools'.\n\n(Currently using %r)" % (
+                    version, e.args[0]),
+                file=sys.stderr)
             sys.exit(2)
     except pkg_resources.DistributionNotFound:
         pass
@@ -206,9 +207,10 @@ def main(argv, version=DEFAULT_VERSION):
     else:
         if setuptools.__version__ == '0.0.1':
             print(
-            "You have an obsolete version of setuptools installed.  Please\n"
-            "remove it from your system entirely before rerunning this script."
-            , file=sys.stderr)
+                "You have an obsolete version of setuptools installed. Please\n"
+                "remove it from your system entirely before rerunning this "
+                "script.",
+                file=sys.stderr)
             sys.exit(2)
 
     req = "setuptools>="+version
@@ -227,7 +229,8 @@ def main(argv, version=DEFAULT_VERSION):
             from setuptools.command.easy_install import main
             main(argv)
         else:
-            print("Setuptools version",version,"or greater has been installed.")
+            print("Setuptools version %s or greater has been installed."
+                  % version)
             print('(Run "ez_setup.py -U setuptools" to reinstall or upgrade.)')
 
 def update_md5(filenames):

--- a/ez_setup.py
+++ b/ez_setup.py
@@ -28,6 +28,7 @@ the appropriate options to ``use_setuptools()``.
 
 This file can also be run as a script to install or upgrade setuptools.
 """
+from __future__ import print_function
 import sys
 DEFAULT_VERSION = "0.6c11"
 DEFAULT_URL     = "http://pypi.python.org/packages/%s/s/setuptools/" % sys.version[:3]
@@ -58,10 +59,10 @@ def _validate_md5(egg_name, data):
     if egg_name in md5_data:
         digest = md5(data).hexdigest()
         if digest != md5_data[egg_name]:
-            print >>sys.stderr, (
+            print((
                 "md5 validation of %s failed!  (Possible download problem?)"
                 % egg_name
-            )
+            ), file=sys.stderr)
             sys.exit(2)
     return data
 
@@ -93,12 +94,12 @@ def use_setuptools(
         pkg_resources.require("setuptools>="+version); return
     except pkg_resources.VersionConflict as e:
         if was_imported:
-            print >>sys.stderr, (
+            print((
             "The required version of setuptools (>=%s) is not available, and\n"
             "can't be installed while this script is running. Please install\n"
             " a more recent version first, using 'easy_install -U setuptools'."
             "\n\n(Currently using %r)"
-            ) % (version, e.args[0])
+            ) % (version, e.args[0]), file=sys.stderr)
             sys.exit(2)
     except pkg_resources.DistributionNotFound:
         pass
@@ -204,10 +205,10 @@ def main(argv, version=DEFAULT_VERSION):
                 os.unlink(egg)
     else:
         if setuptools.__version__ == '0.0.1':
-            print >>sys.stderr, (
+            print((
             "You have an obsolete version of setuptools installed.  Please\n"
             "remove it from your system entirely before rerunning this script."
-            )
+            ), file=sys.stderr)
             sys.exit(2)
 
     req = "setuptools>="+version
@@ -226,8 +227,8 @@ def main(argv, version=DEFAULT_VERSION):
             from setuptools.command.easy_install import main
             main(argv)
         else:
-            print "Setuptools version",version,"or greater has been installed."
-            print '(Run "ez_setup.py -U setuptools" to reinstall or upgrade.)'
+            print("Setuptools version",version,"or greater has been installed.")
+            print('(Run "ez_setup.py -U setuptools" to reinstall or upgrade.)')
 
 def update_md5(filenames):
     """Update our built-in md5 registry"""
@@ -250,7 +251,7 @@ def update_md5(filenames):
 
     match = re.search("\nmd5_data = {\n([^}]+)}", src)
     if not match:
-        print >>sys.stderr, "Internal error!"
+        print("Internal error!", file=sys.stderr)
         sys.exit(2)
 
     src = src[:match.start(1)] + repl + src[match.end(1):]

--- a/ez_setup.py
+++ b/ez_setup.py
@@ -59,10 +59,10 @@ def _validate_md5(egg_name, data):
     if egg_name in md5_data:
         digest = md5(data).hexdigest()
         if digest != md5_data[egg_name]:
-            print((
+            print(
                 "md5 validation of %s failed!  (Possible download problem?)"
                 % egg_name
-            ), file=sys.stderr)
+            , file=sys.stderr)
             sys.exit(2)
     return data
 
@@ -205,10 +205,10 @@ def main(argv, version=DEFAULT_VERSION):
                 os.unlink(egg)
     else:
         if setuptools.__version__ == '0.0.1':
-            print((
+            print(
             "You have an obsolete version of setuptools installed.  Please\n"
             "remove it from your system entirely before rerunning this script."
-            ), file=sys.stderr)
+            , file=sys.stderr)
             sys.exit(2)
 
     req = "setuptools>="+version


### PR DESCRIPTION
Like #228  Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.