### PR TITLE
Add __static_attributes__ to _RESERVED_ATTRIBUTE_NAMES

### DIFF
--- a/apitools/base/protorpclite/messages.py
+++ b/apitools/base/protorpclite/messages.py
@@ -143,7 +143,7 @@ class ValidationError(Error):
 # Attributes that are reserved by a class definition that
 # may not be used by either Enum or Message class definitions.
 _RESERVED_ATTRIBUTE_NAMES = frozenset(
-    ['__module__', '__doc__', '__qualname__'])
+    ['__module__', '__doc__', '__qualname__', '__static_attributes__'])
 
 _POST_INIT_FIELD_ATTRIBUTE_NAMES = frozenset(
     ['name',


### PR DESCRIPTION
This is to fix this error:
```
  File "/home/kbuilder/cloudsdk/google-cloud-sdk/lib/third_party/apitools/base/protorpclite/messages.py", line 549, in <module>
    class Variant(Enum):
    ...<34 lines>...
        SINT64 = 18
  File "/home/kbuilder/cloudsdk/google-cloud-sdk/lib/third_party/apitools/base/protorpclite/messages.py", line 319, in __init__
    raise EnumDefinitionError(
    ...<2 lines>...
        (attribute, value))
apitools.base.protorpclite.messages.EnumDefinitionError: May only use integers in Enum definitions.  Found: __static_attributes__ = ()
```