### PR TITLE
Normalize response from the GCE metadata server.

### DIFF
--- a/apitools/base/py/credentials_lib.py
+++ b/apitools/base/py/credentials_lib.py
@@ -405,7 +405,7 @@ class GceAssertionCredentials(gce.AppAssertionCredentials):
             if self.store:
                 self.store.locked_put(self)
             raise
-        content = response.read()
+        content = six.ensure_str(response.read())
         try:
             credential_info = json.loads(content)
         except ValueError:


### PR DESCRIPTION
The response is always read in as bytes, and sometimes blindly passed to
things that accept strings. In Python 3, some things that accept strings
(like json.loads) will only accept unicode-type objects, not bytes-type
objects. This change makes sure the bytes are converted to a unicode
string (decoded using the utf-8 codec) in Python 3.

Fixes https://github.com/GoogleCloudPlatform/gsutil/issues/819.