### PR TITLE
Retain error details in string representation of errors generated by ApiTools.

### DIFF
--- a/apitools/base/py/exceptions.py
+++ b/apitools/base/py/exceptions.py
@@ -53,7 +53,8 @@ class HttpError(CommunicationError):
 
     def __init__(self, response, content, url,
                  method_config=None, request=None):
-        super(HttpError, self).__init__()
+        error_message = HttpError._build_message(response, content, url)
+        super(HttpError, self).__init__(error_message)
         self.response = response
         self.content = content
         self.url = url
@@ -61,11 +62,14 @@ class HttpError(CommunicationError):
         self.request = request
 
     def __str__(self):
-        content = self.content
+        return HttpError._build_message(self.response, self.content, self.url)
+
+    @staticmethod
+    def _build_message(response, content, url):
         if isinstance(content, bytes):
-            content = self.content.decode('ascii', 'replace')
+            content = content.decode('ascii', 'replace')
         return 'HttpError accessing <%s>: response: <%s>, content <%s>' % (
-            self.url, self.response, content)
+            url, response, content)
 
     @property
     def status_code(self):

--- a/apitools/base/py/exceptions_test.py
+++ b/apitools/base/py/exceptions_test.py
@@ -46,6 +46,12 @@ class HttpErrorFromResponseTest(unittest2.TestCase):
         self.assertIsInstance(err, exceptions.HttpForbiddenError)
         self.assertEquals(err.status_code, 403)
 
+    def testExceptionMessageIncludesErrorDetails(self):
+        err = exceptions.HttpError.FromResponse(_MakeResponse(403))
+        self.assertIn('403', repr(err))
+        self.assertIn('http://www.google.com', repr(err))
+        self.assertIn('{"field": "abc"}', repr(err))
+
     def testNotFound(self):
         err = exceptions.HttpError.FromResponse(_MakeResponse(404))
         self.assertIsInstance(err, exceptions.HttpError)


### PR DESCRIPTION
Currently errors defined in ApiTools don't capture error message details in string representations of the errors:
```
from apitools.base.py.exceptions import HttpError
>>> HttpError("response", "content", "http://url")
HttpError()
```
This PR changes this behavior, for example:
```
>>> from apitools.base.py.exceptions import HttpError
>>> HttpError("response", "content", "http://url")
HttpError(u'HttpError accessing <http://url>: response: <response>, content <content>',)
```
Calling constructor of the superclass with one argument helps to capture the details of exception, as defined[1] in BaseException, the superclass of Exception, the superclass of apitools.base.py.exceptions.Error. 

[1] https://github.com/python/cpython/blob/db7197543112954b0912e3d46e39fefcb1c3b950/Objects/exceptions.c#L111.