### PR TITLE
Pager helper to enable custom field getter

### DIFF
--- a/apitools/base/py/list_pager.py
+++ b/apitools/base/py/list_pager.py
@@ -67,7 +67,8 @@ def YieldFromList(
         method='List', field='items', predicate=None,
         current_token_attribute='pageToken',
         next_token_attribute='nextPageToken',
-        batch_size_attribute='maxResults'):
+        batch_size_attribute='maxResults',
+        get_field_fn=_GetattrNested):
     """Make a series of List requests, keeping track of page tokens.
 
     Args:
@@ -116,7 +117,7 @@ def YieldFromList(
             _SetattrNested(request, batch_size_attribute, request_batch_size)
         response = getattr(service, method)(request,
                                             global_params=global_params)
-        items = _GetattrNested(response, field)
+        items = get_field_fn(response, field)
         if predicate:
             items = list(filter(predicate, items))
         for item in items:

--- a/apitools/base/py/list_pager.py
+++ b/apitools/base/py/list_pager.py
@@ -95,6 +95,7 @@ def YieldFromList(
           response message holding the maximum number of results to be
           returned. None if caller-specified batch size is unsupported.
           If a tuple, path to the attribute.
+      get_field_fn: lambda, A function that returns the items to be yielded.
 
     Yields:
       protorpc.message.Message, The resources listed by the service.

--- a/apitools/base/py/list_pager.py
+++ b/apitools/base/py/list_pager.py
@@ -68,7 +68,7 @@ def YieldFromList(
         current_token_attribute='pageToken',
         next_token_attribute='nextPageToken',
         batch_size_attribute='maxResults',
-        get_field_fn=_GetattrNested):
+        get_field_func=_GetattrNested):
     """Make a series of List requests, keeping track of page tokens.
 
     Args:
@@ -95,7 +95,8 @@ def YieldFromList(
           response message holding the maximum number of results to be
           returned. None if caller-specified batch size is unsupported.
           If a tuple, path to the attribute.
-      get_field_fn: lambda, A function that returns the items to be yielded.
+      get_field_func: Function that returns the items to be yielded. Argument
+          is response message, and field.
 
     Yields:
       protorpc.message.Message, The resources listed by the service.
@@ -118,7 +119,7 @@ def YieldFromList(
             _SetattrNested(request, batch_size_attribute, request_batch_size)
         response = getattr(service, method)(request,
                                             global_params=global_params)
-        items = get_field_fn(response, field)
+        items = get_field_func(response, field)
         if predicate:
             items = list(filter(predicate, items))
         for item in items:

--- a/apitools/base/py/list_pager_test.py
+++ b/apitools/base/py/list_pager_test.py
@@ -289,7 +289,7 @@ class ListPagerTest(unittest2.TestCase):
         client = fusiontables.FusiontablesV1(get_credentials=False)
         request = messages.FusiontablesColumnListRequest(tableId='mytable')
         results = list_pager.YieldFromList(
-            client.column, request, get_field_fn=Custom_Getter)
+            client.column, request, get_field_func=Custom_Getter)
 
         self._AssertInstanceSequence(results, 1)
         self.assertEquals(1, len(custom_getter_called))

--- a/apitools/base/py/list_pager_test.py
+++ b/apitools/base/py/list_pager_test.py
@@ -105,32 +105,6 @@ class ListPagerTest(unittest2.TestCase):
 
         self._AssertInstanceSequence(results, 8)
 
-    def testYieldFromListWithCustomGetFieldFunction(self):
-        self.mocked_client.column.List.Expect(
-            messages.FusiontablesColumnListRequest(
-                maxResults=100,
-                pageToken=None,
-                tableId='mytable',
-            ),
-            messages.ColumnList(
-                items=[
-                    messages.Column(name='c0')
-                ]
-            ))
-        custom_getter_called = False
-
-        def Custom_Getter(message, attribute):
-            custom_getter_called = True
-            return getattr(message, attribute)
-
-        client = fusiontables.FusiontablesV1(get_credentials=False)
-        request = messages.FusiontablesColumnListRequest(tableId='mytable')
-        results = list_pager.YieldFromList(
-            client.column, request, get_field_fn=Custom_Getter)
-
-        self._AssertInstanceSequence(results, 1)
-        self.assertTrue(custom_getter_called)
-
     def testYieldNoRecords(self):
         client = fusiontables.FusiontablesV1(get_credentials=False)
         request = messages.FusiontablesColumnListRequest(tableId='mytable')
@@ -293,6 +267,32 @@ class ListPagerTest(unittest2.TestCase):
             client.column, request, predicate=lambda x: 'c' in x.name)
 
         self._AssertInstanceSequence(results, 3)
+    
+    def testYieldFromListWithCustomGetFieldFunction(self):
+        self.mocked_client.column.List.Expect(
+            messages.FusiontablesColumnListRequest(
+                maxResults=100,
+                pageToken=None,
+                tableId='mytable',
+            ),
+            messages.ColumnList(
+                items=[
+                    messages.Column(name='c0')
+                ]
+            ))
+        custom_getter_called = []
+
+        def Custom_Getter(message, attribute):
+            custom_getter_called.append(True)
+            return getattr(message, attribute)
+
+        client = fusiontables.FusiontablesV1(get_credentials=False)
+        request = messages.FusiontablesColumnListRequest(tableId='mytable')
+        results = list_pager.YieldFromList(
+            client.column, request, get_field_fn=Custom_Getter)
+
+        self._AssertInstanceSequence(results, 1)
+        self.assertEquals(1, len(custom_getter_called))
 
 
 class ListPagerAttributeTest(unittest2.TestCase):

--- a/apitools/base/py/list_pager_test.py
+++ b/apitools/base/py/list_pager_test.py
@@ -267,7 +267,7 @@ class ListPagerTest(unittest2.TestCase):
             client.column, request, predicate=lambda x: 'c' in x.name)
 
         self._AssertInstanceSequence(results, 3)
-    
+ 
     def testYieldFromListWithCustomGetFieldFunction(self):
         self.mocked_client.column.List.Expect(
             messages.FusiontablesColumnListRequest(

--- a/apitools/base/py/list_pager_test.py
+++ b/apitools/base/py/list_pager_test.py
@@ -105,6 +105,31 @@ class ListPagerTest(unittest2.TestCase):
 
         self._AssertInstanceSequence(results, 8)
 
+    def testYieldFromListWithCustomGetFieldFunction(self):
+        self.mocked_client.column.List.Expect(
+            messages.FusiontablesColumnListRequest(
+                maxResults=100,
+                pageToken=None,
+                tableId='mytable',
+            ),
+            messages.ColumnList(
+                items=[
+                    messages.Column(name='c0')
+                ]
+            ))
+        custom_getter_called = False
+
+        def Custom_Getter(message, attribute):
+            custom_getter_called = True
+            return getattr(message, attribute)
+
+        client = fusiontables.FusiontablesV1(get_credentials=False)
+        request = messages.FusiontablesColumnListRequest(tableId='mytable')
+        results = list_pager.YieldFromList(client.column, request, get_field_fn=Custom_Getter)
+
+        self._AssertInstanceSequence(results, 1)
+        self.assertTrue(custom_getter_called)
+
     def testYieldNoRecords(self):
         client = fusiontables.FusiontablesV1(get_credentials=False)
         request = messages.FusiontablesColumnListRequest(tableId='mytable')

--- a/apitools/base/py/list_pager_test.py
+++ b/apitools/base/py/list_pager_test.py
@@ -125,7 +125,8 @@ class ListPagerTest(unittest2.TestCase):
 
         client = fusiontables.FusiontablesV1(get_credentials=False)
         request = messages.FusiontablesColumnListRequest(tableId='mytable')
-        results = list_pager.YieldFromList(client.column, request, get_field_fn=Custom_Getter)
+        results = list_pager.YieldFromList(
+            client.column, request, get_field_fn=Custom_Getter)
 
         self._AssertInstanceSequence(results, 1)
         self.assertTrue(custom_getter_called)

--- a/apitools/base/py/list_pager_test.py
+++ b/apitools/base/py/list_pager_test.py
@@ -267,7 +267,7 @@ class ListPagerTest(unittest2.TestCase):
             client.column, request, predicate=lambda x: 'c' in x.name)
 
         self._AssertInstanceSequence(results, 3)
- 
+
     def testYieldFromListWithCustomGetFieldFunction(self):
         self.mocked_client.column.List.Expect(
             messages.FusiontablesColumnListRequest(


### PR DESCRIPTION
Allow the list pager to accept a custom getter for the items field. 