### PR TITLE
Fix: Avoid name check if JSON keyfile is provided

### DIFF
--- a/apitools/base/py/credentials_lib.py
+++ b/apitools/base/py/credentials_lib.py
@@ -721,10 +721,6 @@ def _GetServiceAccountCredentials(
         client_info, service_account_name=None, service_account_keyfile=None,
         service_account_json_keyfile=None, **unused_kwds):
     """Returns ServiceAccountCredentials from give file."""
-    if ((service_account_name and not service_account_keyfile) or
-            (service_account_keyfile and not service_account_name)):
-        raise exceptions.CredentialsError(
-            'Service account name or keyfile provided without the other')
     scopes = client_info['scope'].split()
     user_agent = client_info['user_agent']
     # Use the .json credentials, if provided.
@@ -732,6 +728,10 @@ def _GetServiceAccountCredentials(
         return ServiceAccountCredentialsFromFile(
             service_account_json_keyfile, scopes, user_agent=user_agent)
     # Fall back to .p12 if there's no .json credentials.
+    if ((service_account_name and not service_account_keyfile) or
+            (service_account_keyfile and not service_account_name)):
+        raise exceptions.CredentialsError(
+            'Service account name or keyfile provided without the other')
     if service_account_name is not None:
         return ServiceAccountCredentialsFromP12File(
             service_account_name, service_account_keyfile, scopes, user_agent)


### PR DESCRIPTION
In `credentials_lib.py` moved `service_account_name` and `service_account_keyfile` check after JSON check, since JSON credentials does not depend on either one to be present.