### PR TITLE
Handle nano secs in DateTime parsing.

### DIFF
--- a/apitools/base/protorpclite/protojson.py
+++ b/apitools/base/protorpclite/protojson.py
@@ -327,7 +327,7 @@ class ProtoJson(object):
 
         elif isinstance(field, message_types.DateTimeField):
             try:
-                return util.decode_datetime(value)
+                return util.decode_datetime(value, truncate_time=True)
             except ValueError as err:
                 raise messages.DecodeError(err)
 

--- a/apitools/base/protorpclite/util.py
+++ b/apitools/base/protorpclite/util.py
@@ -264,7 +264,20 @@ def decode_datetime(encoded_datetime):
     else:
         format_string = '%Y-%m-%dT%H:%M:%S'
 
-    decoded_datetime = datetime.datetime.strptime(time_string, format_string)
+    try:
+        decoded_datetime = datetime.datetime.strptime(time_string,
+                                                      format_string)
+    except ValueError:
+        if '.' in time_string:
+            datetime_string, decimal_secs = time_string.split('.')
+            if len(decimal_secs) > 6:
+                decoded_datetime = datetime.datetime.strptime(
+                    '{}.{}'.format(datetime_string, decimal_secs[:6]),
+                    format_string)
+            else:
+                raise
+        else:
+            raise
 
     if not time_zone_match:
         return decoded_datetime

--- a/apitools/base/protorpclite/util.py
+++ b/apitools/base/protorpclite/util.py
@@ -20,6 +20,7 @@ from __future__ import with_statement
 import datetime
 import functools
 import inspect
+import logging
 import os
 import re
 import sys
@@ -271,9 +272,15 @@ def decode_datetime(encoded_datetime):
         if '.' in time_string:
             datetime_string, decimal_secs = time_string.split('.')
             if len(decimal_secs) > 6:
+                # datetime can handle only microsecs precision.
+                truncated_time_string = '{}.{}'.format(
+                    datetime_string, decimal_secs[:6])
                 decoded_datetime = datetime.datetime.strptime(
-                    '{}.{}'.format(datetime_string, decimal_secs[:6]),
+                    truncated_time_string,
                     format_string)
+                logging.warning(
+                    'Truncating the datetime string from %s to %s',
+                    time_string, truncated_time_string)
             else:
                 raise
         else:

--- a/apitools/base/protorpclite/util.py
+++ b/apitools/base/protorpclite/util.py
@@ -239,11 +239,13 @@ class TimeZoneOffset(datetime.tzinfo):
         return datetime.timedelta(0)
 
 
-def decode_datetime(encoded_datetime):
+def decode_datetime(encoded_datetime, truncate_time=False):
     """Decode a DateTimeField parameter from a string to a python datetime.
 
     Args:
       encoded_datetime: A string in RFC 3339 format.
+      truncate_time: If true, truncate time string with precision higher than
+          microsecs.
 
     Returns:
       A datetime object with the date and time specified in encoded_datetime.
@@ -269,7 +271,7 @@ def decode_datetime(encoded_datetime):
         decoded_datetime = datetime.datetime.strptime(time_string,
                                                       format_string)
     except ValueError:
-        if '.' in time_string:
+        if truncate_time and '.' in time_string:
             datetime_string, decimal_secs = time_string.split('.')
             if len(decimal_secs) > 6:
                 # datetime can handle only microsecs precision.

--- a/apitools/base/protorpclite/util_test.py
+++ b/apitools/base/protorpclite/util_test.py
@@ -182,6 +182,8 @@ class DateTimeTests(test_util.TestCase):
         """Test that a RFC 3339 datetime string is decoded properly."""
         for datetime_string, datetime_vals in (
                 ('2012-09-30T15:31:50.262', (2012, 9, 30, 15, 31, 50, 262000)),
+                ('2012-09-30T15:31:50.262343123',
+                 (2012, 9, 30, 15, 31, 50, 262343)),
                 ('2012-09-30T15:31:50', (2012, 9, 30, 15, 31, 50, 0))):
             decoded = util.decode_datetime(datetime_string)
             expected = datetime.datetime(*datetime_vals)

--- a/apitools/base/protorpclite/util_test.py
+++ b/apitools/base/protorpclite/util_test.py
@@ -182,12 +182,17 @@ class DateTimeTests(test_util.TestCase):
         """Test that a RFC 3339 datetime string is decoded properly."""
         for datetime_string, datetime_vals in (
                 ('2012-09-30T15:31:50.262', (2012, 9, 30, 15, 31, 50, 262000)),
-                ('2012-09-30T15:31:50.262343123',
-                 (2012, 9, 30, 15, 31, 50, 262343)),
                 ('2012-09-30T15:31:50', (2012, 9, 30, 15, 31, 50, 0))):
             decoded = util.decode_datetime(datetime_string)
             expected = datetime.datetime(*datetime_vals)
             self.assertEquals(expected, decoded)
+
+    def testDecodeDateTimeWithTruncateTime(self):
+       """Test that nanosec time is truncated with truncate_time flag."""
+       decoded = util.decode_datetime('2012-09-30T15:31:50.262343123',
+                                      truncate_time=True)
+       expected = datetime.datetime(2012, 9, 30, 15, 31, 50, 262343)
+       self.assertEquals(expected, decoded)
 
     def testDateTimeTimeZones(self):
         """Test that a datetime string with a timezone is decoded correctly."""
@@ -220,7 +225,8 @@ class DateTimeTests(test_util.TestCase):
                                 '2012-09-30T15:31Z',
                                 '2012-09-30T15:31:50ZZ',
                                 '2012-09-30T15:31:50.262 blah blah -08:00',
-                                '1000-99-99T25:99:99.999-99:99'):
+                                '1000-99-99T25:99:99.999-99:99',
+                                '2012-09-30T15:31:50.262343123'):
             self.assertRaises(
                 ValueError, util.decode_datetime, datetime_string)
 

--- a/apitools/base/py/base_api.py
+++ b/apitools/base/py/base_api.py
@@ -443,7 +443,7 @@ class BaseApiClient(object):
     def DeserializeMessage(self, response_type, data):
         """Deserialize the given data as method_config.response_type."""
         try:
-            message = encoding.JsonToMessage(response_type, data)
+            message = encoding.JsonToMessage(response_type, data  )
         except (exceptions.InvalidDataFromServerError,
                 messages.ValidationError, ValueError) as e:
             raise exceptions.InvalidDataFromServerError(

--- a/apitools/base/py/base_api.py
+++ b/apitools/base/py/base_api.py
@@ -443,7 +443,7 @@ class BaseApiClient(object):
     def DeserializeMessage(self, response_type, data):
         """Deserialize the given data as method_config.response_type."""
         try:
-            message = encoding.JsonToMessage(response_type, data  )
+            message = encoding.JsonToMessage(response_type, data)
         except (exceptions.InvalidDataFromServerError,
                 messages.ValidationError, ValueError) as e:
             raise exceptions.InvalidDataFromServerError(


### PR DESCRIPTION
For context b/180215836

Fields like `custom-time` can have nano secs granularity if they are updated using non-Python libraries like the C++ client library or using the REST API directly.
```
custom_time=2020-08-12T13:39:44.51213724Z
```
Python's datetime can  handle only up to microsec precision which means a datetime string with nanosec precision would raise error.  This becomes a problem for gsutil commands like `ls` and `stat` if there are nanosec precision datetime string in the object's metadata.

Note that this change **will affect all decode_field** interaction. For example, if someone uses [JsonToMessage](https://github.com/google/apitools/blob/a48cf52831e6ef4b3ca4fd9aa95b625f6a18b8c8/apitools/base/py/encoding_helper.py#L121) which ultimately calls the `decode_field` for a datetime field, the precision will be truncated. This means that this truncation will also affect cases where a user decides to create a message from json manually with nanosec datetime precision. Hence I am adding a warning log as the best way to warn the user. 

Note that something like
```
gsutil.py setmeta -h custom-time:2020-08-12T13:39:44.512137243Z gs://bucket/obj
```
will still fail (which is good), because `setmeta` does not rely on the decode_field method.

Ideally we would want this precision truncation to be done only for display purpose and it should raise an error for all data modification cases, but this is difficult to handle with the current structure because the datetime decoding is handled
deep down the framework, and the [ProtoJson](https://github.com/google/apitools/blob/a48cf52831e6ef4b3ca4fd9aa95b625f6a18b8c8/apitools/base/protorpclite/protojson.py#L136) class is a [singleton](https://github.com/google/apitools/blob/a48cf52831e6ef4b3ca4fd9aa95b625f6a18b8c8/apitools/base/py/encoding_helper.py#L299), which means we cannot set this based on the each request/response.

I am happy to discard this PR if this seems to risky.