### PR TITLE
Replace deprecated logging.warn with logging.warning

### DIFF
--- a/apitools/gen/service_registry.py
+++ b/apitools/gen/service_registry.py
@@ -355,7 +355,7 @@ class ServiceRegistry(object):
             config.max_size = self.__MaxSizeToInt(
                 media_upload_config['maxSize'])
         if 'accept' not in media_upload_config:
-            logging.warn(
+            logging.warning(
                 'No accept types found for upload configuration in '
                 'method %s, using */*', method_id)
         config.accept.extend([
@@ -363,7 +363,7 @@ class ServiceRegistry(object):
 
         for accept_pattern in config.accept:
             if not _MIME_PATTERN_RE.match(accept_pattern):
-                logging.warn('Unexpected MIME type: %s', accept_pattern)
+                logging.warning('Unexpected MIME type: %s', accept_pattern)
         protocols = media_upload_config.get('protocols', {})
         for protocol in ('simple', 'resumable'):
             media = protocols.get(protocol, {})


### PR DESCRIPTION
Replace `logging.warn` (deprecated in [Python 2.7, 2011](https://github.com/python/cpython/commit/04d5bc00a219860c69ea17eaa633d3ab9917409f)) with `logging.warning` (added in [Python 2.3, 2003](https://github.com/python/cpython/commit/6fa635df7aa88ae9fd8b41ae42743341316c90f7)).

* https://docs.python.org/3/library/logging.html#logging.Logger.warning
* https://github.com/python/cpython/issues/57444