### PR TITLE
Updated messages py for unpickling related issue

### DIFF
--- a/apitools/base/protorpclite/messages.py
+++ b/apitools/base/protorpclite/messages.py
@@ -1139,12 +1139,14 @@ class FieldList(list):
 
     def append(self, value):
         """Validate item appending to list."""
-        self.__field.validate_element(value)
+        if getattr(self, '_FieldList__field', None):
+            self.__field.validate_element(value)
         return list.append(self, value)
 
     def extend(self, sequence):
         """Validate extension of list."""
-        self.__field.validate(sequence)
+        if getattr(self, '_FieldList__field', None):
+            self.__field.validate(sequence)
         return list.extend(self, sequence)
 
     def insert(self, index, value):


### PR DESCRIPTION
To support migration to Python 3.7, setstate is called after append, extend, so when unpickling __field is not set. Guarding the validation to not occur during unpickle resolves this issue.