### PR TITLE
Add support for API version system parameter.

### DIFF
--- a/apitools/base/py/base_api_test.py
+++ b/apitools/base/py/base_api_test.py
@@ -220,10 +220,10 @@ class BaseApiTest(unittest.TestCase):
             with self.assertRaises(exceptions.HttpBadRequestError) as err:
                 service._RunMethod(method_config, request)
         http_error = err.exception
-        self.assertEquals('http://www.google.com', http_error.url)
-        self.assertEquals('{"field": "abc"}', http_error.content)
-        self.assertEquals(method_config, http_error.method_config)
-        self.assertEquals(request, http_error.request)
+        self.assertEqual('http://www.google.com', http_error.url)
+        self.assertEqual('{"field": "abc"}', http_error.content)
+        self.assertEqual(method_config, http_error.method_config)
+        self.assertEqual(request, http_error.request)
 
     def testQueryEncoding(self):
         method_config = base_api.ApiMethodInfo(
@@ -337,6 +337,16 @@ class BaseApiTest(unittest.TestCase):
             'http://normal.googleapis.com/path')
         expected = 'http://custom.p.googleapis.com/path'
         self.assertEqual(observed, expected)
+
+    def testApiVersionSystemParameter(self):
+        method_config = base_api.ApiMethodInfo(
+            request_type_name='SimpleMessage', api_version_param='2024-01-01')
+        service = FakeService()
+        request = SimpleMessage()
+        http_request = service.PrepareHttpRequest(method_config, request)
+        self.assertIn('X-Goog-Api-Version', http_request.headers)
+        self.assertEqual(
+            '2024-01-01', http_request.headers['X-Goog-Api-Version'])
 
 
 if __name__ == '__main__':

--- a/apitools/gen/service_registry.py
+++ b/apitools/gen/service_registry.py
@@ -407,6 +407,8 @@ class ServiceRegistry(object):
                 method_description.get('mediaUpload'), method_id)
         method_info.supports_download = method_description.get(
             'supportsMediaDownload', False)
+        if method_description.get('apiVersion'):
+            method_info.api_version_param = method_description.get('apiVersion')
         self.__all_scopes.update(method_description.get('scopes', ()))
         for param, desc in method_description.get('parameters', {}).items():
             param = self.__names.CleanName(param)


### PR DESCRIPTION
This is a method-specific parameter specified in the discovery doc that can be passed as a system parameter to the API request (see https://cloud.google.com/apis/docs/system-parameters).