### PR TITLE
Add __hash__ to class Message to make it hashable in Python 3

### DIFF
--- a/apitools/base/protorpclite/messages.py
+++ b/apitools/base/protorpclite/messages.py
@@ -758,6 +758,8 @@ class Message(six.with_metaclass(_MessageClass, object)):
 
     """
 
+    __hash__ = object.__hash__
+
     def __init__(self, **kwargs):
         """Initialize internal messages state.
 


### PR DESCRIPTION
The class Message defines a __eq__ method, but, does not define a
__hash__ method. This makes it unhashable in Python 3. But, it is
hashable in Python 2.