### PR TITLE
Use getfullargspec instead of getargspec

### DIFF
--- a/apitools/base/protorpclite/util.py
+++ b/apitools/base/protorpclite/util.py
@@ -148,7 +148,7 @@ def positional(max_positional_args):
     if isinstance(max_positional_args, six.integer_types):
         return positional_decorator
     else:
-        args, _, _, defaults = inspect.getargspec(max_positional_args)
+        args, _, _, defaults = inspect.getfullargspec(max_positional_args)
         if defaults is None:
             raise ValueError(
                 'Functions with no keyword arguments must specify '


### PR DESCRIPTION
`inspect.getargspec` is deprecated since Python 3.0 and removed in Python 3.11.

https://docs.python.org/3.11/whatsnew/3.11.html#removed.