### PR TITLE
Add option to overwrite transfer URLs with a client's base URL.

### DIFF
--- a/apitools/base/py/base_api.py
+++ b/apitools/base/py/base_api.py
@@ -271,6 +271,9 @@ class BaseApiClient(object):
         self.check_response_func = check_response_func
         self.retry_func = retry_func
         self.response_encoding = response_encoding
+        # Since we can't change the init arguments without regenerating clients,
+        # offer this hook to affect FinalizeTransferUrl behavior.
+        self.overwrite_transfer_urls_with_client_base = False
 
         # TODO(craigcitro): Finish deprecating these fields.
         _ = model
@@ -454,8 +457,11 @@ class BaseApiClient(object):
     def FinalizeTransferUrl(self, url):
         """Modify the url for a given transfer, based on auth and version."""
         url_builder = _UrlBuilder.FromUrl(url)
-        if self.global_params.key:
+        if getattr(self.global_params, 'key', None):
             url_builder.query_params['key'] = self.global_params.key
+        if self.overwrite_transfer_urls_with_client_base:
+            client_url_builder = _UrlBuilder.FromUrl(self._url)
+            url_builder.base_url = client_url_builder.base_url
         return url_builder.url
 
 

--- a/apitools/base/py/base_api_test.py
+++ b/apitools/base/py/base_api_test.py
@@ -329,6 +329,15 @@ class BaseApiTest(unittest.TestCase):
         self.assertEqual('http://www.example.com/path:withJustColon',
                          http_request.url)
 
+    def testOverwritesTransferUrlBase(self):
+        client = self.__GetFakeClient()
+        client.overwrite_transfer_urls_with_client_base = True
+        client._url = 'http://custom.p.googleapis.com/'
+        observed = client.FinalizeTransferUrl(
+            'http://normal.googleapis.com/path')
+        expected = 'http://custom.p.googleapis.com/path'
+        self.assertEqual(observed, expected)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/apitools/base/py/transfer.py
+++ b/apitools/base/py/transfer.py
@@ -236,7 +236,7 @@ class Download(_Transfer):
 
     @classmethod
     def FromData(cls, stream, json_data, http=None, auto_transfer=None,
-                 **kwds):
+                 client=None, **kwds):
         """Create a new Download object from a stream and serialized data."""
         info = json.loads(json_data)
         missing_keys = cls._REQUIRED_SERIALIZATION_KEYS - set(info.keys())
@@ -249,10 +249,15 @@ class Download(_Transfer):
             download.auto_transfer = auto_transfer
         else:
             download.auto_transfer = info['auto_transfer']
+        if client is not None:
+            url = client.FinalizeTransferUrl(info['url'])
+        else:
+            url = info['url']
+
         setattr(download, '_Download__progress', info['progress'])
         setattr(download, '_Download__total_size', info['total_size'])
         download._Initialize(  # pylint: disable=protected-access
-            http, info['url'])
+            http, url)
         return download
 
     @property
@@ -637,7 +642,7 @@ class Upload(_Transfer):
 
     @classmethod
     def FromData(cls, stream, json_data, http, auto_transfer=None,
-                 gzip_encoded=False, **kwds):
+                 gzip_encoded=False, client=None, **kwds):
         """Create a new Upload of stream from serialized json_data and http."""
         info = json.loads(json_data)
         missing_keys = cls._REQUIRED_SERIALIZATION_KEYS - set(info.keys())
@@ -658,9 +663,14 @@ class Upload(_Transfer):
             upload.auto_transfer = auto_transfer
         else:
             upload.auto_transfer = info['auto_transfer']
+        if client is not None:
+          url = client.FinalizeTransferUrl(info['url'])
+        else:
+          url = info['url']
+
         upload.strategy = RESUMABLE_UPLOAD
         upload._Initialize(  # pylint: disable=protected-access
-            http, info['url'])
+            http, url)
         upload.RefreshResumableUploadState()
         upload.EnsureInitialized()
         if upload.auto_transfer:


### PR DESCRIPTION
Needed because FromData and InitializeUpload methods sometimes ignore
custom endpoints set by the client.

Test environment was a bit broken, but Python 2.7 tests passed. My
Python3.5 version was having SSL issues so ended up running the tests with
Python3.9. Failures look unrelated to changes:

```
ERROR: Testing pickling and unpickling of FieldList instances.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/google/home/hartunian/Desktop/apitools/apitools/base/protorpclite/messages_test.py", line 511, in testPickle
    unpickled = pickle.loads(pickle.dumps(field_list))
  File "/usr/local/google/home/hartunian/Desktop/apitools/apitools/base/protorpclite/messages.py", line 1147, in extend
    self.__field.validate(sequence)
AttributeError: 'FieldList' object has no attribute '_FieldList__field'

======================================================================
ERROR: Testing pickling and unpickling of Message instances.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/google/home/hartunian/Desktop/apitools/apitools/base/protorpclite/messages_test.py", line 1876, in testPickle
    unpickled = pickle.loads(pickle.dumps(message))
  File "/usr/local/google/home/hartunian/Desktop/apitools/apitools/base/protorpclite/messages.py", line 1147, in extend
    self.__field.validate(sequence)
AttributeError: 'FieldList' object has no attribute '_FieldList__field'

======================================================================
FAIL: Test decoding improperly encoded base64 bytes value.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/google/home/hartunian/Desktop/apitools/apitools/base/protorpclite/protojson.py", line 324, in decode_field
    return base64.b64decode(value)
  File "/usr/lib/python3.9/base64.py", line 87, in b64decode
    return binascii.a2b_base64(s)
binascii.Error: Invalid base64-encoded string: number of data characters (17) cannot be 1 more than a multiple of 4

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/google/home/hartunian/Desktop/apitools/apitools/base/protorpclite/test_util.py", line 70, in assertRaisesWithRegexpMatch
    function(*params, **kwargs)
  File "/usr/local/google/home/hartunian/Desktop/apitools/apitools/base/protorpclite/protojson.py", line 214, in decode_message
    message = self.__decode_dictionary(message_type, dictionary)
apitools.base.protorpclite.messages.DecodeError: Base64 decoding error: Invalid base64-encoded string: number of data characters (17) cannot be 1 more than a multiple of 4

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/google/home/hartunian/Desktop/apitools/apitools/base/protorpclite/protojson_test.py", line 441, in testDecodeBadBase64BytesField
    self.assertRaisesWithRegexpMatch(
  File "/usr/local/google/home/hartunian/Desktop/apitools/apitools/base/protorpclite/test_util.py", line 75, in assertRaisesWithRegexpMatch
    self.assertTrue(match, 'Expected match "%s", found "%s"' % (regexp,
AssertionError: False is not true : Expected match "Base64 decoding error: Incorrect padding", found "Base64 decoding error: Invalid base64-encoded string: number of data characters (17) cannot be 1 more than a multiple of 4"

======================================================================
FAIL: testConvertIdThatNeedsEscaping (apitools.base.py.batch_test.BatchTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/google/home/hartunian/Desktop/apitools/apitools/base/py/batch_test.py", line 360, in testConvertIdThatNeedsEscaping
    self._DoTestConvertIdToHeader('~tilde1', '<%s+%%7Etilde1>')
  File "/usr/local/google/home/hartunian/Desktop/apitools/apitools/base/py/batch_test.py", line 352, in _DoTestConvertIdToHeader
    self.assertEqual(
AssertionError: '<30037b18-267d-4e07-9ac8-bc3c8da9a959+%7Etilde1>' != '<30037b18-267d-4e07-9ac8-bc3c8da9a959+~tilde1>'
- <30037b18-267d-4e07-9ac8-bc3c8da9a959+%7Etilde1>
?                                       ^^^
+ <30037b18-267d-4e07-9ac8-bc3c8da9a959+~tilde1>

```