### PR TITLE
Fix test failure in python37 because of tilde

### DIFF
--- a/apitools/base/py/batch_test.py
+++ b/apitools/base/py/batch_test.py
@@ -357,7 +357,7 @@ class BatchTest(unittest.TestCase):
         self._DoTestConvertIdToHeader('blah', '<%s+blah>')
 
     def testConvertIdThatNeedsEscaping(self):
-        self._DoTestConvertIdToHeader('~tilde1', '<%s+%%7Etilde1>')
+        self._DoTestConvertIdToHeader(' space1', '<%s+%%20space1>')
 
     def _DoTestConvertHeaderToId(self, header, expected_id):
         batch_request = batch.BatchHttpRequest('https://www.example.com')

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ REQUIRED_PACKAGES = [
     'httplib2>=0.8',
     'fasteners>=0.14',
     'oauth2client>=1.4.12',
+    'rsa<=4.0; python_version < "3.5"',
     'six>=1.12.0',
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,10 @@ except ImportError:
 # Configure the required packages and scripts to install, depending on
 # Python version and OS.
 REQUIRED_PACKAGES = [
+    'rsa<=4.0; python_version < "3.5"',
     'httplib2>=0.8',
     'fasteners>=0.14',
     'oauth2client>=1.4.12',
-    'rsa<=4.0; python_version < "3.5"',
     'six>=1.12.0',
     ]
 


### PR DESCRIPTION
For reference b/187847843

testConvertIdThatNeedsEscaping (apitools.base.py.batch_test.BatchTest)  fails because tilde is reserved char as per. https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote

Chaning the character to a space fixes it. We just care if escaping is done properly, so checking for space instead of tilde