### PR TITLE
Remove rsa restriction

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ except ImportError:
 # Python version and OS.
 # Adding a comment just to trigger the travis build
 REQUIRED_PACKAGES = [
-    'rsa<=4.0; python_version < "3.5"',
     'httplib2>=0.8',
     'fasteners>=0.14',
     'oauth2client>=1.4.12',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ except ImportError:
 
 # Configure the required packages and scripts to install, depending on
 # Python version and OS.
-# Adding a comment just to trigger the travis build
 REQUIRED_PACKAGES = [
     'httplib2>=0.8',
     'fasteners>=0.14',

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ except ImportError:
 
 # Configure the required packages and scripts to install, depending on
 # Python version and OS.
+# Adding a comment just to trigger the travis build
 REQUIRED_PACKAGES = [
     'rsa<=4.0; python_version < "3.5"',
     'httplib2>=0.8',


### PR DESCRIPTION
We had added a restriction on RSA lib, because version 4.1 is only available for python 3.5 and above, so travis for python2.7 fails. But doing this upsets dependabot and we get security vulnerability errors. So rolling this back to not restricting rsa and just letting travis CI fail for python2.7