### PR TITLE
allow sets to be used for repeated fields

### DIFF
--- a/apitools/base/protorpclite/messages.py
+++ b/apitools/base/protorpclite/messages.py
@@ -1358,7 +1358,7 @@ class Field(six.with_metaclass(_FieldMeta, object)):
             return validate_element(value)
         else:
             # Must be a list or tuple, may not be a string.
-            if isinstance(value, (list, tuple)):
+            if isinstance(value, (list, tuple, set)):
                 result = []
                 for element in value:
                     if element is None:
@@ -1644,7 +1644,7 @@ class MessageField(Field):
         t = self.type
         if isinstance(t, type) and issubclass(t, Message):
             if self.repeated:
-                if value and isinstance(value, (list, tuple)):
+                if value and isinstance(value, (list, tuple, set)):
                     value = [(t(**v) if isinstance(v, dict) else v)
                              for v in value]
             elif isinstance(value, dict):


### PR DESCRIPTION
Part of fixing http://issuetracker.google.com/132917477

```
Field scope is repeated. Found: set([u'https://www.googleapis.com/auth/compute', u'https://www.googleapis.com/auth/appengine.admin', u'https://www.googleapis.com/auth/userinfo.email', u'https://www.googleapis.com/auth/cloud-platform'])
```

Disclaimer: no idea what's going on with apitools or python, just want the bug fixed. Feel free to co-opt this change.