### PR TITLE
add compatibility check badges to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 google-apitools
 ===============
 
-|pypi| |build| |coverage|
+|pypi| |build| |coverage| |compat_check_pypi| |compat_check_github|
 
 ``google-apitools`` is a collection of utilities to make it easier to build
 client-side tools, especially those that talk to Google APIs.
@@ -45,3 +45,7 @@ Then run the tests::
    :target: https://pypi.python.org/pypi/google-apitools
 .. |coverage| image:: https://coveralls.io/repos/google/apitools/badge.svg?branch=master
    :target: https://coveralls.io/r/google/apitools?branch=master
+.. |compat_check_pypi| image:: https://python-compatibility-tools.appspot.com/one_badge_image?package=google-apitools
+   :target: https://python-compatibility-tools.appspot.com/one_badge_target?package=google-apitools
+.. |compat_check_github| image:: https://python-compatibility-tools.appspot.com/one_badge_image?package=git%2Bgit%3A//github.com/google/apitools.git
+   :target: https://python-compatibility-tools.appspot.com/one_badge_target?package=git%2Bgit%3A//github.com/google/apitools.git


### PR DESCRIPTION
Hello google package maintainer,
The badges being added to the README in this PR will indicate your compatibility with other google packages. This addresses a set of user bugs which have happened when a user depends on two Cloud libraries (or runtimes that bundle libraries), say A and B, which both depend on library C. If the two libraries require different versions of C, the users can run into issues both when they pip install the libraries, and when they deploy their code. Our compatibility server checks that all libraries we make including this one are self and pairwise compatible as well as not having any deprecated dependencies. The two badges will mark the build for your project green when the latest version available on PyPI and github HEAD respectively meet all compatibility checks with itself and all other libraries. The badge target will link to a details page that ellaborates on the current status. This should help you fix issues pre-release, to avoid user surprises. For more information, please take a look at our project charter at go/python-cloud-dependencies-project-charter and the badging PRD https://docs.google.com/document/d/1GYRFrfUou2ssY71AtnLkc8Sg1SD4dxqN4GzlatGHHyI/edit?ts=5c6f031d