### PR TITLE
Pager helper to work with nested fields for limit or continuation token

### DIFF
--- a/apitools/base/py/list_pager.py
+++ b/apitools/base/py/list_pager.py
@@ -42,7 +42,7 @@ def _GetattrNested(message, attribute):
 
 
 def _SetattrNested(message, attribute, value):
-      """Sets a possibly nested attribute.
+    """Sets a possibly nested attribute.
 
     Same as setattr() if attribute is a string;
     if attribute is a tuple, sets the nested attribute referred to by
@@ -51,7 +51,6 @@ def _SetattrNested(message, attribute, value):
     (ex _SetattrNested(msg, ('foo', 'bar', 'baz'), 'v') sets msg.foo.bar.baz
     to 'v'
     """
-
     if isinstance(attribute, six.string_types):
         return setattr(message, attribute, value)
     elif len(attribute) < 1:

--- a/apitools/base/py/list_pager.py
+++ b/apitools/base/py/list_pager.py
@@ -25,6 +25,14 @@ __all__ = [
 
 
 def _GetattrNested(message, attribute):
+    """Gets a possibly nested attribute.
+
+    Same as getattr() if attribute is a string;
+    if attribute is a tuple, returns the nested attribute referred to by
+    the fields in the tuple as if they were a dotted accessor path.
+
+    (ex _GetattrNested(msg, ('foo', 'bar', 'baz')) gets msg.foo.bar.baz
+    """
     if isinstance(attribute, six.string_types):
         return getattr(message, attribute)
     elif len(attribute) == 0:
@@ -34,6 +42,16 @@ def _GetattrNested(message, attribute):
 
 
 def _SetattrNested(message, attribute, value):
+      """Sets a possibly nested attribute.
+
+    Same as setattr() if attribute is a string;
+    if attribute is a tuple, sets the nested attribute referred to by
+    the fields in the tuple as if they were a dotted accessor path.
+
+    (ex _SetattrNested(msg, ('foo', 'bar', 'baz'), 'v') sets msg.foo.bar.baz
+    to 'v'
+    """
+
     if isinstance(attribute, six.string_types):
         return setattr(message, attribute, value)
     elif len(attribute) < 1:

--- a/apitools/base/py/list_pager.py
+++ b/apitools/base/py/list_pager.py
@@ -22,23 +22,26 @@ __all__ = [
     'YieldFromList',
 ]
 
+
 def _GetattrNested(message, attribute):
-  if isinstance(attribute, str):
-    return getattr(message, attribute)
-  elif len(attribute) == 0:
-    return message
-  else:
-    return _GetattrNested(getattr(message, attribute[0]), attribute[1:])
+    if isinstance(attribute, str):
+        return getattr(message, attribute)
+    elif len(attribute) == 0:
+        return message
+    else:
+        return _GetattrNested(getattr(message, attribute[0]), attribute[1:])
+
 
 def _SetattrNested(message, attribute, value):
-  if isinstance(attribute, str):
-    return setattr(message, attribute, value)
-  elif len(attribute) < 1:
-    raise ValueError("Need an attribute to set")
-  elif len(attribute) == 1:
-    return setattr(message, attribute[0], value)
-  else:
-    return setattr(_GetattrNested(message, attribute[:-1]), attribute[-1], value)
+    if isinstance(attribute, str):
+        return setattr(message, attribute, value)
+    elif len(attribute) < 1:
+        raise ValueError("Need an attribute to set")
+    elif len(attribute) == 1:
+        return setattr(message, attribute[0], value)
+    else:
+        return setattr(_GetattrNested(message, attribute[:-1]),
+                       attribute[-1], value)
 
 
 def YieldFromList(
@@ -65,12 +68,14 @@ def YieldFromList(
       predicate: lambda, A function that returns true for items to be yielded.
       current_token_attribute: str or tuple, The name of the attribute in a
           request message holding the page token for the page being
-          requested.
+          requested. If a tuple, path to attribute.
       next_token_attribute: str or tuple, The name of the attribute in a
-          response message holding the page token for the next page.
+          response message holding the page token for the next page. If a
+          tuple, path to the attribute.
       batch_size_attribute: str or tuple, The name of the attribute in a
           response message holding the maximum number of results to be
           returned. None if caller-specified batch size is unsupported.
+          If a tuple, path to the attribute.
 
     Yields:
       protorpc.message.Message, The resources listed by the service.

--- a/apitools/base/py/list_pager.py
+++ b/apitools/base/py/list_pager.py
@@ -17,6 +17,7 @@
 """A helper function that executes a series of List queries for many APIs."""
 
 from apitools.base.py import encoding
+import six
 
 __all__ = [
     'YieldFromList',
@@ -24,7 +25,7 @@ __all__ = [
 
 
 def _GetattrNested(message, attribute):
-    if isinstance(attribute, str):
+    if isinstance(attribute, six.string_types):
         return getattr(message, attribute)
     elif len(attribute) == 0:
         return message
@@ -33,7 +34,7 @@ def _GetattrNested(message, attribute):
 
 
 def _SetattrNested(message, attribute, value):
-    if isinstance(attribute, str):
+    if isinstance(attribute, six.string_types):
         return setattr(message, attribute, value)
     elif len(attribute) < 1:
         raise ValueError("Need an attribute to set")

--- a/apitools/base/py/list_pager_test.py
+++ b/apitools/base/py/list_pager_test.py
@@ -26,11 +26,13 @@ from samples.fusiontables_sample.fusiontables_v1 \
 from samples.iam_sample.iam_v1 import iam_v1_client as iam_client
 from samples.iam_sample.iam_v1 import iam_v1_messages as iam_messages
 
+
 class Example(object):
-  def __init__(self):
-    self.a = 'aaa'
-    self.b = 'bbb'
-    self.c = 'ccc'
+    def __init__(self):
+        self.a = 'aaa'
+        self.b = 'bbb'
+        self.c = 'ccc'
+
 
 class GetterSetterTest(unittest2.TestCase):
 

--- a/apitools/base/py/list_pager_test.py
+++ b/apitools/base/py/list_pager_test.py
@@ -26,6 +26,30 @@ from samples.fusiontables_sample.fusiontables_v1 \
 from samples.iam_sample.iam_v1 import iam_v1_client as iam_client
 from samples.iam_sample.iam_v1 import iam_v1_messages as iam_messages
 
+class Example(object):
+  def __init__(self):
+    self.a = 'aaa'
+    self.b = 'bbb'
+    self.c = 'ccc'
+
+class GetterSetterTest(unittest2.TestCase):
+
+    def testGetattrNested(self):
+        o = Example()
+        self.assertEqual(list_pager._GetattrNested(o, 'a'), 'aaa')
+        self.assertEqual(list_pager._GetattrNested(o, ('a',)), 'aaa')
+        o.b = Example()
+        self.assertEqual(list_pager._GetattrNested(o, ('b', 'c')), 'ccc')
+
+    def testSetattrNested(self):
+        o = Example()
+        list_pager._SetattrNested(o, 'b', Example())
+        self.assertEqual(o.b.a, 'aaa')
+        list_pager._SetattrNested(o, ('b', 'a'), 'AAA')
+        self.assertEqual(o.b.a, 'AAA')
+        list_pager._SetattrNested(o, ('c',), 'CCC')
+        self.assertEqual(o.c, 'CCC')
+
 
 class ListPagerTest(unittest2.TestCase):
 


### PR DESCRIPTION
Allow a limit or a continuation token to be in a nested field in the list request or response.

This allows, for example, if the continuation token is `metadata.continue_` like it is for a Kubernetes-style api, where `metadata` is a `ListMeta` and common to all list responses.

This still needs a little more tests.