### PR TITLE
Drop support for EOL Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 matrix:
   include:
   - python: "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ matrix:
     env: TOX_ENV=py27-oauth2client3
   - python: "2.7"
     env: TOX_ENV=py27-oauth2client4
-  - python: "3.4"
-    env: TOX_ENV=py34-oauth2client4
   - python: "3.5"
     env: TOX_ENV=py35-oauth2client1
   - python: "3.5"

--- a/apitools/base/protorpclite/descriptor_test.py
+++ b/apitools/base/protorpclite/descriptor_test.py
@@ -18,9 +18,9 @@
 """Tests for apitools.base.protorpclite.descriptor."""
 import platform
 import types
+import unittest
 
 import six
-import unittest2
 
 from apitools.base.protorpclite import descriptor
 from apitools.base.protorpclite import message_types
@@ -78,8 +78,8 @@ class DescribeEnumTest(test_util.TestCase):
         described.check_initialized()
         self.assertEquals(expected, described)
 
-    @unittest2.skipIf('PyPy' in platform.python_implementation(),
-                      'todo: reenable this')
+    @unittest.skipIf('PyPy' in platform.python_implementation(),
+                     'todo: reenable this')
     def testEnumWithItems(self):
         class EnumWithItems(messages.Enum):
             A = 3
@@ -512,4 +512,4 @@ class DescriptorLibraryTest(test_util.TestCase):
 
 
 if __name__ == '__main__':
-    unittest2.main()
+    unittest.main()

--- a/apitools/base/protorpclite/test_util.py
+++ b/apitools/base/protorpclite/test_util.py
@@ -33,10 +33,10 @@ import os
 import re
 import socket
 import types
+import unittest
 
 import six
 from six.moves import range  # pylint: disable=redefined-builtin
-import unittest2 as unittest
 
 from apitools.base.protorpclite import message_types
 from apitools.base.protorpclite import messages

--- a/apitools/base/py/base_api_test.py
+++ b/apitools/base/py/base_api_test.py
@@ -17,11 +17,11 @@ import base64
 import datetime
 import sys
 import contextlib
+import unittest
 
 import six
 from six.moves import http_client
 from six.moves import urllib_parse
-import unittest2
 
 from apitools.base.protorpclite import message_types
 from apitools.base.protorpclite import messages
@@ -96,7 +96,7 @@ class FakeService(base_api.BaseApiService):
         super(FakeService, self).__init__(client)
 
 
-class BaseApiTest(unittest2.TestCase):
+class BaseApiTest(unittest.TestCase):
 
     def __GetFakeClient(self):
         return FakeClient('', credentials=FakeCredentials())
@@ -331,4 +331,4 @@ class BaseApiTest(unittest2.TestCase):
 
 
 if __name__ == '__main__':
-    unittest2.main()
+    unittest.main()

--- a/apitools/base/py/batch_test.py
+++ b/apitools/base/py/batch_test.py
@@ -16,12 +16,12 @@
 """Tests for apitools.base.py.batch."""
 
 import textwrap
+import unittest
 
 import mock
 from six.moves import http_client
 from six.moves import range  # pylint:disable=redefined-builtin
 from six.moves.urllib import parse
-import unittest2
 
 from apitools.base.py import batch
 from apitools.base.py import exceptions
@@ -69,7 +69,7 @@ class FakeService(object):
         return http_response
 
 
-class BatchTest(unittest2.TestCase):
+class BatchTest(unittest.TestCase):
 
     def assertUrlEqual(self, expected_url, provided_url):
 

--- a/apitools/base/py/buffered_stream_test.py
+++ b/apitools/base/py/buffered_stream_test.py
@@ -16,15 +16,15 @@
 """Tests for buffered_stream."""
 
 import string
+import unittest
 
 import six
-import unittest2
 
 from apitools.base.py import buffered_stream
 from apitools.base.py import exceptions
 
 
-class BufferedStreamTest(unittest2.TestCase):
+class BufferedStreamTest(unittest.TestCase):
 
     def setUp(self):
         self.stream = six.StringIO(string.ascii_letters)

--- a/apitools/base/py/compression_test.py
+++ b/apitools/base/py/compression_test.py
@@ -16,14 +16,15 @@
 
 """Tests for compression."""
 
+import unittest
+
 from apitools.base.py import compression
 from apitools.base.py import gzip
 
 import six
-import unittest2
 
 
-class CompressionTest(unittest2.TestCase):
+class CompressionTest(unittest.TestCase):
 
     def setUp(self):
         # Sample highly compressible data (~50MB).
@@ -98,7 +99,7 @@ class CompressionTest(unittest2.TestCase):
         self.assertTrue(exhausted)
 
 
-class StreamingBufferTest(unittest2.TestCase):
+class StreamingBufferTest(unittest.TestCase):
 
     def setUp(self):
         self.stream = compression.StreamingBuffer()

--- a/apitools/base/py/credentials_lib.py
+++ b/apitools/base/py/credentials_lib.py
@@ -17,6 +17,7 @@
 """Common credentials classes and constructors."""
 from __future__ import print_function
 
+import argparse
 import contextlib
 import datetime
 import json
@@ -512,10 +513,6 @@ def _GetRunFlowFlags(args=None):
     # since they're bringing their own credentials. So we just allow this
     # to fail with an ImportError in those cases.
     #
-    # TODO(craigcitro): Move this import back to the top when we drop
-    # python 2.6 support (eg when gsutil does).
-    import argparse
-
     parser = argparse.ArgumentParser(parents=[tools.argparser])
     # Get command line argparse flags.
     flags, _ = parser.parse_known_args(args=args)

--- a/apitools/base/py/credentials_lib_test.py
+++ b/apitools/base/py/credentials_lib_test.py
@@ -17,10 +17,10 @@ import json
 import os.path
 import shutil
 import tempfile
+import unittest
 
 import mock
 import six
-import unittest2
 
 from apitools.base.py import credentials_lib
 from apitools.base.py import util
@@ -43,7 +43,7 @@ class MetadataMock(object):
         self.fail('Unexpected HTTP request to %s' % request_url)
 
 
-class CredentialsLibTest(unittest2.TestCase):
+class CredentialsLibTest(unittest.TestCase):
 
     def _RunGceAssertionCredentials(
             self, service_account_name=None, scopes=None, cache_filename=None):
@@ -153,7 +153,7 @@ class CredentialsLibTest(unittest2.TestCase):
         self.assertIsNone(creds)
 
 
-class TestGetRunFlowFlags(unittest2.TestCase):
+class TestGetRunFlowFlags(unittest.TestCase):
 
     def setUp(self):
         self._flags_actual = credentials_lib.FLAGS

--- a/apitools/base/py/encoding_test.py
+++ b/apitools/base/py/encoding_test.py
@@ -17,8 +17,7 @@ import base64
 import datetime
 import json
 import sys
-
-import unittest2
+import unittest
 
 from apitools.base.protorpclite import message_types
 from apitools.base.protorpclite import messages
@@ -238,7 +237,7 @@ encoding.AddCustomJsonFieldMapping(MessageWithRemappings,
                                    'repeated_field', 'repeatedField')
 
 
-class EncodingTest(unittest2.TestCase):
+class EncodingTest(unittest.TestCase):
 
     def testCopyProtoMessage(self):
         msg = SimpleMessage(field='abc')

--- a/apitools/base/py/exceptions_test.py
+++ b/apitools/base/py/exceptions_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest2
+import unittest
 
 from apitools.base.py import exceptions
 from apitools.base.py import http_wrapper
@@ -24,7 +24,7 @@ def _MakeResponse(status_code):
         request_url='http://www.google.com')
 
 
-class HttpErrorFromResponseTest(unittest2.TestCase):
+class HttpErrorFromResponseTest(unittest.TestCase):
 
     """Tests for exceptions.HttpError.FromResponse."""
 

--- a/apitools/base/py/extra_types_test.py
+++ b/apitools/base/py/extra_types_test.py
@@ -16,8 +16,7 @@
 import datetime
 import json
 import math
-
-import unittest2
+import unittest
 
 from apitools.base.protorpclite import messages
 from apitools.base.py import encoding
@@ -25,7 +24,7 @@ from apitools.base.py import exceptions
 from apitools.base.py import extra_types
 
 
-class ExtraTypesTest(unittest2.TestCase):
+class ExtraTypesTest(unittest.TestCase):
 
     def assertRoundTrip(self, value):
         if isinstance(value, extra_types._JSON_PROTO_TYPES):

--- a/apitools/base/py/http_wrapper_test.py
+++ b/apitools/base/py/http_wrapper_test.py
@@ -15,10 +15,10 @@
 
 """Tests for http_wrapper."""
 import socket
+import unittest
 
 import httplib2
 from six.moves import http_client
-import unittest2
 
 from mock import patch
 
@@ -57,7 +57,7 @@ class RaisesExceptionOnLen(object):
         return 1
 
 
-class HttpWrapperTest(unittest2.TestCase):
+class HttpWrapperTest(unittest.TestCase):
 
     def testRequestBodyUsesLengthProperty(self):
         http_wrapper.Request(body=RaisesExceptionOnLen())
@@ -65,8 +65,8 @@ class HttpWrapperTest(unittest2.TestCase):
     def testRequestBodyWithLen(self):
         http_wrapper.Request(body='burrito')
 
-    @unittest2.skipIf(not _TOKEN_REFRESH_STATUS_AVAILABLE,
-                      'oauth2client<1.5 lacks HttpAccessTokenRefreshError.')
+    @unittest.skipIf(not _TOKEN_REFRESH_STATUS_AVAILABLE,
+                     'oauth2client<1.5 lacks HttpAccessTokenRefreshError.')
     def testExceptionHandlerHttpAccessTokenError(self):
         exception_arg = HttpAccessTokenRefreshError(status=503)
         retry_args = http_wrapper.ExceptionRetryArgs(
@@ -80,8 +80,8 @@ class HttpWrapperTest(unittest2.TestCase):
             http_wrapper.HandleExceptionsAndRebuildHttpConnections(
                 retry_args)
 
-    @unittest2.skipIf(not _TOKEN_REFRESH_STATUS_AVAILABLE,
-                      'oauth2client<1.5 lacks HttpAccessTokenRefreshError.')
+    @unittest.skipIf(not _TOKEN_REFRESH_STATUS_AVAILABLE,
+                     'oauth2client<1.5 lacks HttpAccessTokenRefreshError.')
     def testExceptionHandlerHttpAccessTokenErrorRaises(self):
         exception_arg = HttpAccessTokenRefreshError(status=200)
         retry_args = http_wrapper.ExceptionRetryArgs(

--- a/apitools/base/py/list_pager_test.py
+++ b/apitools/base/py/list_pager_test.py
@@ -34,7 +34,7 @@ class Example(object):
         self.c = 'ccc'
 
 
-class GetterSetterTest(unittest2.TestCase):
+class GetterSetterTest(unittest.TestCase):
 
     def testGetattrNested(self):
         o = Example()
@@ -53,7 +53,7 @@ class GetterSetterTest(unittest2.TestCase):
         self.assertEqual(o.c, 'CCC')
 
 
-class ListPagerTest(unittest2.TestCase):
+class ListPagerTest(unittest.TestCase):
 
     def _AssertInstanceSequence(self, results, n):
         counter = 0

--- a/apitools/base/py/list_pager_test.py
+++ b/apitools/base/py/list_pager_test.py
@@ -15,7 +15,7 @@
 
 """Tests for list_pager."""
 
-import unittest2
+import unittest
 
 from apitools.base.py import list_pager
 from apitools.base.py.testing import mock
@@ -27,7 +27,7 @@ from samples.iam_sample.iam_v1 import iam_v1_client as iam_client
 from samples.iam_sample.iam_v1 import iam_v1_messages as iam_messages
 
 
-class ListPagerTest(unittest2.TestCase):
+class ListPagerTest(unittest.TestCase):
 
     def _AssertInstanceSequence(self, results, n):
         counter = 0
@@ -243,7 +243,7 @@ class ListPagerTest(unittest2.TestCase):
         self._AssertInstanceSequence(results, 3)
 
 
-class ListPagerAttributeTest(unittest2.TestCase):
+class ListPagerAttributeTest(unittest.TestCase):
 
     def setUp(self):
         self.mocked_client = mock.Client(iam_client.IamV1)

--- a/apitools/base/py/stream_slice_test.py
+++ b/apitools/base/py/stream_slice_test.py
@@ -16,15 +16,15 @@
 """Tests for stream_slice."""
 
 import string
+import unittest
 
 import six
-import unittest2
 
 from apitools.base.py import exceptions
 from apitools.base.py import stream_slice
 
 
-class StreamSliceTest(unittest2.TestCase):
+class StreamSliceTest(unittest.TestCase):
 
     def setUp(self):
         self.stream = six.StringIO(string.ascii_letters)

--- a/apitools/base/py/testing/mock_test.py
+++ b/apitools/base/py/testing/mock_test.py
@@ -15,8 +15,9 @@
 
 """Tests for apitools.base.py.testing.mock."""
 
+import unittest
+
 import httplib2
-import unittest2
 import six
 
 from apitools.base.protorpclite import messages
@@ -42,7 +43,7 @@ class CustomException(Exception):
     pass
 
 
-class MockTest(unittest2.TestCase):
+class MockTest(unittest.TestCase):
 
     def testMockFusionBasic(self):
         with mock.Client(fusiontables.FusiontablesV1) as client_class:
@@ -220,7 +221,7 @@ class _NestedNestedMessage(messages.Message):
     nested = messages.MessageField(_NestedMessage, 1)
 
 
-class UtilTest(unittest2.TestCase):
+class UtilTest(unittest.TestCase):
 
     def testMessagesEqual(self):
         self.assertFalse(mock._MessagesEqual(

--- a/apitools/base/py/transfer_test.py
+++ b/apitools/base/py/transfer_test.py
@@ -16,12 +16,12 @@
 
 """Tests for transfer.py."""
 import string
+import unittest
 
 import httplib2
 import mock
 import six
 from six.moves import http_client
-import unittest2
 
 from apitools.base.py import base_api
 from apitools.base.py import exceptions
@@ -30,7 +30,7 @@ from apitools.base.py import http_wrapper
 from apitools.base.py import transfer
 
 
-class TransferTest(unittest2.TestCase):
+class TransferTest(unittest.TestCase):
 
     def assertRangeAndContentRangeCompatible(self, request, response):
         request_prefix = 'bytes='
@@ -311,7 +311,7 @@ class TransferTest(unittest2.TestCase):
             self.assertTrue(rewritten_upload_contents.endswith(upload_bytes))
 
 
-class UploadTest(unittest2.TestCase):
+class UploadTest(unittest.TestCase):
 
     def setUp(self):
         # Sample highly compressible data.

--- a/apitools/base/py/util_test.py
+++ b/apitools/base/py/util_test.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 """Tests for util.py."""
-import unittest2
+import unittest
 
 from apitools.base.protorpclite import messages
 from apitools.base.py import encoding
@@ -48,7 +48,7 @@ encoding.AddCustomJsonEnumMapping(
     MessageWithRemappings.AnEnum, 'value_one', 'ONE')
 
 
-class UtilTest(unittest2.TestCase):
+class UtilTest(unittest.TestCase):
 
     def testExpand(self):
         method_config_xy = MockedMethodConfig(relative_path='{x}/y/{z}',

--- a/apitools/gen/client_generation_test.py
+++ b/apitools/gen/client_generation_test.py
@@ -22,14 +22,10 @@ import six
 import subprocess
 import sys
 import tempfile
+import unittest
 
 from apitools.gen import gen_client
 from apitools.gen import test_utils
-
-if six.PY2:
-    import unittest2 as unittest
-else:
-    import unittest
 
 _API_LIST = [
     'bigquery.v2',

--- a/apitools/gen/gen_client_test.py
+++ b/apitools/gen/gen_client_test.py
@@ -16,8 +16,7 @@
 """Test for gen_client module."""
 
 import os
-
-import unittest2
+import unittest
 
 from apitools.gen import gen_client
 from apitools.gen import test_utils
@@ -32,7 +31,7 @@ def _GetContent(file_path):
         return f.read()
 
 
-class ClientGenCliTest(unittest2.TestCase):
+class ClientGenCliTest(unittest.TestCase):
 
     def testHelp_NotEnoughArguments(self):
         with self.assertRaisesRegexp(SystemExit, '0'):

--- a/apitools/gen/test_utils.py
+++ b/apitools/gen/test_utils.py
@@ -20,12 +20,12 @@ import os
 import shutil
 import sys
 import tempfile
+import unittest
 
 import six
-import unittest2
 
 
-SkipOnWindows = unittest2.skipIf(
+SkipOnWindows = unittest.skipIf(
     os.name == 'nt', 'Does not run on windows')
 
 

--- a/apitools/gen/util_test.py
+++ b/apitools/gen/util_test.py
@@ -21,13 +21,13 @@ import gzip
 import os
 import six.moves.urllib.request as urllib_request
 import tempfile
-import unittest2
+import unittest
 
 from apitools.gen import util
 from mock import MagicMock
 
 
-class NormalizeVersionTest(unittest2.TestCase):
+class NormalizeVersionTest(unittest.TestCase):
 
     def testVersions(self):
         already_valid = 'v1'
@@ -36,7 +36,7 @@ class NormalizeVersionTest(unittest2.TestCase):
         self.assertEqual('v0_1', util.NormalizeVersion(to_clean))
 
 
-class NamesTest(unittest2.TestCase):
+class NamesTest(unittest.TestCase):
 
     def testKeywords(self):
         names = util.Names([''])
@@ -81,7 +81,7 @@ def _Gzip(raw_content):
         os.unlink(f.name)
 
 
-class GetURLContentTest(unittest2.TestCase):
+class GetURLContentTest(unittest.TestCase):
 
     def testUnspecifiedContentEncoding(self):
         data = 'regular non-gzipped content'

--- a/samples/dns_sample/gen_dns_client_test.py
+++ b/samples/dns_sample/gen_dns_client_test.py
@@ -15,7 +15,8 @@
 
 """Test for generated sample module."""
 
-import unittest2
+import unittest
+
 import six
 
 from apitools.base.py import list_pager
@@ -25,7 +26,7 @@ from samples.dns_sample.dns_v1 import dns_v1_client
 from samples.dns_sample.dns_v1 import dns_v1_messages
 
 
-class DnsGenClientSanityTest(unittest2.TestCase):
+class DnsGenClientSanityTest(unittest.TestCase):
 
     def testBaseUrl(self):
         self.assertEquals(u'https://www.googleapis.com/dns/v1/',
@@ -46,7 +47,7 @@ class DnsGenClientSanityTest(unittest2.TestCase):
             'ResourceRecordSetsService']), inner_classes)
 
 
-class DnsGenClientTest(unittest2.TestCase):
+class DnsGenClientTest(unittest.TestCase):
 
     def setUp(self):
         self.mocked_dns_v1 = mock.Client(dns_v1_client.DnsV1)

--- a/samples/iam_sample/iam_client_test.py
+++ b/samples/iam_sample/iam_client_test.py
@@ -15,7 +15,8 @@
 
 """Test for generated sample module."""
 
-import unittest2
+import unittest
+
 import six
 
 from apitools.base.py.testing import mock
@@ -24,7 +25,7 @@ from samples.iam_sample.iam_v1 import iam_v1_client  # nopep8
 from samples.iam_sample.iam_v1 import iam_v1_messages  # nopep8
 
 
-class DnsGenClientSanityTest(unittest2.TestCase):
+class DnsGenClientSanityTest(unittest.TestCase):
 
     def testBaseUrl(self):
         self.assertEquals(u'https://iam.googleapis.com/',
@@ -46,7 +47,7 @@ class DnsGenClientSanityTest(unittest2.TestCase):
             'RolesService']), inner_classes)
 
 
-class IamGenClientTest(unittest2.TestCase):
+class IamGenClientTest(unittest.TestCase):
 
     def setUp(self):
         self.mocked_iam_v1 = mock.Client(iam_v1_client.IamV1)

--- a/samples/servicemanagement_sample/messages_test.py
+++ b/samples/servicemanagement_sample/messages_test.py
@@ -15,7 +15,7 @@
 
 """Test for generated servicemanagement messages module."""
 
-import unittest2
+import unittest
 
 from apitools.base.py import extra_types
 
@@ -23,7 +23,7 @@ from samples.servicemanagement_sample.servicemanagement_v1 \
     import servicemanagement_v1_messages as messages  # nopep8
 
 
-class MessagesTest(unittest2.TestCase):
+class MessagesTest(unittest.TestCase):
 
     def testInstantiateMessageWithAdditionalProperties(self):
         PROJECT_NAME = 'test-project'

--- a/samples/uptodate_check_test.py
+++ b/samples/uptodate_check_test.py
@@ -14,9 +14,9 @@
 
 import os
 import difflib
+import unittest
 
 import six
-import unittest2
 
 from apitools.gen import gen_client
 from apitools.gen import test_utils
@@ -31,7 +31,7 @@ def _GetContent(file_path):
         return f.read()
 
 
-class ClientGenCliTest(unittest2.TestCase):
+class ClientGenCliTest(unittest.TestCase):
 
     def AssertDiffEqual(self, expected, actual):
         """Like unittest.assertEqual with a diff in the exception message."""

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setuptools.setup(
     url='http://github.com/google/apitools',
     author='Craig Citro',
     author_email='craigcitro@google.com',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     # Contained modules and scripts.
     packages=setuptools.find_packages(include=['apitools']),
     entry_points={'console_scripts': CONSOLE_SCRIPTS},
@@ -87,6 +88,10 @@ setuptools.setup(
     # PyPI package information.
     classifiers=[
         'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules',
         ],

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ CLI_PACKAGES = [
 ]
 
 TESTING_PACKAGES = [
-    'unittest2>=0.5.1',
     'mock>=1.0.1',
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,6 @@
 [tox]
 envlist =
-    py26-oauth2client4
     py27-oauth2client{1,2,3,4}
-    py33-oauth2client41
-    py34-oauth2client41
     py35-oauth2client{1,2,3,4}
 
 [testenv]


### PR DESCRIPTION
Python 2.6, 3.3 and 3.4 are EOL and no longer receiving security updates (or any updates) from the core Python team.

Version | Release date | Supported until
--- | ---------- | ----------
2.6 | 2008-10-01 | 2013-10-29
3.3 | 2012-09-29 | 2017-09-29
3.4 | 2014-03-16 | 2019-03-16

Source: https://en.wikipedia.org/wiki/CPython#Version_history

They're also little used. Here's the pip installs for google-apitools from PyPI for March 2019:

| category | percent | downloads |
|----------|--------:|----------:|
|      2.7 |  89.28% |   663,944 |
|      3.6 |   9.54% |    70,984 |
|      3.5 |   0.57% |     4,217 |
|      3.7 |   0.29% |     2,144 |
| null     |   0.17% |     1,239 |
|      2.6 |   0.14% |     1,078 |
|      3.4 |   0.01% |        75 |
|      3.8 |   0.00% |         1 |
| Total    |         |   743,682 |

Source: `pypistats python_minor google-apitools --last-month # pip install pypistats`

This PR also:

* adds `python_requires` to help pip install the right version for the running Python
* adds Trove classifiers to make supported versions clear on PyPI
* Remove `unittest2` dependency, which was required for EOL Python 2.6
* `sudo` is no longer needed on Travis CI