### PR TITLE
Fix mock for urllib_request in GetURLContentTest

### DIFF
--- a/apitools/gen/util_test.py
+++ b/apitools/gen/util_test.py
@@ -24,7 +24,7 @@ import tempfile
 import unittest2
 
 from apitools.gen import util
-from mock import MagicMock
+from mock import patch
 
 
 class NormalizeVersionTest(unittest2.TestCase):
@@ -85,16 +85,14 @@ class GetURLContentTest(unittest2.TestCase):
 
     def testUnspecifiedContentEncoding(self):
         data = 'regular non-gzipped content'
-        urllib_request.urlopen = MagicMock(
-            return_value=MockRequestResponse(data, ''))
-
-        self.assertEqual(data, util._GetURLContent('unused_url_parameter'))
+        with patch.object(urllib_request, 'urlopen',
+            return_value=MockRequestResponse(data, '')):
+          self.assertEqual(data, util._GetURLContent('unused_url_parameter'))
 
     def testGZippedContent(self):
         data = u'¿Hola qué tal?'
         compressed_data = _Gzip(data.encode('utf-8'))
-        urllib_request.urlopen = MagicMock(
-            return_value=MockRequestResponse(compressed_data, 'gzip'))
-
-        self.assertEqual(data, util._GetURLContent(
-            'unused_url_parameter').decode('utf-8'))
+        with patch.object(urllib_request, 'urlopen',
+            return_value=MockRequestResponse(compressed_data, 'gzip')):
+          self.assertEqual(data, util._GetURLContent(
+              'unused_url_parameter').decode('utf-8'))

--- a/apitools/gen/util_test.py
+++ b/apitools/gen/util_test.py
@@ -85,7 +85,7 @@ class GetURLContentTest(unittest2.TestCase):
 
     def testUnspecifiedContentEncoding(self):
         data = 'regular non-gzipped content'
-        with patch.object(urllib_request, 'urlopen', 
+        with patch.object(urllib_request, 'urlopen',
                           return_value=MockRequestResponse(data, '')):
             self.assertEqual(data, util._GetURLContent('unused_url_parameter'))
 
@@ -93,6 +93,7 @@ class GetURLContentTest(unittest2.TestCase):
         data = u'¿Hola qué tal?'
         compressed_data = _Gzip(data.encode('utf-8'))
         with patch.object(urllib_request, 'urlopen',
-                          return_value=MockRequestResponse(compressed_data, 'gzip')):
+                          return_value=MockRequestResponse(
+                              compressed_data, 'gzip')):
             self.assertEqual(data, util._GetURLContent(
                 'unused_url_parameter').decode('utf-8'))

--- a/apitools/gen/util_test.py
+++ b/apitools/gen/util_test.py
@@ -85,14 +85,14 @@ class GetURLContentTest(unittest2.TestCase):
 
     def testUnspecifiedContentEncoding(self):
         data = 'regular non-gzipped content'
-        with patch.object(urllib_request, 'urlopen',
-            return_value=MockRequestResponse(data, '')):
-          self.assertEqual(data, util._GetURLContent('unused_url_parameter'))
+        with patch.object(urllib_request, 'urlopen', 
+                          return_value=MockRequestResponse(data, '')):
+            self.assertEqual(data, util._GetURLContent('unused_url_parameter'))
 
     def testGZippedContent(self):
         data = u'¿Hola qué tal?'
         compressed_data = _Gzip(data.encode('utf-8'))
         with patch.object(urllib_request, 'urlopen',
-            return_value=MockRequestResponse(compressed_data, 'gzip')):
-          self.assertEqual(data, util._GetURLContent(
-              'unused_url_parameter').decode('utf-8'))
+                          return_value=MockRequestResponse(compressed_data, 'gzip')):
+            self.assertEqual(data, util._GetURLContent(
+                'unused_url_parameter').decode('utf-8'))


### PR DESCRIPTION
We were replacing the urlopen and it wasn't being unmocked, so other tests got the value 'regular non-gzipped content' when calling urlopen.