### PR TITLE
Python 2 / 3 compatibility changes

### DIFF
--- a/apitools/base/protorpclite/protojson.py
+++ b/apitools/base/protorpclite/protojson.py
@@ -206,6 +206,7 @@ class ProtoJson(object):
           ValueError: If encoded_message is not valid JSON.
           messages.ValidationError if merged message is not initialized.
         """
+        encoded_message = six.ensure_str(encoded_message)
         if not encoded_message.strip():
             return message_type()
 

--- a/apitools/base/py/encoding_helper.py
+++ b/apitools/base/py/encoding_helper.py
@@ -528,7 +528,7 @@ def _ProcessUnknownEnums(message, encoded_message):
     """
     if not encoded_message:
         return message
-    decoded_message = json.loads(encoded_message)
+    decoded_message = json.loads(six.ensure_str(encoded_message))
     for field in message.all_fields():
         if (isinstance(field, messages.EnumField) and
                 field.name in decoded_message and
@@ -556,7 +556,7 @@ def _ProcessUnknownMessages(message, encoded_message):
     """
     if not encoded_message:
         return message
-    decoded_message = json.loads(encoded_message)
+    decoded_message = json.loads(six.ensure_str(encoded_message))
     message_fields = [x.name for x in message.all_fields()] + list(
         message.all_unrecognized_fields())
     missing_fields = [x for x in decoded_message.keys()

--- a/apitools/base/py/transfer.py
+++ b/apitools/base/py/transfer.py
@@ -426,7 +426,7 @@ class Download(_Transfer):
                 raise exceptions.TransferRetryError(response.content)
         if response.status_code in (http_client.OK,
                                     http_client.PARTIAL_CONTENT):
-            self.stream.write(response.content)
+            self.stream.write(six.ensure_binary(response.content))
             self.__progress += response.length
             if response.info and 'content-encoding' in response.info:
                 # TODO(craigcitro): Handle the case where this changes over a

--- a/apitools/base/py/transfer.py
+++ b/apitools/base/py/transfer.py
@@ -423,10 +423,10 @@ class Download(_Transfer):
                                         http_client.NOT_FOUND):
                 raise exceptions.HttpError.FromResponse(response)
             else:
-                raise exceptions.TransferRetryError(six.ensure_str(response.content))
+                raise exceptions.TransferRetryError(response.content)
         if response.status_code in (http_client.OK,
                                     http_client.PARTIAL_CONTENT):
-            self.stream.write(six.ensure_str(response.content))
+            self.stream.write(six.ensure_binary(response.content))
             self.__progress += response.length
             if response.info and 'content-encoding' in response.info:
                 # TODO(craigcitro): Handle the case where this changes over a

--- a/apitools/base/py/transfer.py
+++ b/apitools/base/py/transfer.py
@@ -544,6 +544,25 @@ class Download(_Transfer):
         self._ExecuteCallback(finish_callback, response)
 
 
+if six.PY3:
+    class MultipartBytesGenerator(email_generator.BytesGenerator):
+        """Generates a bytes version of a Message object tree for multipart messages
+        This is a BytesGenerator that has been modified to not attempt line
+        termination character modification in the bytes payload. Known to work
+        with the compat32 policy only. It may work on others, but not tested.
+        The outfp object must accept bytes in its write method.
+        """
+        def _handle_text(self, msg):
+            # If the string has surrogates the original source was bytes, so
+            # just write it back out.
+            if msg._payload is None:
+                return
+            self.write(msg._payload)
+
+        # Default body handler
+        _writeBody = _handle_text
+
+
 class Upload(_Transfer):
 
     """Data for a single Upload.
@@ -796,7 +815,7 @@ class Upload(_Transfer):
         #       `> ` to `From ` lines.
         fp = six.BytesIO()
         if six.PY3:
-            generator_class = email_generator.BytesGenerator
+            generator_class = MultipartBytesGenerator
         else:
             generator_class = email_generator.Generator
         g = generator_class(fp, mangle_from_=False)

--- a/apitools/base/py/transfer.py
+++ b/apitools/base/py/transfer.py
@@ -426,7 +426,10 @@ class Download(_Transfer):
                 raise exceptions.TransferRetryError(response.content)
         if response.status_code in (http_client.OK,
                                     http_client.PARTIAL_CONTENT):
-            self.stream.write(six.ensure_binary(response.content))
+            try:
+                self.stream.write(six.ensure_binary(response.content))
+            except TypeError:
+                self.stream.write(six.ensure_text(response.content))
             self.__progress += response.length
             if response.info and 'content-encoding' in response.info:
                 # TODO(craigcitro): Handle the case where this changes over a

--- a/apitools/base/py/transfer.py
+++ b/apitools/base/py/transfer.py
@@ -423,10 +423,10 @@ class Download(_Transfer):
                                         http_client.NOT_FOUND):
                 raise exceptions.HttpError.FromResponse(response)
             else:
-                raise exceptions.TransferRetryError(response.content)
+                raise exceptions.TransferRetryError(six.ensure_str(response.content))
         if response.status_code in (http_client.OK,
                                     http_client.PARTIAL_CONTENT):
-            self.stream.write(six.ensure_binary(response.content))
+            self.stream.write(six.ensure_str(response.content))
             self.__progress += response.length
             if response.info and 'content-encoding' in response.info:
                 # TODO(craigcitro): Handle the case where this changes over a

--- a/apitools/base/py/transfer.py
+++ b/apitools/base/py/transfer.py
@@ -546,11 +546,12 @@ class Download(_Transfer):
 
 if six.PY3:
     class MultipartBytesGenerator(email_generator.BytesGenerator):
-        """Generates a bytes version of a Message object tree for multipart messages
+        """Generates a bytes Message object tree for multipart messages
+
         This is a BytesGenerator that has been modified to not attempt line
-        termination character modification in the bytes payload. Known to work
-        with the compat32 policy only. It may work on others, but not tested.
-        The outfp object must accept bytes in its write method.
+        termination character modification in the bytes payload. Known to
+        work with the compat32 policy only. It may work on others, but not
+        tested. The outfp object must accept bytes in its write method.
         """
         def _handle_text(self, msg):
             # If the string has surrogates the original source was bytes, so

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ REQUIRED_PACKAGES = [
     'httplib2>=0.8',
     'fasteners>=0.14',
     'oauth2client>=1.4.12',
-    'six>=1.9.0',
+    'six>=1.12.0',
     ]
 
 CLI_PACKAGES = [

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ except ImportError:
 # Configure the required packages and scripts to install, depending on
 # Python version and OS.
 REQUIRED_PACKAGES = [
-    'httplib2>=0.12',
+    'httplib2>=0.8',
     'fasteners>=0.14',
     'oauth2client>=1.4.12',
     'six>=1.9.0',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ except ImportError:
 # Configure the required packages and scripts to install, depending on
 # Python version and OS.
 REQUIRED_PACKAGES = [
-    'httplib2>=0.8',
+    'httplib2>=0.12',
     'fasteners>=0.14',
     'oauth2client>=1.4.12',
     'six>=1.9.0',


### PR DESCRIPTION
@walkerjoe and I made several small fixes to help apitools be cross-compatible with Python 2 and 3. These issues were identified while working on making [gsutil's py-six-current branch](https://github.com/GoogleCloudPlatform/gsutil/tree/py-six-current) compatible with Python 2.7 and 3.5+. This was done under the guidance of @houglum 

Notably, we're using the [six](https://github.com/benjaminp/six) library to help ensure byte strings vs unicode strings work together nicely.

Email generator had some small text encoding issues with generating text in Python 3.5+, so we added `MultipartBytesGenerator` method to alleviate the issue.

Let us know if you have any questions about these changes! :slightly_smiling_face: 