### PR TITLE
Add __firstlineno__ to _RESERVED_ATTRIBUTE_NAMES

### DIFF
--- a/apitools/base/protorpclite/messages.py
+++ b/apitools/base/protorpclite/messages.py
@@ -143,7 +143,7 @@ class ValidationError(Error):
 # Attributes that are reserved by a class definition that
 # may not be used by either Enum or Message class definitions.
 _RESERVED_ATTRIBUTE_NAMES = frozenset(
-    ['__module__', '__doc__', '__qualname__', '__static_attributes__'])
+    ['__module__', '__doc__', '__qualname__', '__static_attributes__', '__firstlineno__'])
 
 _POST_INIT_FIELD_ATTRIBUTE_NAMES = frozenset(
     ['name',


### PR DESCRIPTION
This is to fix the error:
```
  File "/home/kbuilder/cloudsdk/google-cloud-sdk/lib/third_party/apitools/base/protorpclite/message_types.py", line 35, in <module>
    class VoidMessage(messages.Message):
        """Empty message."""
  File "/home/kbuilder/cloudsdk/google-cloud-sdk/lib/third_party/apitools/base/protorpclite/messages.py", line 650, in __new__
    raise MessageDefinitionError(
    ...<2 lines>...
        (key, field))
apitools.base.protorpclite.messages.MessageDefinitionError: May only use fields in message definitions.  Found: __firstlineno__ = 35
ERROR: gcloud failed to load. This usually indicates corruption in your gcloud installation or problems with your Python interpreter.
```