### PR TITLE
Switch apitools default JSON endpoint to storage.googleapis.com

### DIFF
--- a/samples/storage_sample/storage_v1/storage_v1_client.py
+++ b/samples/storage_sample/storage_v1/storage_v1_client.py
@@ -8,7 +8,7 @@ class StorageV1(base_api.BaseApiClient):
   """Generated client library for service storage version v1."""
 
   MESSAGES_MODULE = messages
-  BASE_URL = u'https://www.googleapis.com/storage/v1/'
+  BASE_URL = u'https://storage.googleapis.com/storage/v1/'
 
   _PACKAGE = u'storage'
   _SCOPES = [u'https://www.googleapis.com/auth/cloud-platform', u'https://www.googleapis.com/auth/cloud-platform.read-only', u'https://www.googleapis.com/auth/devstorage.full_control', u'https://www.googleapis.com/auth/devstorage.read_only', u'https://www.googleapis.com/auth/devstorage.read_write']


### PR DESCRIPTION
This is for GCS split domain serving. Please contact me at mfschwartz@google.com if you have questions.