### PR TITLE
Fix URL query param field mappings for enum fields

### DIFF
--- a/apitools/base/py/util.py
+++ b/apitools/base/py/util.py
@@ -224,6 +224,7 @@ def MapRequestParams(params, request_type):
             request_type, python_name=param_name)
         if field_remapping is not None:
             new_params[field_remapping] = new_params.pop(param_name)
+            param_name = field_remapping
         if isinstance(value, messages.Enum):
             new_params[param_name] = encoding.GetCustomJsonEnumMapping(
                 type(value), python_name=str(value)) or str(value)

--- a/apitools/base/py/util_test.py
+++ b/apitools/base/py/util_test.py
@@ -37,13 +37,13 @@ class MessageWithRemappings(messages.Message):
 
     str_field = messages.StringField(1)
     enum_field = messages.EnumField('AnEnum', 2)
-    enum_field_with_remapping = messages.EnumField('AnEnum', 3)
+    enum_field_remapping = messages.EnumField('AnEnum', 3)
 
 
 encoding.AddCustomJsonFieldMapping(
     MessageWithRemappings, 'str_field', 'path_field')
 encoding.AddCustomJsonFieldMapping(
-    MessageWithRemappings, 'enum_field_with_remapping', 'enum_field_remapped')
+    MessageWithRemappings, 'enum_field_remapping', 'enum_field_remapped')
 encoding.AddCustomJsonEnumMapping(
     MessageWithRemappings.AnEnum, 'value_one', 'ONE')
 
@@ -181,7 +181,7 @@ class UtilTest(unittest2.TestCase):
         params = {
             'str_field': 'foo',
             'enum_field': MessageWithRemappings.AnEnum.value_one,
-            'enum_field_with_remapping': MessageWithRemappings.AnEnum.value_one,
+            'enum_field_remapping': MessageWithRemappings.AnEnum.value_one,
         }
         remapped_params = {
             'path_field': 'foo',

--- a/apitools/base/py/util_test.py
+++ b/apitools/base/py/util_test.py
@@ -37,10 +37,13 @@ class MessageWithRemappings(messages.Message):
 
     str_field = messages.StringField(1)
     enum_field = messages.EnumField('AnEnum', 2)
+    enum_field_with_remapping = messages.EnumField('AnEnum', 3)
 
 
 encoding.AddCustomJsonFieldMapping(
     MessageWithRemappings, 'str_field', 'path_field')
+encoding.AddCustomJsonFieldMapping(
+    MessageWithRemappings, 'enum_field_with_remapping', 'enum_field_remapped')
 encoding.AddCustomJsonEnumMapping(
     MessageWithRemappings.AnEnum, 'value_one', 'ONE')
 
@@ -178,10 +181,12 @@ class UtilTest(unittest2.TestCase):
         params = {
             'str_field': 'foo',
             'enum_field': MessageWithRemappings.AnEnum.value_one,
+            'enum_field_with_remapping': MessageWithRemappings.AnEnum.value_one,
         }
         remapped_params = {
             'path_field': 'foo',
             'enum_field': 'ONE',
+            'enum_field_remapped': 'ONE',
         }
         self.assertEqual(remapped_params,
                          util.MapRequestParams(params, MessageWithRemappings))


### PR DESCRIPTION
When converting params into query params, we had a bug where enums would be mapped to their original param name. Instead we should set the mapped value to the mapped param name, too.