### PR TITLE
Cast mimetype to lang-appropriate str type.

### DIFF
--- a/apitools/base/py/util.py
+++ b/apitools/base/py/util.py
@@ -174,6 +174,7 @@ def AcceptableMimeType(accept_patterns, mime_type):
     Returns:
       Whether or not mime_type matches (at least) one of these patterns.
     """
+    mime_type = six.ensure_str(mime_type)
     if '/' not in mime_type:
         raise exceptions.InvalidUserInputError(
             'Invalid MIME type: "%s"' % mime_type)


### PR DESCRIPTION
Fixes https://issuetracker.google.com/issues/136688879. This line will
fail in Python 3 if mime_type is a `bytes` object:

    if '/' not in mime_type:

with this error:

    TypeError: a bytes-like object is required, not 'str'