### PR TITLE
Handle unknown values in repeated enums

### DIFF
--- a/apitools/base/protorpclite/protojson.py
+++ b/apitools/base/protorpclite/protojson.py
@@ -279,14 +279,60 @@ class ProtoJson(object):
                     message.set_unrecognized_field(key, value, variant)
                 continue
 
+            is_enum_field = isinstance(field, messages.EnumField)
+            # if field.repeated:
+            #     # This should be unnecessary? Or in fact become an error.
+            #     if not isinstance(value, list):
+            #         value = [value]
+            #     valid_value = []
+            #     for item in value:
+            #         v = self.decode_field(field, item)
+            #         if is_enum_field and v is None:
+            #           continue
+            #         valid_value.append(v)
+                
+            #     setattr(message, field.name, valid_value)
+            #     continue
+            # # This is just for consistency with the old behavior.
+            # if value == []:
+            #     continue
+            # try:
+            #     setattr(message, field.name, self.decode_field(field, value))
+            # except messages.DecodeError:
+            #     # Save unknown enum values.
+            #     if not is_enum_field:
+            #         raise
+            #     variant = self.__find_variant(value)
+            #     if variant:
+            #         message.set_unrecognized_field(key, value, variant)
+            
+            is_unrecognized_field = False
             if field.repeated:
                 # This should be unnecessary? Or in fact become an error.
                 if not isinstance(value, list):
                     value = [value]
-                valid_value = [self.decode_field(field, item)
-                               for item in value]
+                valid_value = []
+                for item in value:
+                    try:
+                        v = self.decode_field(field, item)
+                        if is_enum_field and v is None:
+                            continue
+                    except messages.DecodeError:
+                        print('ew decoding: {} val: {} valid: {}'.format(field, value, valid_value))
+                        if not is_enum_field:
+                            raise
+
+                        is_unrecognized_field = True
+                        continue
+                    valid_value.append(v)
+
                 setattr(message, field.name, valid_value)
+                if is_unrecognized_field:
+                    variant = self.__find_variant(value)
+                    if variant:
+                        message.set_unrecognized_field(key, value, variant)
                 continue
+            
             # This is just for consistency with the old behavior.
             if value == []:
                 continue
@@ -294,12 +340,12 @@ class ProtoJson(object):
                 setattr(message, field.name, self.decode_field(field, value))
             except messages.DecodeError:
                 # Save unknown enum values.
-                if not isinstance(field, messages.EnumField):
+                if not is_enum_field:
                     raise
                 variant = self.__find_variant(value)
                 if variant:
                     message.set_unrecognized_field(key, value, variant)
-
+            
         return message
 
     def decode_field(self, field, value):
@@ -312,6 +358,7 @@ class ProtoJson(object):
         Return:
           A Python value compatible with field.
         """
+        print('decode_field: %s: %s' % (field, value))
         if isinstance(field, messages.EnumField):
             try:
                 return field.type(value)

--- a/apitools/base/protorpclite/protojson.py
+++ b/apitools/base/protorpclite/protojson.py
@@ -280,32 +280,6 @@ class ProtoJson(object):
                 continue
 
             is_enum_field = isinstance(field, messages.EnumField)
-            # if field.repeated:
-            #     # This should be unnecessary? Or in fact become an error.
-            #     if not isinstance(value, list):
-            #         value = [value]
-            #     valid_value = []
-            #     for item in value:
-            #         v = self.decode_field(field, item)
-            #         if is_enum_field and v is None:
-            #           continue
-            #         valid_value.append(v)
-                
-            #     setattr(message, field.name, valid_value)
-            #     continue
-            # # This is just for consistency with the old behavior.
-            # if value == []:
-            #     continue
-            # try:
-            #     setattr(message, field.name, self.decode_field(field, value))
-            # except messages.DecodeError:
-            #     # Save unknown enum values.
-            #     if not is_enum_field:
-            #         raise
-            #     variant = self.__find_variant(value)
-            #     if variant:
-            #         message.set_unrecognized_field(key, value, variant)
-            
             is_unrecognized_field = False
             if field.repeated:
                 # This should be unnecessary? Or in fact become an error.
@@ -318,7 +292,6 @@ class ProtoJson(object):
                         if is_enum_field and v is None:
                             continue
                     except messages.DecodeError:
-                        print('ew decoding: {} val: {} valid: {}'.format(field, value, valid_value))
                         if not is_enum_field:
                             raise
 
@@ -345,7 +318,7 @@ class ProtoJson(object):
                 variant = self.__find_variant(value)
                 if variant:
                     message.set_unrecognized_field(key, value, variant)
-            
+
         return message
 
     def decode_field(self, field, value):
@@ -358,7 +331,6 @@ class ProtoJson(object):
         Return:
           A Python value compatible with field.
         """
-        print('decode_field: %s: %s' % (field, value))
         if isinstance(field, messages.EnumField):
             try:
                 return field.type(value)

--- a/apitools/base/protorpclite/protojson_test.py
+++ b/apitools/base/protorpclite/protojson_test.py
@@ -152,6 +152,8 @@ class ProtojsonTest(test_util.TestCase,
     encoded_string_types = '{"string_value": "Latin"}'
 
     encoded_invalid_enum = '{"enum_value": "undefined"}'
+    
+    encoded_invalid_repeated_enum = '{"enum_value": ["VAL1", "undefined"]}'
 
     def testConvertIntegerToFloat(self):
         """Test that integers passed in to float fields are converted.

--- a/apitools/base/protorpclite/test_util.py
+++ b/apitools/base/protorpclite/test_util.py
@@ -428,6 +428,11 @@ class ProtoConformanceTestBase(object):
         <OptionalMessage
           enum_value: (invalid value for serialization type)
           >
+
+      encoded_invalid_repeated_enum:
+        <RepeatedMessage
+          enum_value: (invalid value for serialization type)
+          >
     """
 
     encoded_empty_message = ''
@@ -589,6 +594,21 @@ class ProtoConformanceTestBase(object):
         self.assertEqual(message, decoded)
         encoded = self.PROTOLIB.encode_message(decoded)
         self.assertEqual(self.encoded_invalid_enum, encoded)
+    
+    def testDecodeInvalidRepeatedEnumType(self):
+        # Since protos need to be able to add new enums, a message should be
+        # successfully decoded even if the enum value is invalid. Encoding the
+        # decoded message should result in equivalence with the original
+        # encoded message containing an invalid enum.
+        decoded = self.PROTOLIB.decode_message(RepeatedMessage,
+                                               self.encoded_invalid_repeated_enum)
+        message = RepeatedMessage()
+        message.enum_value = [RepeatedMessage.SimpleEnum.VAL1]
+        print(message)
+        print(decoded)
+        self.assertEqual(message, decoded)
+        encoded = self.PROTOLIB.encode_message(decoded)
+        self.assertEqual(self.encoded_invalid_repeated_enum, encoded)
 
     def testDateTimeNoTimeZone(self):
         """Test that DateTimeFields are encoded/decoded correctly."""

--- a/apitools/base/protorpclite/test_util.py
+++ b/apitools/base/protorpclite/test_util.py
@@ -604,8 +604,6 @@ class ProtoConformanceTestBase(object):
                                                self.encoded_invalid_repeated_enum)
         message = RepeatedMessage()
         message.enum_value = [RepeatedMessage.SimpleEnum.VAL1]
-        print(message)
-        print(decoded)
         self.assertEqual(message, decoded)
         encoded = self.PROTOLIB.encode_message(decoded)
         self.assertEqual(self.encoded_invalid_repeated_enum, encoded)

--- a/apitools/base/py/encoding_helper.py
+++ b/apitools/base/py/encoding_helper.py
@@ -533,7 +533,8 @@ def _ProcessUnknownEnums(message, encoded_message):
         if (isinstance(field, messages.EnumField) and
                 field.name in decoded_message):
             value = message.get_assigned_value(field.name)
-            if (field.repeated and len(value) != len(decoded_message[field.name])) or value is None:
+            if ((field.repeated and len(value) != len(decoded_message[field.name])) or
+                    value is None):
                 message.set_unrecognized_field(
                     field.name, decoded_message[field.name], messages.Variant.ENUM)
     return message

--- a/apitools/base/py/encoding_helper.py
+++ b/apitools/base/py/encoding_helper.py
@@ -531,10 +531,11 @@ def _ProcessUnknownEnums(message, encoded_message):
     decoded_message = json.loads(six.ensure_str(encoded_message))
     for field in message.all_fields():
         if (isinstance(field, messages.EnumField) and
-                field.name in decoded_message and
-                message.get_assigned_value(field.name) is None):
-            message.set_unrecognized_field(
-                field.name, decoded_message[field.name], messages.Variant.ENUM)
+                field.name in decoded_message):
+            value = message.get_assigned_value(field.name)
+            if (field.repeated and len(value) != len(decoded_message[field.name])) or value is None:
+                message.set_unrecognized_field(
+                    field.name, decoded_message[field.name], messages.Variant.ENUM)
     return message
 
 

--- a/apitools/base/py/encoding_test.py
+++ b/apitools/base/py/encoding_test.py
@@ -91,7 +91,8 @@ class MessageWithEnum(messages.Message):
 
     field_one = messages.EnumField(ThisEnum, 1)
     field_two = messages.EnumField(ThisEnum, 2, default=ThisEnum.VALUE_TWO)
-    ignored_field = messages.EnumField(ThisEnum, 3)
+    field_three = messages.EnumField(ThisEnum, 3, repeated=True)
+    ignored_field = messages.EnumField(ThisEnum, 4)
 
 
 @encoding.MapUnrecognizedFields('additionalProperties')
@@ -257,6 +258,17 @@ class EncodingTest(unittest.TestCase):
                                                 value_default=None),
                 ('BAD_VALUE', messages.Variant.ENUM))
 
+    def testCopyProtoMessageInvalidRepeatedEnum(self):
+        json_msg = '{"field_three": ["VALUE_ONE", "BAD_VALUE"]}'
+        orig_msg = encoding.JsonToMessage(MessageWithEnum, json_msg)
+        new_msg = encoding.CopyProtoMessage(orig_msg)
+        for msg in (orig_msg, new_msg):
+            self.assertEqual(msg.all_unrecognized_fields(), ['field_three'])
+            self.assertEqual(
+                msg.get_unrecognized_field_info('field_three',
+                                                value_default=None),
+                (['VALUE_ONE', 'BAD_VALUE'], messages.Variant.ENUM))
+
     def testCopyProtoMessageAdditionalProperties(self):
         msg = AdditionalPropertiesMessage(additionalProperties=[
             AdditionalPropertiesMessage.AdditionalProperty(
@@ -278,6 +290,20 @@ class EncodingTest(unittest.TestCase):
                 msg.additionalProperties[0].value.get_unrecognized_field_info(
                     'field_one', value_default=None),
                 ('BAD_VALUE', messages.Variant.ENUM))
+
+    def testCopyProtoMessageMappingInvalidRepeatedEnum(self):
+        json_msg = '{"key_one": {"field_three": ["VALUE_ONE", "BAD_VALUE"]}}'
+        orig_msg = encoding.JsonToMessage(MapToMessageWithEnum, json_msg)
+        print('TEXTING: %s' % orig_msg)
+        new_msg = encoding.CopyProtoMessage(orig_msg)
+        for msg in (orig_msg, new_msg):
+            self.assertEqual(
+                msg.additionalProperties[0].value.all_unrecognized_fields(),
+                ['field_three'])
+            self.assertEqual(
+                msg.additionalProperties[0].value.get_unrecognized_field_info(
+                    'field_three', value_default=None),
+                (['VALUE_ONE', 'BAD_VALUE'], messages.Variant.ENUM))
 
     def testBytesEncoding(self):
         b64_str = 'AAc+'
@@ -362,6 +388,15 @@ class EncodingTest(unittest.TestCase):
         msg = encoding.JsonToMessage(MapToMessageWithEnum, json_msg)
         new_msg = encoding.MessageToJson(msg)
         self.assertEqual('{"key_one": {"field_one": "BAD_VALUE"}}', new_msg)
+
+    def testInvalidRepeatedEnumEncodingInAMap(self):
+        json_msg = '{"key_one": {"field_three": ["VALUE_ONE", "BAD_VALUE"]}}'
+        print('JsonToMessage...')
+        msg = encoding.JsonToMessage(MapToMessageWithEnum, json_msg)
+        print('MessageToJson...')
+        new_msg = encoding.MessageToJson(msg)
+        self.assertEqual(
+            '{"key_one": {"field_three": ["VALUE_ONE", "BAD_VALUE"]}}', new_msg)
 
     def testIncludeFields(self):
         msg = SimpleMessage()
@@ -513,7 +548,7 @@ class EncodingTest(unittest.TestCase):
 
     def testUnknownEnumNestedRoundtrip(self):
         json_with_typo = ('{"outer_key": {"key_one": {"field_one": '
-                          '"VALUE_OEN", "field_two": "VALUE_OEN"}}}')
+                          '"VALUE_OEN", "field_two": "VALUE_OEN", "field_three": ["VALUE_ONE", "BAD_VALUE"]}}}')
         msg = encoding.JsonToMessage(NestedAdditionalPropertiesWithEnumMessage,
                                      json_with_typo)
         self.assertEqual(json.loads(json_with_typo),

--- a/apitools/base/py/encoding_test.py
+++ b/apitools/base/py/encoding_test.py
@@ -294,7 +294,6 @@ class EncodingTest(unittest.TestCase):
     def testCopyProtoMessageMappingInvalidRepeatedEnum(self):
         json_msg = '{"key_one": {"field_three": ["VALUE_ONE", "BAD_VALUE"]}}'
         orig_msg = encoding.JsonToMessage(MapToMessageWithEnum, json_msg)
-        print('TEXTING: %s' % orig_msg)
         new_msg = encoding.CopyProtoMessage(orig_msg)
         for msg in (orig_msg, new_msg):
             self.assertEqual(
@@ -391,9 +390,7 @@ class EncodingTest(unittest.TestCase):
 
     def testInvalidRepeatedEnumEncodingInAMap(self):
         json_msg = '{"key_one": {"field_three": ["VALUE_ONE", "BAD_VALUE"]}}'
-        print('JsonToMessage...')
         msg = encoding.JsonToMessage(MapToMessageWithEnum, json_msg)
-        print('MessageToJson...')
         new_msg = encoding.MessageToJson(msg)
         self.assertEqual(
             '{"key_one": {"field_three": ["VALUE_ONE", "BAD_VALUE"]}}', new_msg)
@@ -548,7 +545,8 @@ class EncodingTest(unittest.TestCase):
 
     def testUnknownEnumNestedRoundtrip(self):
         json_with_typo = ('{"outer_key": {"key_one": {"field_one": '
-                          '"VALUE_OEN", "field_two": "VALUE_OEN", "field_three": ["VALUE_ONE", "BAD_VALUE"]}}}')
+                          '"VALUE_OEN", "field_two": "VALUE_OEN", '
+                          '"field_three": ["VALUE_ONE", "BAD_VALUE"]}}}')
         msg = encoding.JsonToMessage(NestedAdditionalPropertiesWithEnumMessage,
                                      json_with_typo)
         self.assertEqual(json.loads(json_with_typo),


### PR DESCRIPTION
Repeated enums will be handled in a similar way to enum fields.

Unknown enums are set to None and the field is marked as unrecognized. Any changes to the field are ignored and the original value is restored when the message is serialized.
```
msg_json = '{"enum_field": "UNKNOWN"}'
msg = encoding.JsonToMessage(Message, msg_json)
msg.enum_field  # None
msg.enum_field = 'VAL1'
encoding.MessageToJson(msg)  # '{"enum_field": "UNKNOWN"}'
```

Unknown enums in repeated enum fields are ignored and the field is marked as unrecognized. Any changes to the field are ignored and the original value is restored when the message is serialized.
```
msg_json = '{"enum_field": ["VAL1", "UNKNOWN"]}'
msg = encoding.JsonToMessage(Message, msg_json)
msg.enum_field  # ["VAL1"]
msg.enum_field = ["VAL2"]
encoding.MessageToJson(msg)  # '{"enum_field": ["VAL1", "UNKNOWN"]}'
```

Fixes #258 