### PR TITLE
Fix a Python 3.7 test failure in protojson_test.py.

### DIFF
--- a/apitools/base/protorpclite/protojson_test.py
+++ b/apitools/base/protorpclite/protojson_test.py
@@ -440,7 +440,7 @@ class ProtojsonTest(test_util.TestCase,
         """Test decoding improperly encoded base64 bytes value."""
         self.assertRaisesWithRegexpMatch(
             messages.DecodeError,
-            'Base64 decoding error: Incorrect padding',
+            'Base64 decoding error',
             protojson.decode_message,
             test_util.OptionalMessage,
             '{"bytes_value": "abcdefghijklmnopq"}')


### PR DESCRIPTION
This fixes a test failure caused by an error message changing from
"Base64 decoding error: Incorrect padding" to
"Base64 decoding error: Invalid base64-encoded string: number of data characters (17) cannot be 1 more than a multiple of 4".