### PR TITLE
Update message_registry to ignore custom format for any/object types.

### DIFF
--- a/apitools/gen/gen_client_test.py
+++ b/apitools/gen/gen_client_test.py
@@ -136,6 +136,25 @@ __path__ = pkgutil.extend_path(__path__, __name__)
             self.assertIn('2015-02-02-preview', client_file)
             self.assertIn('2015-03-03-preview', client_file)
 
+    def testGenClient_AnyObjectCustomFormat(self):
+        with test_utils.TempDir() as tmp_dir_path:
+            gen_client.main([
+                gen_client.__file__,
+                '--infile', GetTestDataPath(
+                    'compute', 'compute_2025-01-01-preview.json'),
+                '--outdir', tmp_dir_path,
+                '--overwrite',
+                '--version-identifier', 'v2025_01_01_preview',
+                '--root_package', 'google.apis',
+                'client'
+            ])
+            self.assertEqual(
+                set([
+                    'compute_v2025_01_01_preview_client.py',
+                    'compute_v2025_01_01_preview_messages.py',
+                    '__init__.py']),
+                set(os.listdir(tmp_dir_path)))
+
     def testGenPipPackage_SimpleDoc(self):
         with test_utils.TempDir() as tmp_dir_path:
             gen_client.main([

--- a/apitools/gen/message_registry.py
+++ b/apitools/gen/message_registry.py
@@ -402,23 +402,19 @@ class MessageRegistry(object):
 
         if 'format' in attrs:
             type_info = self.PRIMITIVE_FORMAT_MAP.get(attrs['format'])
-            if type_info is None:
-                # If we don't recognize the format, the spec says we fall back
-                # to just using the type name.
-                if type_name in self.PRIMITIVE_TYPE_INFO_MAP:
-                    return self.PRIMITIVE_TYPE_INFO_MAP[type_name]
-                raise ValueError('Unknown type/format "%s"/"%s"' % (
-                    attrs['format'], type_name))
-            if type_info.type_name.startswith((
-                    'apitools.base.protorpclite.message_types.',
-                    'message_types.')):
-                self.__AddImport(
-                    'from %s import message_types as _message_types' %
-                    self.__protorpc_package)
-            if type_info.type_name.startswith('extra_types.'):
-                self.__AddImport(
-                    'from %s import extra_types' % self.__base_files_package)
-            return type_info
+            # NOTE: If we don't recognize the format, the spec says we fall back
+            # to just using the type name.
+            if type_info is not None:
+                if type_info.type_name.startswith((
+                        'apitools.base.protorpclite.message_types.',
+                        'message_types.')):
+                    self.__AddImport(
+                        'from %s import message_types as _message_types' %
+                        self.__protorpc_package)
+                if type_info.type_name.startswith('extra_types.'):
+                    self.__AddImport(
+                        'from %s import extra_types' % self.__base_files_package)
+                return type_info
 
         if type_name in self.PRIMITIVE_TYPE_INFO_MAP:
             type_info = self.PRIMITIVE_TYPE_INFO_MAP[type_name]


### PR DESCRIPTION
The comment in the code said 'If we don't recognize the format, the spec says we fall back to just using the type name.', but it was not fully true as it was only falling back for certain types, updated logic should fix this.