### PR TITLE
Announce apitools deprecation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+DEPRECATED - 
+
 google-apitools
 ===============
 
@@ -6,9 +8,14 @@ google-apitools
 ``google-apitools`` is a collection of utilities to make it easier to build
 client-side tools, especially those that talk to Google APIs.
 
-**NOTE**: This library is stable, but in maintenance mode, and not under
-active development. However, any bugs or security issues will be fixed
-promptly.
+**NOTE**: This library is deprecated and unsupported. Please read below for suggested alternatives.
+
+Alternatives to apitools
+-----------------------
+For the official Cloud client libraries used to communicating with Google Cloud APIs, go to https://cloud.google.com/apis/docs/cloud-client-libraries.
+
+To generate Python API client libraries for APIs specified by protos, such as those inside Google, see https://github.com/googleapis/gapic-generator-python. 
+API client library generators for other languages can be found in https://github.com/googleapis.
 
 Installing as a library
 -----------------------

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-DEPRECATED - 
+**DEPRECATED - Please see alternatives below**
 
 google-apitools
 ===============


### PR DESCRIPTION
After over 6 years of maintenance mode support, we are officially deprecating and discontinuing support on apitools.