### PR TITLE
Bump apitools version to 0.5.35

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ CONSOLE_SCRIPTS = [
 
 py_version = platform.python_version()
 
-_APITOOLS_VERSION = '0.5.34'
+_APITOOLS_VERSION = '0.5.35'
 
 with open('README.rst') as fileobj:
     README = fileobj.read()


### PR DESCRIPTION
Bump the apitools version to 0.5.35 in anticipation of a release.